### PR TITLE
Fix Path calculation for projects with '.' in the project Name

### DIFF
--- a/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
@@ -616,7 +616,7 @@ public class ExtractorUtils {
      * @throws Exception
      */
     public static FilePath createAndGetTempDir(hudson.Launcher launcher, FilePath ws) throws Exception {
-        final FilePath tempDirPath = new FilePath(ws.getParent(), ws.getBaseName() + "@tmp");
+        final FilePath tempDirPath = new FilePath(ws.getParent(), ws.getName() + "@tmp");
         launcher.getChannel().call(new MasterToSlaveCallable<Boolean, IOException>() {
             public Boolean call() {
                 File tempDirFile = new File(tempDirPath.getRemote());


### PR DESCRIPTION
When a Jenkins Project is configured with '.' in the name e.g. "test.project" the generated path for the buildInfo properties file is wrong.