### PR TITLE
Add matrix project dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,11 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <version>1.10</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ant</artifactId>
             <version>1.2</version>
         </dependency>


### PR DESCRIPTION
There is matri x project dependency from git version 2.5.0. That time git has dependency on matrix project, but now in current version of git plugin the dependency is optional - so jenkins will not install it unless other plugin require it. Since plugin depends on matrix project, it has to declare dependency on it.