### PR TITLE
ExtractorUtils: use same tmp directory as jenkins (respect hudson.slaves.WorkspaceList)

### DIFF
--- a/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
@@ -610,13 +610,19 @@ public class ExtractorUtils {
     }
 
     /**
+     * The token that combines the project name and unique number to create unique workspace directory.
+     */
+    private static final String WORKSPACELIST = System.getProperty("hudson.slaves.WorkspaceList");
+
+    /**
      * Create a temporary directory under a given workspace
      * @param launcher
      * @param ws
      * @throws Exception
      */
     public static FilePath createAndGetTempDir(hudson.Launcher launcher, FilePath ws) throws Exception {
-        final FilePath tempDirPath = new FilePath(ws.getParent(), ws.getName() + "@tmp");
+        final String WORKSPACELIST = System.getProperty("hudson.slaves.WorkspaceList");
+        final FilePath tempDirPath = new FilePath(ws.getParent(), ws.getName() + ((WORKSPACELIST != null) ? WORKSPACELIST : "@") + "tmp");
         launcher.getChannel().call(new MasterToSlaveCallable<Boolean, IOException>() {
             public Boolean call() {
                 File tempDirFile = new File(tempDirPath.getRemote());


### PR DESCRIPTION
    ExtractorUtils: make it work with non-default workspace name
    
    The Artifactory plugin ignores the token configured in Jenkins
    to be used for creating unique directories. It just hard-codes
    '@'.
    
    From the description of hudson.slaves.WorkspaceList:
        https://wiki.jenkins.io/display/JENKINS/Features+controlled+by+system+properties
    
        When concurrent builds is enabled, a unique workspace directory name is
        required for each concurrent build. To create this name, this token is
        placed between project name and a unique ID, e.g. "my-project@123".
    
    There are two problems with this:
    * the workspace directory is cluttered with additional directories
    * Jenkins actually seems to prevent access to those directories -
      in particular builds are failing because files can not be found
    
    Let's make the Artifactory plugin do the same so as to resolve both
    issues.
