### PR TITLE
New Fail No Op flag in generic pipeline

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/executors/GenericDownloadExecutor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/executors/GenericDownloadExecutor.java
@@ -22,14 +22,16 @@ public class GenericDownloadExecutor {
     private final Run build;
     private transient FilePath ws;
     private BuildInfo buildInfo;
+    private boolean failNoOp;
     private ArtifactoryServer server;
     private TaskListener listener;
 
-    public GenericDownloadExecutor(ArtifactoryServer server, TaskListener listener, Run build, FilePath ws, BuildInfo buildInfo) {
+    public GenericDownloadExecutor(ArtifactoryServer server, TaskListener listener, Run build, FilePath ws, BuildInfo buildInfo, boolean failNoOp) {
         this.build = build;
         this.server = server;
         this.listener = listener;
         this.buildInfo = Utils.prepareBuildinfo(build, buildInfo);
+        this.failNoOp = failNoOp;
         this.ws = ws;
     }
 
@@ -40,6 +42,9 @@ public class GenericDownloadExecutor {
                         preferredResolver.provideUsername(build.getParent()),
                         preferredResolver.providePassword(build.getParent()),
                         server.getUrl(), spec, Utils.getProxyConfiguration(server)));
+        if (failNoOp && resolvedDependencies.size() <= 0) {
+            throw new RuntimeException("Fail-no-op: No files were affected in the download process.");
+        }
         new BuildInfoAccessor(this.buildInfo).appendPublishedDependencies(resolvedDependencies);
         return this.buildInfo;
     }

--- a/src/main/java/org/jfrog/hudson/pipeline/executors/GenericDownloadExecutor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/executors/GenericDownloadExecutor.java
@@ -42,7 +42,7 @@ public class GenericDownloadExecutor {
                         preferredResolver.provideUsername(build.getParent()),
                         preferredResolver.providePassword(build.getParent()),
                         server.getUrl(), spec, Utils.getProxyConfiguration(server)));
-        if (failNoOp && resolvedDependencies.size() <= 0) {
+        if (failNoOp && resolvedDependencies.isEmpty()) {
             throw new RuntimeException("Fail-no-op: No files were affected in the download process.");
         }
         new BuildInfoAccessor(this.buildInfo).appendPublishedDependencies(resolvedDependencies);

--- a/src/main/java/org/jfrog/hudson/pipeline/executors/GenericUploadExecutor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/executors/GenericUploadExecutor.java
@@ -6,7 +6,6 @@ import hudson.FilePath;
 import hudson.model.Cause;
 import hudson.model.Run;
 import hudson.model.TaskListener;
-import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jfrog.build.api.Artifact;
@@ -32,15 +31,17 @@ public class GenericUploadExecutor {
     private transient FilePath ws;
     private transient Run build;
     private transient TaskListener listener;
-    private BuildInfo buildinfo;
+    private BuildInfo buildInfo;
+    private boolean failNoOp;
     private ArtifactoryServer server;
     private StepContext context;
 
-    public GenericUploadExecutor(ArtifactoryServer server, TaskListener listener, Run build, FilePath ws, BuildInfo buildInfo, StepContext context) {
+    public GenericUploadExecutor(ArtifactoryServer server, TaskListener listener, Run build, FilePath ws, BuildInfo buildInfo, boolean failNoOp, StepContext context) {
         this.server = server;
         this.listener = listener;
         this.build = build;
-        this.buildinfo = Utils.prepareBuildinfo(build, buildInfo);
+        this.buildInfo = Utils.prepareBuildinfo(build, buildInfo);
+        this.failNoOp = failNoOp;
         this.ws = ws;
         this.context = context;
     }
@@ -49,22 +50,25 @@ public class GenericUploadExecutor {
         Credentials credentials = new Credentials(server.getDeployerCredentialsConfig().provideUsername(build.getParent()),
                 server.getDeployerCredentialsConfig().providePassword(build.getParent()));
         ProxyConfiguration proxyConfiguration = Utils.getProxyConfiguration(server);
-        List<Artifact> artifactsToDeploy = ws.act(new GenericArtifactsDeployer.FilesDeployerCallable(listener, spec,
+        List<Artifact> deployedArtifacts = ws.act(new GenericArtifactsDeployer.FilesDeployerCallable(listener, spec,
                 server, credentials, getPropertiesMap(), proxyConfiguration));
-        new BuildInfoAccessor(buildinfo).appendDeployedArtifacts(artifactsToDeploy);
-        return buildinfo;
+        if (failNoOp && deployedArtifacts.size() <= 0) {
+            throw new RuntimeException("Fail-no-op: No files were affected in the upload process.");
+        }
+        new BuildInfoAccessor(buildInfo).appendDeployedArtifacts(deployedArtifacts);
+        return buildInfo;
     }
 
     private ArrayListMultimap<String, String> getPropertiesMap() throws IOException, InterruptedException {
         ArrayListMultimap<String, String> properties = ArrayListMultimap.create();
 
-        if (buildinfo.getName() != null) {
-            properties.put("build.name", buildinfo.getName());
+        if (buildInfo.getName() != null) {
+            properties.put("build.name", buildInfo.getName());
         } else {
             properties.put("build.name", BuildUniqueIdentifierHelper.getBuildName(build));
         }
-        if (buildinfo.getNumber() != null) {
-            properties.put("build.number", buildinfo.getNumber());
+        if (buildInfo.getNumber() != null) {
+            properties.put("build.number", buildInfo.getNumber());
         } else {
             properties.put("build.number", BuildUniqueIdentifierHelper.getBuildNumber(build));
         }

--- a/src/main/java/org/jfrog/hudson/pipeline/executors/GenericUploadExecutor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/executors/GenericUploadExecutor.java
@@ -52,7 +52,7 @@ public class GenericUploadExecutor {
         ProxyConfiguration proxyConfiguration = Utils.getProxyConfiguration(server);
         List<Artifact> deployedArtifacts = ws.act(new GenericArtifactsDeployer.FilesDeployerCallable(listener, spec,
                 server, credentials, getPropertiesMap(), proxyConfiguration));
-        if (failNoOp && deployedArtifacts.size() <= 0) {
+        if (failNoOp && deployedArtifacts.isEmpty()) {
             throw new RuntimeException("Fail-no-op: No files were affected in the upload process.");
         }
         new BuildInfoAccessor(buildInfo).appendDeployedArtifacts(deployedArtifacts);

--- a/src/main/java/org/jfrog/hudson/pipeline/steps/DownloadStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/steps/DownloadStep.java
@@ -21,18 +21,24 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class DownloadStep extends AbstractStepImpl {
 
     private BuildInfo buildInfo;
+    private boolean failNoOp;
     private String spec;
     private ArtifactoryServer server;
 
     @DataBoundConstructor
-    public DownloadStep(String spec, BuildInfo buildInfo, ArtifactoryServer server) {
+    public DownloadStep(String spec, BuildInfo buildInfo, boolean failNoOp, ArtifactoryServer server) {
         this.spec = spec;
         this.buildInfo = buildInfo;
+        this.failNoOp = failNoOp;
         this.server = server;
     }
 
     public BuildInfo getBuildInfo() {
         return buildInfo;
+    }
+
+    public boolean getFailNoOp() {
+        return failNoOp;
     }
 
     public String getSpec() {
@@ -63,7 +69,7 @@ public class DownloadStep extends AbstractStepImpl {
         @Override
         protected BuildInfo run() throws Exception {
             BuildInfo buildInfo = new GenericDownloadExecutor(Utils.prepareArtifactoryServer(null, step.getServer()),
-                    this.listener, this.build, this.ws, step.getBuildInfo()).execution(Util.replaceMacro(step.getSpec(), env));
+                    this.listener, this.build, this.ws, step.getBuildInfo(), step.getFailNoOp()).execution(Util.replaceMacro(step.getSpec(), env));
             new BuildInfoAccessor(buildInfo).captureVariables(env, build, listener);
             return buildInfo;
         }

--- a/src/main/java/org/jfrog/hudson/pipeline/steps/UploadStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/steps/UploadStep.java
@@ -23,16 +23,22 @@ public class UploadStep extends AbstractStepImpl {
     private BuildInfo buildInfo;
     private String spec;
     private ArtifactoryServer server;
+    private boolean failNoOp;
 
     @DataBoundConstructor
-    public UploadStep(String spec, BuildInfo buildInfo, ArtifactoryServer server) {
+    public UploadStep(String spec, BuildInfo buildInfo, boolean failNoOp, ArtifactoryServer server) {
         this.spec = spec;
         this.buildInfo = buildInfo;
+        this.failNoOp = failNoOp;
         this.server = server;
     }
 
     public BuildInfo getBuildInfo() {
         return buildInfo;
+    }
+
+    public boolean getFailNoOp() {
+        return failNoOp;
     }
 
     public String getSpec() {
@@ -62,7 +68,7 @@ public class UploadStep extends AbstractStepImpl {
 
         @Override
         protected BuildInfo run() throws Exception {
-            BuildInfo buildInfo = new GenericUploadExecutor(Utils.prepareArtifactoryServer(null, step.getServer()), listener, build, ws, step.getBuildInfo(), getContext()).execution(Util.replaceMacro(step.getSpec(), env));
+            BuildInfo buildInfo = new GenericUploadExecutor(Utils.prepareArtifactoryServer(null, step.getServer()), listener, build, ws, step.getBuildInfo(), step.getFailNoOp(), getContext()).execution(Util.replaceMacro(step.getSpec(), env));
             new BuildInfoAccessor(buildInfo).captureVariables(env, build, listener);
             return buildInfo;
         }


### PR DESCRIPTION
Upload and download commands now accept a failNoOp boolean that throws an exception if no files were affected during these processes.