### PR TITLE
[JENKINS-55224] Replace JGit Repository.getRef() call

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
@@ -20,8 +20,7 @@ import jenkins.plugins.nodejs.tools.NodeJSInstallation;
 import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
-import org.eclipse.jgit.internal.storage.file.FileRepository;
-import org.eclipse.jgit.lib.Ref;
+import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jfrog.build.api.BuildInfoFields;
@@ -144,9 +143,7 @@ public class Utils {
         if (dotGitPath.exists()) {
             return dotGitPath.act(new MasterToSlaveFileCallable<String>() {
                 public String invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
-                    FileRepository repository = new FileRepository(f);
-                    Ref head = repository.getRef("HEAD");
-                    return head.getObjectId().getName();
+                    return Git.with(TaskListener.NULL, new EnvVars()).in(f).getClient().revParse("HEAD").getName();
                 }
             });
         }


### PR DESCRIPTION
The JGit project replaced the Repository.getRef(String) method with Repository.exactRef(String) and Repository.findRef(String) in JGit 5. The getRef(String) method was removed from JGit 5.2.

JGit compatibility does not provide the same upgrade path as Jenkins compatibility. The removal of the getRef(String) API will break Jenkins plugins that depend on git client plugin prior to 3.0. The simplest solution seems to be to find and replace all calls to Repository.getRef() with an equivalent call to the Jenkins git client plugin.

Key issues:

* Can't use Repository.getRef() with git client plugin 3.0.
* Can't use Repository.exactRef() with git client plugin before 3.0.

Solution:

* Use Jenkins git client plugin and let it call the correct JGit method

My apologies that my editors (vi and emacs) are determined to add the newline to the last line of the file.  If that is enough to reject the pull request, I hope that someone else will take the changes so that the artifactory plugin won't be broken by the release of git client plugin 4.0.