### PR TITLE
Skip integration tests by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,5 @@ To run unit tests execute the following command:
 
 To run integration tests execute the following command:
 ```
-> mvn clean verify
+> mvn clean verify -DskipITs=false
 ```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ before_test:
   - sh: export GRADLE_HOME=/home/appveyor/.sdkman/candidates/gradle/current && sdk install gradle
 
 test_script:
-  - mvn -V -B -U clean verify
+  - mvn -V -B -U clean verify -DskipITs=false
 
 cache:
   - C:\Users\appveyor\.m2\ -> pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <!-- TODO: enforcer is full of upper bound dependency issues, including real ones -->
         <enforcer.skip>true</enforcer.skip>
         <findbugs.failOnError>false</findbugs.failOnError>
+        <!--Skip integration tests unless explicitly requested with -DskipITs=false-->
         <skipITs>true</skipITs>
 
         <buildinfo.version>2.13.1</buildinfo.version>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <!-- TODO: enforcer is full of upper bound dependency issues, including real ones -->
         <enforcer.skip>true</enforcer.skip>
         <findbugs.failOnError>false</findbugs.failOnError>
+        <skipITs>true</skipITs>
 
         <buildinfo.version>2.13.1</buildinfo.version>
         <buildinfo.maven3.version>2.13.1</buildinfo.maven3.version>


### PR DESCRIPTION
Currently integration tests run by default. This behavior causes some problems:
1. Failures in [Cloudbees tests](https://ci.jenkins.io/blue/organizations/jenkins/Plugins%2Fartifactory-plugin/detail/master/8/pipeline).
2. Anyone who runs `mvn install` encounters failures in tests due to lack of configured Artifactory for the tests.

With the suggested behavior in this PR, integration tests can be run with `mvn clean install/verify -DskipITs=false`