### PR TITLE
HAP-1190 add docker credentials to pull/push steps

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/common/docker/utils/DockerAgentUtils.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/docker/utils/DockerAgentUtils.java
@@ -1,6 +1,7 @@
 package org.jfrog.hudson.pipeline.common.docker.utils;
 
 import com.google.common.collect.ArrayListMultimap;
+import hudson.EnvVars;
 import hudson.Launcher;
 import hudson.model.Node;
 import hudson.model.TaskListener;
@@ -26,18 +27,21 @@ public class DockerAgentUtils implements Serializable {
     /**
      * Registers an image to be captured by the build-info proxy.
      *
+     * @param launcher
      * @param imageTag
      * @param host
      * @param targetRepo
+     * @param artifactsProps
      * @param buildInfoId
+     * @param envVars
      * @throws IOException
      * @throws InterruptedException
      */
     public synchronized static void registerImagOnAgents(Launcher launcher, final String imageTag,
             final String host, final String targetRepo, final ArrayListMultimap<String, String> artifactsProps,
-                final int buildInfoId) throws IOException, InterruptedException {
+                final int buildInfoId, final EnvVars envVars) throws IOException, InterruptedException {
         // Master
-        final String imageId = getImageIdFromAgent(launcher, imageTag, host);
+        final String imageId = getImageIdFromAgent(launcher, imageTag, host, envVars);
         registerImage(imageId, imageTag, targetRepo, artifactsProps, buildInfoId);
 
         // Agents
@@ -169,11 +173,13 @@ public class DockerAgentUtils implements Serializable {
      * @param imageTag
      * @param username
      * @param password
-     * @param host     @return
+     * @param host     
+     * @param envVars
+     * @return 
      * @throws IOException
      * @throws InterruptedException
      */
-    public static boolean pushImage(Launcher launcher, final JenkinsBuildInfoLog log, final String imageTag, final String username, final String password, final String host)
+    public static boolean pushImage(Launcher launcher, final JenkinsBuildInfoLog log, final String imageTag, final String username, final String password, final String host, final EnvVars envVars)
             throws IOException, InterruptedException {
 
         return launcher.getChannel().call(new  MasterToSlaveCallable<Boolean, IOException>() {
@@ -184,7 +190,7 @@ public class DockerAgentUtils implements Serializable {
                 }
 
                 log.info(message);
-                DockerUtils.pushImage(imageTag, username, password, host);
+                DockerUtils.pushImage(imageTag, username, password, host, envVars);
                 return true;
             }
         });
@@ -198,16 +204,17 @@ public class DockerAgentUtils implements Serializable {
      * @param username
      * @param password
      * @param host
+     * @param envVars
      * @return
      * @throws IOException
      * @throws InterruptedException
      */
-    public static boolean pullImage(Launcher launcher, final String imageTag, final String username, final String password, final String host)
+    public static boolean pullImage(Launcher launcher, final String imageTag, final String username, final String password, final String host, final EnvVars envVars)
             throws IOException, InterruptedException {
 
         return launcher.getChannel().call(new MasterToSlaveCallable<Boolean, IOException>() {
             public Boolean call() throws IOException {
-                DockerUtils.pullImage(imageTag, username, password, host);
+                DockerUtils.pullImage(imageTag, username, password, host, envVars);
                 return true;
             }
         });
@@ -221,12 +228,13 @@ public class DockerAgentUtils implements Serializable {
      * @param imageTag
      * @param host
      * @param buildInfoId
+     * @param envVars
      * @return
      * @throws IOException
      * @throws InterruptedException
      */
-    public static boolean updateImageParentOnAgents(final JenkinsBuildInfoLog log, final String imageTag, final String host, final int buildInfoId) throws IOException, InterruptedException {
-        boolean parentUpdated = updateImageParent(log, imageTag, host, buildInfoId);
+    public static boolean updateImageParentOnAgents(final JenkinsBuildInfoLog log, final String imageTag, final String host, final int buildInfoId, final EnvVars envVars) throws IOException, InterruptedException {
+        boolean parentUpdated = updateImageParent(log, imageTag, host, buildInfoId, envVars);
         List<Node> nodes = Jenkins.getInstance().getNodes();
         for (Node node : nodes) {
             if (node == null || node.getChannel() == null) {
@@ -234,7 +242,7 @@ public class DockerAgentUtils implements Serializable {
             }
             boolean parentNodeUpdated = node.getChannel().call(new MasterToSlaveCallable<Boolean, IOException>() {
                 public Boolean call() throws IOException {
-                    return updateImageParent(log, imageTag, host, buildInfoId);
+                    return updateImageParent(log, imageTag, host, buildInfoId, envVars);
                 }
             });
             parentUpdated = parentUpdated ? parentUpdated : parentNodeUpdated;
@@ -249,14 +257,15 @@ public class DockerAgentUtils implements Serializable {
      * @param imageTag
      * @param host
      * @param buildInfoId
+     * @param envVars
      * @return
      * @throws IOException
      */
-    private static boolean updateImageParent(JenkinsBuildInfoLog log, String imageTag, String host, int buildInfoId) throws IOException {
+    private static boolean updateImageParent(JenkinsBuildInfoLog log, String imageTag, String host, int buildInfoId, EnvVars envVars) throws IOException {
         boolean parentUpdated = false;
         for (DockerImage image : getImagesByBuildId(buildInfoId)) {
             if (image.getImageTag().equals(imageTag)) {
-                String parentId = DockerUtils.getParentId(image.getImageId(), host);
+                String parentId = DockerUtils.getParentId(image.getImageId(), host, envVars);
                 if (StringUtils.isNotEmpty(parentId)) {
                     Properties properties = new Properties();
                     properties.setProperty("docker.image.parent", DockerUtils.getShaValue(parentId));
@@ -272,13 +281,16 @@ public class DockerAgentUtils implements Serializable {
     /**
      * Get image ID from imageTag on the current agent.
      *
+     * @param launcher
      * @param imageTag
+     * @param host
+     * @param envVars
      * @return
      */
-    public static String getImageIdFromAgent(Launcher launcher, final String imageTag, final String host) throws IOException, InterruptedException {
+    public static String getImageIdFromAgent(Launcher launcher, final String imageTag, final String host, final EnvVars envVars) throws IOException, InterruptedException {
         return launcher.getChannel().call(new MasterToSlaveCallable<String, IOException>() {
             public String call() throws IOException {
-                return DockerUtils.getImageIdFromTag(imageTag, host);
+                return DockerUtils.getImageIdFromTag(imageTag, host, envVars);
             }
         });
     }
@@ -286,13 +298,16 @@ public class DockerAgentUtils implements Serializable {
     /**
      * Get image parent ID from imageID on the current agent.
      *
+     * @param launcher
      * @param imageID
+     * @param host
+     * @param envVars
      * @return
      */
-    public static String getParentIdFromAgent(Launcher launcher, final String imageID, final String host) throws IOException, InterruptedException {
+    public static String getParentIdFromAgent(Launcher launcher, final String imageID, final String host, final EnvVars envVars) throws IOException, InterruptedException {
         return launcher.getChannel().call(new MasterToSlaveCallable<String, IOException>() {
             public String call() throws IOException {
-                return DockerUtils.getParentId(imageID, host);
+                return DockerUtils.getParentId(imageID, host, envVars);
             }
         });
     }

--- a/src/main/java/org/jfrog/hudson/pipeline/common/docker/utils/DockerUtils.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/docker/utils/DockerUtils.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.core.DefaultDockerClientConfig;
+import com.github.dockerjava.core.DefaultDockerClientConfig.Builder;
 import com.github.dockerjava.core.DockerClientBuilder;
 import com.github.dockerjava.core.DockerClientConfig;
 import com.github.dockerjava.core.command.PullImageResultCallback;
@@ -11,6 +12,7 @@ import com.github.dockerjava.core.command.PushImageResultCallback;
 import com.github.dockerjava.netty.NettyDockerCmdExecFactory;
 import com.google.common.base.Charsets;
 import com.google.common.hash.Hashing;
+import hudson.EnvVars;
 import org.apache.commons.lang.StringUtils;
 import org.jfrog.hudson.pipeline.common.Utils;
 
@@ -29,12 +31,13 @@ public class DockerUtils implements Serializable {
      *
      * @param imageTag
      * @param host
+     * @param envVars
      * @return
      */
-    public static String getImageIdFromTag(String imageTag, String host) throws IOException {
+    public static String getImageIdFromTag(String imageTag, String host, EnvVars envVars) throws IOException {
         DockerClient dockerClient = null;
         try {
-            dockerClient = getDockerClient(host);
+            dockerClient = getDockerClient(host, envVars);
             return dockerClient.inspectImageCmd(imageTag).exec().getId();
         } finally {
             closeQuietly(dockerClient);
@@ -48,15 +51,16 @@ public class DockerUtils implements Serializable {
      * @param username
      * @param password
      * @param host
+     * @param envVars
      */
-    public static void pushImage(String imageTag, String username, String password, String host) throws IOException {
+    public static void pushImage(String imageTag, String username, String password, String host, EnvVars envVars) throws IOException {
         final AuthConfig authConfig = new AuthConfig();
         authConfig.withUsername(username);
         authConfig.withPassword(password);
 
         DockerClient dockerClient = null;
         try {
-            dockerClient = getDockerClient(host);
+            dockerClient = getDockerClient(host, envVars);
             dockerClient.pushImageCmd(imageTag).withAuthConfig(authConfig).exec(new PushImageResultCallback()).awaitSuccess();
         } finally {
             closeQuietly(dockerClient);
@@ -71,14 +75,14 @@ public class DockerUtils implements Serializable {
      * @param password
      * @param host
      */
-    public static void pullImage(String imageTag, String username, String password, String host) throws IOException {
+    public static void pullImage(String imageTag, String username, String password, String host, EnvVars envVars) throws IOException {
         final AuthConfig authConfig = new AuthConfig();
         authConfig.withUsername(username);
         authConfig.withPassword(password);
 
         DockerClient dockerClient = null;
         try {
-            dockerClient = getDockerClient(host);
+            dockerClient = getDockerClient(host, envVars);
             dockerClient.pullImageCmd(imageTag).withAuthConfig(authConfig).exec(new PullImageResultCallback()).awaitSuccess();
         } finally {
             closeQuietly(dockerClient);
@@ -90,12 +94,13 @@ public class DockerUtils implements Serializable {
      *
      * @param digest
      * @param host
+     * @param envVars
      * @return
      */
-    public static String getParentId(String digest, String host) throws IOException {
+    public static String getParentId(String digest, String host, EnvVars envVars) throws IOException {
         DockerClient dockerClient = null;
         try {
-            dockerClient = getDockerClient(host);
+            dockerClient = getDockerClient(host, envVars);
             return dockerClient.inspectImageCmd(digest).exec().getParent();
         } finally {
             closeQuietly(dockerClient);
@@ -318,20 +323,31 @@ public class DockerUtils implements Serializable {
         return layersNum;
     }
 
-    public static DockerClient getDockerClient(String host) {
-        NettyDockerCmdExecFactory nettyDockerCmdExecFactory;
 
-        nettyDockerCmdExecFactory = new NettyDockerCmdExecFactory();
-        // If open JDK is used and the host is null
-        // then instead of a null reference, the host is the string "null".
-        if (StringUtils.isEmpty(host) || host.equalsIgnoreCase("null")) {
-            return DockerClientBuilder.getInstance().withDockerCmdExecFactory(nettyDockerCmdExecFactory).build();
-        }
+    public static DockerClient getDockerClient(String host, EnvVars envVars) {
 
-        DockerClientConfig config = DefaultDockerClientConfig.createDefaultConfigBuilder()
-                .withDockerHost(host)
-                .build();
-        return DockerClientBuilder.getInstance(config).withDockerCmdExecFactory(nettyDockerCmdExecFactory).build();
+      if(envVars == null) {
+          throw new IllegalStateException("envVars must not be null");
+      }
+
+      Builder configBuilder = DefaultDockerClientConfig.createDefaultConfigBuilder();
+
+      if (envVars.containsKey(DefaultDockerClientConfig.DOCKER_HOST)) {
+          configBuilder.withDockerHost(envVars.get(DefaultDockerClientConfig.DOCKER_HOST));
+      } else {
+          if (!StringUtils.isEmpty(host)) {
+              configBuilder.withDockerHost(host);
+          }
+      }
+      if (envVars.containsKey(DefaultDockerClientConfig.DOCKER_TLS_VERIFY)) {
+          configBuilder.withDockerTlsVerify(envVars.get(DefaultDockerClientConfig.DOCKER_TLS_VERIFY));
+      }
+      if (envVars.containsKey(DefaultDockerClientConfig.DOCKER_CERT_PATH)) {
+          configBuilder.withDockerCertPath(envVars.get(DefaultDockerClientConfig.DOCKER_CERT_PATH));
+      }
+
+      DockerClientConfig config = configBuilder.build();
+      return DockerClientBuilder.getInstance(config).withDockerCmdExecFactory(new NettyDockerCmdExecFactory()).build();      
     }
 
     private static void closeQuietly(DockerClient dockerClient) {

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/docker/DockerPushStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/docker/DockerPushStep.java
@@ -92,7 +92,7 @@ public class DockerPushStep extends AbstractStepImpl {
         protected Void run() throws Exception {
             BuildInfo buildInfo = DeclarativePipelineUtils.getBuildInfo(ws, build, step.buildName, step.buildNumber);
             org.jfrog.hudson.pipeline.common.types.ArtifactoryServer pipelineServer = DeclarativePipelineUtils.getArtifactoryServer(build, ws, getContext(), step.serverId);
-            DockerExecutor dockerExecutor = new DockerExecutor(pipelineServer, buildInfo, build, step.image, step.targetRepo, step.host, launcher, step.properties, listener);
+            DockerExecutor dockerExecutor = new DockerExecutor(pipelineServer, buildInfo, build, step.image, step.targetRepo, step.host, launcher, step.properties, listener, env);
             dockerExecutor.execute();
             DeclarativePipelineUtils.saveBuildInfo(dockerExecutor.getBuildInfo(), ws, build, new JenkinsBuildInfoLog(listener));
             return null;

--- a/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/DockerPullStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/DockerPullStep.java
@@ -1,6 +1,7 @@
 package org.jfrog.hudson.pipeline.scripted.steps;
 
 import com.google.inject.Inject;
+import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.model.Run;
@@ -68,6 +69,9 @@ public class DockerPullStep extends AbstractStepImpl {
         @StepContextParameter
         private transient Launcher launcher;
 
+        @StepContextParameter
+        private transient EnvVars envVars; 
+        
         @Override
         protected BuildInfo run() throws Exception {
             if (step.getImage() == null) {
@@ -85,7 +89,7 @@ public class DockerPullStep extends AbstractStepImpl {
             String username = server.createCredentialsConfig().provideUsername(build.getParent());
             String password = server.createCredentialsConfig().providePassword(build.getParent());
 
-            DockerAgentUtils.pullImage(launcher, imageTag, username, password, step.getHost());
+            DockerAgentUtils.pullImage(launcher, imageTag, username, password, step.getHost(), envVars);
             JenkinsBuildInfoLog log = new JenkinsBuildInfoLog(listener);
             log.info("Successfully pulled docker image: " + imageTag);
             return buildInfo;

--- a/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/DockerPushStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/DockerPushStep.java
@@ -2,6 +2,7 @@ package org.jfrog.hudson.pipeline.scripted.steps;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.inject.Inject;
+import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.model.Run;
@@ -82,6 +83,9 @@ public class DockerPushStep extends AbstractStepImpl {
         @StepContextParameter
         private transient Launcher launcher;
 
+        @StepContextParameter
+        private transient EnvVars envVars; 
+        
         @Override
         protected BuildInfo run() throws Exception {
             if (step.getImage() == null) {
@@ -96,7 +100,7 @@ public class DockerPushStep extends AbstractStepImpl {
             BuildInfo buildInfo = Utils.prepareBuildinfo(build, step.getBuildInfo());
 
             ArtifactoryServer server = step.getServer();
-            DockerExecutor dockerExecutor = new DockerExecutor(server, buildInfo, build, step.image, step.targetRepo, step.host, launcher, step.properties, listener);
+            DockerExecutor dockerExecutor = new DockerExecutor(server, buildInfo, build, step.image, step.targetRepo, step.host, launcher, step.properties, listener, envVars);
             dockerExecutor.execute();
             return dockerExecutor.getBuildInfo();
         }

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
@@ -4,6 +4,9 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.BuildImageCmd;
 import com.github.dockerjava.core.command.BuildImageResultCallback;
 import com.google.common.collect.Sets;
+
+import hudson.EnvVars;
+
 import org.apache.commons.cli.MissingArgumentException;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -362,7 +365,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
             }
             String imageName = domainName + "jfrog_artifactory_jenkins_tests:2";
             String host = System.getenv("JENKINS_ARTIFACTORY_DOCKER_HOST");
-            DockerClient dockerClient = DockerUtils.getDockerClient(host);
+            DockerClient dockerClient = DockerUtils.getDockerClient(host, new EnvVars());
             String projectPath = getProjectPath("docker-example");
             // Build the docker image with the name provided from env.
             BuildImageCmd buildImageCmd = dockerClient.buildImageCmd(Paths.get(projectPath).toFile()).withTags(new HashSet<>(Arrays.asList(imageName)));


### PR DESCRIPTION
As discussed with Alexei today here our PR for https://www.jfrog.com/jira/browse/HAP-1190

I developed this originally with 3.2.2 as base. Since then there started development to implement push/pull also for declarative pipelines. Because there seems to be nothing like docker.withServer with scripted pipeline, Docker credentials can't be set this way.
