### PR TITLE
[HAP-1219] folder scoped credentials for deploy step

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/DeployStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/DeployStep.java
@@ -3,6 +3,7 @@ package org.jfrog.hudson.pipeline.scripted.steps;
 import com.google.inject.Inject;
 import hudson.Extension;
 import hudson.FilePath;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
@@ -33,6 +34,9 @@ public class DeployStep extends AbstractStepImpl {
         private transient DeployStep step;
 
         @StepContextParameter
+        private transient Run build;
+
+        @StepContextParameter
         private transient FilePath ws;
 
         @StepContextParameter
@@ -40,7 +44,7 @@ public class DeployStep extends AbstractStepImpl {
 
         @Override
         protected Boolean run() throws Exception {
-            step.deployer.deployArtifacts(step.buildInfo, listener, ws);
+            step.deployer.deployArtifacts(step.buildInfo, listener, ws, build);
             return true;
         }
     }

--- a/src/main/java/org/jfrog/hudson/util/plugins/PluginsUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/plugins/PluginsUtils.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import hudson.model.Hudson;
 import hudson.model.Item;
+import hudson.model.Queue;
+import hudson.model.queue.Tasks;
 import hudson.security.ACL;
 import hudson.util.ListBoxModel;
 import org.acegisecurity.Authentication;
@@ -57,9 +59,13 @@ public class PluginsUtils {
     public static Credentials credentialsLookup(String credentialsId, Item item) {
         UsernamePasswordCredentials usernamePasswordCredentials = CredentialsMatchers.firstOrNull(
                 CredentialsProvider.lookupCredentials(
-                        UsernamePasswordCredentials.class, item, ACL.SYSTEM,
+                        UsernamePasswordCredentials.class,
+                        item,
+                        item instanceof Queue.Task
+                            ? Tasks.getAuthenticationOf((Queue.Task) item)
+                            : ACL.SYSTEM,
                         Collections.<DomainRequirement>emptyList()),
-                CredentialsMatchers.allOf(CredentialsMatchers.withId(credentialsId))
+                CredentialsMatchers.withId(credentialsId)
         );
 
         if (usernamePasswordCredentials != null) {


### PR DESCRIPTION
Added support for folder scoped credentials for `DeployStep`.

This should be the last place which was previously missed.  I have searched and it seems that anything else that calls `getCredentials()` is sending, at least, some sort of `Item` along as the context.

This closes HAP-1219
