### PR TITLE
Allow to set Conan user without adding the remote itself

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/ConanRemote.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/ConanRemote.java
@@ -41,6 +41,17 @@ public class ConanRemote implements Serializable {
         return serverName;
     }
 
+    @Whitelisted
+    public String addUser(Map<String, Object> args) {
+        if (!args.containsKey("server") || !args.containsKey("remoteName")) {
+            throw new IllegalArgumentException("server and remoteName are mandatory arguments.");
+        }
+        ArtifactoryServer server = (ArtifactoryServer) args.get("server");
+        String remoteName = (String) args.get("remoteName");
+        cpsScript.invokeMethod("conanAddUser", getAddUserExecutionArguments(server, remoteName));
+        return remoteName;
+    }
+
     private Map<String, Object> getAddRemoteExecutionArguments(ArtifactoryServer server, String serverName, String repo) {
         String serverUrl = buildConanRemoteUrl(server, repo);
         Map<String, Object> stepVariables = Maps.newLinkedHashMap();


### PR DESCRIPTION
closes #122 

It is quite common for a company to share the Conan configuration using `conan config install` (remotes are already added) and then just adding the credentials to be able to access/upload the artifacts.

This PR adds a new function to the ConanRemote class, so the user can associate a `user` with a `remote` without adding the remote itself:

```groovy
def server = Artifactory.server artifactory_name
def client = Artifactory.newConanClient()
def remoteName = client.remote.addUser server: server, remoteName: "conan-center"
```

Thanks for taking this PR into consideration, let me know if I have to modify anything. Cheers!