### PR TITLE
Create user-provided CONAN_USER_HOME if it doesn't exist

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/conan/InitConanClientStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/conan/InitConanClientStep.java
@@ -77,9 +77,10 @@ public class InitConanClientStep extends AbstractStepImpl {
                 conanHomeDirectory = env.containsKey(Utils.CONAN_USER_HOME) ? new FilePath(new File(env.get(Utils.CONAN_USER_HOME))) : createConanTempHome();
             } else {
                 conanHomeDirectory = new FilePath(launcher.getChannel(), conanClient.getUserPath());
-                if (!conanHomeDirectory.exists()) {
-                    conanHomeDirectory.mkdirs();
-                }
+            }
+
+            if (!conanHomeDirectory.exists()) {
+                conanHomeDirectory.mkdirs();
             }
 
             conanClient.setUserPath(conanHomeDirectory.getRemote());

--- a/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/conan/RunCommandStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/conan/RunCommandStep.java
@@ -93,7 +93,7 @@ public class RunCommandStep extends AbstractStepImpl {
         }
 
         // Conan collect buildInfo as part of the tasks execution.
-        // In order to transform the collected buildInfo into Artifctory buildInfo format we need to execute the conan_build_info command.
+        // In order to transform the collected buildInfo into Artifactory buildInfo format we need to execute the conan_build_info command.
         // The conan_build_info command expect to get a path for the output file.
         private FilePath execConanCollectBuildInfo(EnvVars extendedEnv) throws Exception {
             FilePath tempDir = ExtractorUtils.createAndGetTempDir(ws);


### PR DESCRIPTION
Fixes: https://issues.jenkins-ci.org/browse/JENKINS-50218
also reported in https://github.com/conan-io/conan/issues/2690

When the user provides a custom CONAN_USER_HOME using the environment variable or the argument `userHome` in `Artifactory.newConanClient`, the provided folder might not exist and it leads to a crash when the plugin tries to touch the file `CONAN_LOG_FILE`.

This PR creates the folder if it doesn't exist.