### PR TITLE
Add 'force' and 'remoteName' arguments to 'client.remote.add' function

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/ConanRemote.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/ConanRemote.java
@@ -34,19 +34,21 @@ public class ConanRemote implements Serializable {
             throw new IllegalArgumentException("server and repo are mandatory arguments.");
         }
         ArtifactoryServer server = (ArtifactoryServer) args.get("server");
-        String serverName = UUID.randomUUID().toString();
+        String serverName = args.containsKey("remoteName") ? args.get("remoteName").toString() : UUID.randomUUID().toString();
         String repo = (String) args.get("repo");
-        cpsScript.invokeMethod("conanAddRemote", getAddRemoteExecutionArguments(server, serverName, repo));
+        boolean force = args.containsKey("force") && (boolean) args.get("force");
+        cpsScript.invokeMethod("conanAddRemote", getAddRemoteExecutionArguments(server, serverName, repo, force));
         cpsScript.invokeMethod("conanAddUser", getAddUserExecutionArguments(server, serverName));
         return serverName;
     }
 
-    private Map<String, Object> getAddRemoteExecutionArguments(ArtifactoryServer server, String serverName, String repo) {
+    private Map<String, Object> getAddRemoteExecutionArguments(ArtifactoryServer server, String serverName, String repo, boolean force) {
         String serverUrl = buildConanRemoteUrl(server, repo);
         Map<String, Object> stepVariables = Maps.newLinkedHashMap();
         stepVariables.put("serverUrl", serverUrl);
         stepVariables.put("serverName", serverName);
         stepVariables.put("conanHome", conanHome);
+        stepVariables.put("force", force);
         return stepVariables;
     }
 

--- a/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/conan/AddRemoteStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/conan/AddRemoteStep.java
@@ -19,12 +19,14 @@ public class AddRemoteStep extends AbstractStepImpl {
     private String serverUrl;
     private String serverName;
     private String conanHome;
+    private boolean force;
 
     @DataBoundConstructor
-    public AddRemoteStep(String serverUrl, String serverName, String conanHome) {
+    public AddRemoteStep(String serverUrl, String serverName, String conanHome, boolean force) {
         this.serverUrl = serverUrl;
         this.serverName = serverName;
         this.conanHome = conanHome;
+        this.force = force;
     }
 
     public String getServerUrl() {
@@ -37,6 +39,10 @@ public class AddRemoteStep extends AbstractStepImpl {
 
     public String getConanHome() {
         return this.conanHome;
+    }
+
+    public boolean getForce() {
+        return this.force;
     }
 
     public static class Execution extends AbstractSynchronousStepExecution<Boolean> {
@@ -64,6 +70,9 @@ public class AddRemoteStep extends AbstractStepImpl {
         protected Boolean run() throws Exception {
             ArgumentListBuilder args = new ArgumentListBuilder();
             args.addTokenized("conan remote add");
+            if (step.getForce()) {
+                args.add("--force");
+            }
             args.add(step.getServerName());
             args.add(step.getServerUrl());
             EnvVars extendedEnv = new EnvVars(env);


### PR DESCRIPTION
Add the following **optional arguments** to the `client.remote.add` function:
 * `force`: if true, it adds a `--force` flag to the Conan call
 * `remoteName`: if provided, it will be used as the name for the remote instead of using a generated UUID identifier.

These arguments are [already available in the Conan CLI](https://docs.conan.io/en/latest/reference/commands/misc/remote.html), and are requested in some issues related to the Artifactory plugin in the Conan repo (https://github.com/conan-io/conan/issues/2690).

A common use-case for the `force` argument would be to reuse the Conan cache between jobs, like this:

```groovy
def server = Artifactory.server artifactory_name
def client = Artifactory.newConanClient(userHome: "${env.WORKSPACE}/conan_home".toString())
def remoteName = client.remote.add server: server, repo: artifactory_repo, force: true
```

The `remoteName` argument, together with the `force` one, will allow the user to authenticate against a remote which is already in the Conan configuration: this is a common scenario in companies that share the configuration between employees (or CI nodes) using a repository or URL ([Conan docs](https://docs.conan.io/en/latest/reference/commands/consumer/config.html#conan-config-install)). This  use-case is also possible through https://github.com/jfrog/jenkins-artifactory-plugin/pull/177 

closes #122 (see comment here: https://github.com/jfrog/jenkins-artifactory-plugin/pull/177#issuecomment-517170925)