### PR TITLE
Whitelist BuildInfo getModules

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/buildInfo/BuildInfo.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/buildInfo/BuildInfo.java
@@ -283,6 +283,7 @@ public class BuildInfo implements Serializable {
         this.issues.setCpsScript(cpsScript);
     }
 
+    @Whitelisted
     public List<Module> getModules() {
         return modules;
     }


### PR DESCRIPTION
I would like the `getModules` method in `BuildInfo` type to be whiltelisted. 
The `getArtifacts` and `getDependencies` methods are already whitelisted and they expose the `org.jfrog.hudson.pipeline.types.File` type. I think it makes sense to also whitelist `getModules`that ultimately returns the `Module` type from the integration layer API: https://github.com/jfrog/build-info 