### PR TITLE
Add 'VerifySSL' argument to conan.remote.add function

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/ConanRemote.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/ConanRemote.java
@@ -37,18 +37,20 @@ public class ConanRemote implements Serializable {
         String serverName = args.containsKey("remoteName") ? args.get("remoteName").toString() : UUID.randomUUID().toString();
         String repo = (String) args.get("repo");
         boolean force = args.containsKey("force") && (boolean) args.get("force");
-        cpsScript.invokeMethod("conanAddRemote", getAddRemoteExecutionArguments(server, serverName, repo, force));
+        boolean verifySSL = args.containsKey("verifySSL") ? (boolean) args.get("verifySSL") : true;
+        cpsScript.invokeMethod("conanAddRemote", getAddRemoteExecutionArguments(server, serverName, repo, force, verifySSL));
         cpsScript.invokeMethod("conanAddUser", getAddUserExecutionArguments(server, serverName));
         return serverName;
     }
 
-    private Map<String, Object> getAddRemoteExecutionArguments(ArtifactoryServer server, String serverName, String repo, boolean force) {
+    private Map<String, Object> getAddRemoteExecutionArguments(ArtifactoryServer server, String serverName, String repo, boolean force, boolean verifySSL) {
         String serverUrl = buildConanRemoteUrl(server, repo);
         Map<String, Object> stepVariables = Maps.newLinkedHashMap();
         stepVariables.put("serverUrl", serverUrl);
         stepVariables.put("serverName", serverName);
         stepVariables.put("conanHome", conanHome);
         stepVariables.put("force", force);
+        stepVariables.put("verifySSL", verifySSL);
         return stepVariables;
     }
 

--- a/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/conan/AddRemoteStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/conan/AddRemoteStep.java
@@ -20,13 +20,15 @@ public class AddRemoteStep extends AbstractStepImpl {
     private String serverName;
     private String conanHome;
     private boolean force;
+    private boolean verifySSL;
 
     @DataBoundConstructor
-    public AddRemoteStep(String serverUrl, String serverName, String conanHome, boolean force) {
+    public AddRemoteStep(String serverUrl, String serverName, String conanHome, boolean force, boolean verifySSL) {
         this.serverUrl = serverUrl;
         this.serverName = serverName;
         this.conanHome = conanHome;
         this.force = force;
+        this.verifySSL = verifySSL;
     }
 
     public String getServerUrl() {
@@ -43,6 +45,10 @@ public class AddRemoteStep extends AbstractStepImpl {
 
     public boolean getForce() {
         return this.force;
+    }
+
+    public boolean getVerifySSL() {
+    	return this.verifySSL;
     }
 
     public static class Execution extends AbstractSynchronousStepExecution<Boolean> {
@@ -75,6 +81,11 @@ public class AddRemoteStep extends AbstractStepImpl {
             }
             args.add(step.getServerName());
             args.add(step.getServerUrl());
+            if(step.getVerifySSL()) {
+            	args.add("True");
+            } else {
+            	args.add("False");
+            }
             EnvVars extendedEnv = new EnvVars(env);
             extendedEnv.put(Utils.CONAN_USER_HOME, step.getConanHome());
             Utils.exeConan(args, ws, launcher, listener, extendedEnv);


### PR DESCRIPTION
Since there is currently no convenient way to allow self signed certificated (see https://issues.jenkins-ci.org/browse/JENKINS-56835), I implemented a work around to allow one to specify the `verify_ssl` conan option