### PR TITLE
NPM build in container not working

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/common/executors/NpmEnvExtractor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/executors/NpmEnvExtractor.java
@@ -14,16 +14,14 @@ import org.jfrog.hudson.pipeline.common.types.resolvers.Resolver;
  * @author yahavi
  */
 public class NpmEnvExtractor extends EnvExtractor {
-    private String npmExe;
     private String args;
     private String path;
     private String module;
 
     public NpmEnvExtractor(Run build, BuildInfo buildInfo, Deployer deployer, Resolver resolver,
                            TaskListener buildListener, Launcher launcher, FilePath tempDir,
-                           EnvVars env, String args, String path, String npmExe, String module) {
+                           EnvVars env, String args, String path, String module) {
         super(build, buildInfo, deployer, resolver, buildListener, launcher, tempDir, env);
-        this.npmExe = npmExe;
         this.args = args;
         this.path = path;
         this.module = module;
@@ -31,7 +29,6 @@ public class NpmEnvExtractor extends EnvExtractor {
 
     @Override
     protected void addExtraConfiguration(ArtifactoryClientConfiguration configuration) {
-        configuration.npmHandler.setNpmExecutablePath(npmExe);
         configuration.npmHandler.setNpmInstallArgs(args);
         configuration.npmHandler.setNpmPath(path);
         configuration.npmHandler.setNpmModule(module);

--- a/src/main/java/org/jfrog/hudson/pipeline/common/executors/NpmExecutor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/executors/NpmExecutor.java
@@ -30,20 +30,18 @@ public abstract class NpmExecutor implements Executor {
     Launcher launcher;
     NpmBuild npmBuild;
     String javaArgs;
-    String npmExe;
     FilePath ws;
     String path;
     String module;
     EnvVars env;
     Run build;
 
-    public NpmExecutor(BuildInfo buildInfo, Launcher launcher, NpmBuild npmBuild, String javaArgs, String npmExe, FilePath ws, String path, String module, EnvVars env, TaskListener listener, Run build) {
+    public NpmExecutor(BuildInfo buildInfo, Launcher launcher, NpmBuild npmBuild, String javaArgs, FilePath ws, String path, String module, EnvVars env, TaskListener listener, Run build) {
         this.listener = listener;
         this.buildInfo = Utils.prepareBuildinfo(build, buildInfo);
         this.launcher = launcher;
         this.npmBuild = npmBuild;
         this.javaArgs = javaArgs;
-        this.npmExe = npmExe;
         this.ws = ws;
         this.path = Objects.toString(path, ".");
         this.module = module;
@@ -59,7 +57,7 @@ public abstract class NpmExecutor implements Executor {
         ExtractorUtils.addVcsDetailsToEnv(new FilePath(ws, path), env, listener);
         FilePath tempDir = ExtractorUtils.createAndGetTempDir(ws);
         EnvExtractor envExtractor = new NpmEnvExtractor(build,
-                buildInfo, deployer, resolver, listener, launcher, tempDir, env, args, path, npmExe, module);
+                buildInfo, deployer, resolver, listener, launcher, tempDir, env, args, path, module);
         envExtractor.execute();
         String absoluteDependencyDirPath = copyExtractorJars(tempDir);
         Utils.launch("npm", launcher, getArgs(absoluteDependencyDirPath, classToExecute), env, listener, ws);

--- a/src/main/java/org/jfrog/hudson/pipeline/common/executors/NpmInstallExecutor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/executors/NpmInstallExecutor.java
@@ -18,8 +18,8 @@ public class NpmInstallExecutor extends NpmExecutor {
 
     private String args;
 
-    public NpmInstallExecutor(BuildInfo buildInfo, Launcher launcher, NpmBuild npmBuild, String javaArgs, String npmExe, String args, FilePath ws, String path, String module, EnvVars env, TaskListener listener, Run build) {
-        super(buildInfo, launcher, npmBuild, javaArgs, npmExe, ws, path, module, env, listener, build);
+    public NpmInstallExecutor(BuildInfo buildInfo, Launcher launcher, NpmBuild npmBuild, String javaArgs, String args, FilePath ws, String path, String module, EnvVars env, TaskListener listener, Run build) {
+        super(buildInfo, launcher, npmBuild, javaArgs, ws, path, module, env, listener, build);
         this.args = StringUtils.defaultIfEmpty(args, "");
     }
 

--- a/src/main/java/org/jfrog/hudson/pipeline/common/executors/NpmPublishExecutor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/executors/NpmPublishExecutor.java
@@ -15,8 +15,8 @@ import org.jfrog.hudson.pipeline.common.types.resolvers.NpmGoResolver;
  */
 public class NpmPublishExecutor extends NpmExecutor {
 
-    public NpmPublishExecutor(TaskListener listener, BuildInfo buildInfo, Launcher launcher, NpmBuild npmBuild, String javaArgs, String npmExe, String path, String module, FilePath ws, EnvVars env, Run build) {
-        super(buildInfo, launcher, npmBuild, javaArgs, npmExe, ws, path, module, env, listener, build);
+    public NpmPublishExecutor(TaskListener listener, BuildInfo buildInfo, Launcher launcher, NpmBuild npmBuild, String javaArgs, String path, String module, FilePath ws, EnvVars env, Run build) {
+        super(buildInfo, launcher, npmBuild, javaArgs, ws, path, module, env, listener, build);
     }
 
     @Override

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/npm/NpmInstallStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/npm/NpmInstallStep.java
@@ -115,8 +115,8 @@ public class NpmInstallStep extends AbstractStepImpl {
         protected Void run() throws Exception {
             BuildInfo buildInfo = DeclarativePipelineUtils.getBuildInfo(ws, build, step.customBuildName, step.customBuildNumber);
             setResolver(BuildUniqueIdentifierHelper.getBuildNumber(build));
-            String npmExe = Utils.getNpmExe(ws, listener, env, launcher, step.npmBuild.getTool());
-            NpmInstallExecutor npmInstallExecutor = new NpmInstallExecutor(buildInfo, launcher, step.npmBuild, step.javaArgs, npmExe, step.args, ws, step.path, step.module, env, listener, build);
+            Utils.addNpmToPath(ws, listener, env, launcher, step.npmBuild.getTool());
+            NpmInstallExecutor npmInstallExecutor = new NpmInstallExecutor(buildInfo, launcher, step.npmBuild, step.javaArgs, step.args, ws, step.path, step.module, env, listener, build);
             npmInstallExecutor.execute();
             DeclarativePipelineUtils.saveBuildInfo(npmInstallExecutor.getBuildInfo(), ws, build, new JenkinsBuildInfoLog(listener));
             return null;

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/npm/NpmPublishStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/npm/NpmPublishStep.java
@@ -17,8 +17,8 @@ import org.jfrog.hudson.pipeline.common.Utils;
 import org.jfrog.hudson.pipeline.common.executors.NpmPublishExecutor;
 import org.jfrog.hudson.pipeline.common.types.ArtifactoryServer;
 import org.jfrog.hudson.pipeline.common.types.buildInfo.BuildInfo;
-import org.jfrog.hudson.pipeline.common.types.deployers.NpmGoDeployer;
 import org.jfrog.hudson.pipeline.common.types.builds.NpmBuild;
+import org.jfrog.hudson.pipeline.common.types.deployers.NpmGoDeployer;
 import org.jfrog.hudson.pipeline.declarative.BuildDataFile;
 import org.jfrog.hudson.pipeline.declarative.utils.DeclarativePipelineUtils;
 import org.jfrog.hudson.util.BuildUniqueIdentifierHelper;
@@ -110,8 +110,8 @@ public class NpmPublishStep extends AbstractStepImpl {
         protected Void run() throws Exception {
             BuildInfo buildInfo = DeclarativePipelineUtils.getBuildInfo(ws, build, step.customBuildName, step.customBuildNumber);
             setDeployer(BuildUniqueIdentifierHelper.getBuildNumber(build));
-            String npmExe = Utils.getNpmExe(ws, listener, env, launcher, step.npmBuild.getTool());
-            NpmPublishExecutor npmPublishExecutor = new NpmPublishExecutor(listener, buildInfo, launcher, step.npmBuild, step.javaArgs, npmExe, step.path, step.module, ws, env, build);
+            Utils.addNpmToPath(ws, listener, env, launcher, step.npmBuild.getTool());
+            NpmPublishExecutor npmPublishExecutor = new NpmPublishExecutor(listener, buildInfo, launcher, step.npmBuild, step.javaArgs, step.path, step.module, ws, env, build);
             npmPublishExecutor.execute();
             DeclarativePipelineUtils.saveBuildInfo(npmPublishExecutor.getBuildInfo(), ws, build, new JenkinsBuildInfoLog(listener));
             return null;

--- a/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/NpmInstallStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/NpmInstallStep.java
@@ -63,8 +63,8 @@ public class NpmInstallStep extends AbstractStepImpl {
 
         @Override
         protected BuildInfo run() throws Exception {
-            String npmExe = Utils.getNpmExe(ws, listener, env, launcher, step.npmBuild.getTool());
-            NpmInstallExecutor npmInstallExecutor = new NpmInstallExecutor(step.buildInfo, launcher, step.npmBuild, step.javaArgs, npmExe, step.args, ws, step.path, step.module, env, listener, build);
+            Utils.addNpmToPath(ws, listener, env, launcher, step.npmBuild.getTool());
+            NpmInstallExecutor npmInstallExecutor = new NpmInstallExecutor(step.buildInfo, launcher, step.npmBuild, step.javaArgs, step.args, ws, step.path, step.module, env, listener, build);
             npmInstallExecutor.execute();
             return npmInstallExecutor.getBuildInfo();
         }

--- a/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/NpmPublishStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/NpmPublishStep.java
@@ -61,8 +61,8 @@ public class NpmPublishStep extends AbstractStepImpl {
 
         @Override
         protected BuildInfo run() throws Exception {
-            String npmExe = Utils.getNpmExe(ws, listener, env, launcher, step.npmBuild.getTool());
-            NpmPublishExecutor npmPublishExecutor = new NpmPublishExecutor(listener, step.buildInfo, launcher, step.npmBuild, step.javaArgs, npmExe, step.path, step.module, ws, env, build);
+            Utils.addNpmToPath(ws, listener, env, launcher, step.npmBuild.getTool());
+            NpmPublishExecutor npmPublishExecutor = new NpmPublishExecutor(listener, step.buildInfo, launcher, step.npmBuild, step.javaArgs, step.path, step.module, ws, env, build);
             npmPublishExecutor.execute();
             return npmPublishExecutor.getBuildInfo();
         }


### PR DESCRIPTION
This supposed to fix these 2 scenarios:
1. Allow running npm in Windows using NodeJS tool.
2. When NodeJS tool is configured in agent, the container get the executable path of `${NODEJS_HOME}/bin/npm`, instead of the node `npm` configured in PATH.