### PR TITLE
Update Gradle and Maven default deployment threads to match extractors

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/deployers/Deployer.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/deployers/Deployer.java
@@ -34,6 +34,8 @@ import java.io.Serializable;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
 
+import static org.jfrog.build.extractor.ModuleParallelDeployHelper.DEFAULT_DEPLOYMENT_THREADS;
+
 /**
  * Created by Tamirh on 04/08/2016.
  */
@@ -43,7 +45,7 @@ public abstract class Deployer implements DeployerOverrider, Serializable {
     private ArrayListMultimap<String, String> properties = ArrayListMultimap.create();
     private Filter artifactDeploymentPatterns = new Filter();
     private String customBuildName = "";
-    private int threads = 8;
+    private int threads = DEFAULT_DEPLOYMENT_THREADS;
     private transient CpsScript cpsScript;
 
     protected transient ArtifactoryServer server;


### PR DESCRIPTION
Following [BI-522](https://www.jfrog.com/jira/browse/BI-522), set the pipeline default to match the one configured in the extractors.