### PR TITLE
Make layout compatible with upcoming jenkins core

### DIFF
--- a/src/main/resources/lib/jfrog/blockWrapper.jelly
+++ b/src/main/resources/lib/jfrog/blockWrapper.jelly
@@ -1,0 +1,25 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <st:documentation>
+    This adds a wrapper allowing adding an ID to a field or group of fields that can be targeted by JavaScript
+    The wrapper will be a `table` tag on Jenkins Core less than 2.236, and a `div` tag after that
+
+    <st:attribute name="id">
+      ID to add to the wrapper
+    </st:attribute>
+  </st:documentation>
+  
+  <j:choose>
+    <j:when test="${divBasedFormLayout}">
+      <div id="${attrs.id}">
+        <d:invokeBody/>
+      </div>
+    </j:when>
+    <j:otherwise>
+      <table id="${attrs.id}">
+        <d:invokeBody/>
+      </table>
+    </j:otherwise>
+  </j:choose>
+
+</j:jelly>

--- a/src/main/resources/org/jfrog/hudson/ArtifactoryBuilder/global.jelly
+++ b/src/main/resources/org/jfrog/hudson/ArtifactoryBuilder/global.jelly
@@ -2,7 +2,7 @@
          xmlns:f="/lib/form"
          xmlns:st="jelly:stapler"
          xmlns:r="/lib/jfrog"
-         xmlns:c="/lib/credentials" xmlns:l="/lib/layout">
+         xmlns:c="/lib/credentials">
     <st:adjunct includes="lib.jfrog.repos.credentials"/>
     <f:section title="Artifactory">
 

--- a/src/main/resources/org/jfrog/hudson/ArtifactoryBuilder/global.jelly
+++ b/src/main/resources/org/jfrog/hudson/ArtifactoryBuilder/global.jelly
@@ -2,20 +2,21 @@
          xmlns:f="/lib/form"
          xmlns:st="jelly:stapler"
          xmlns:r="/lib/jfrog"
-         xmlns:c="/lib/credentials">
+         xmlns:c="/lib/credentials" xmlns:l="/lib/layout">
     <st:adjunct includes="lib.jfrog.repos.credentials"/>
     <f:section title="Artifactory">
 
         <f:entry
             help="/plugin/artifactory/help/ArtifactoryBuilder/help-useCredentialsPlugin.html">
-                <input id="useCredentialsPlugin" type="checkbox" onclick="updateViewForCredentialsMethod(this.checked)"
-                   name="useCredentialsPlugin" value="${descriptor.useCredentialsPlugin}"
-                        field="useCredentialsPlugin">Use the Credentials Plugin
-                </input>
+                <f:checkbox id="useCredentialsPlugin"
+                            onclick="updateViewForCredentialsMethod(this.checked)"
+                            name="useCredentialsPlugin"
+                            value="${descriptor.useCredentialsPlugin}"
+                            field="useCredentialsPlugin"
+                            title="${%Use the Credentials Plugin}"/>
         </f:entry>
         <f:entry title="Artifactory servers"
                  description="List of Artifactory servers that projects will want to deploy artifacts and build info to">
-
 
             <f:repeatable name="artifactoryServer" var="server" items="${descriptor.artifactoryServers}"
                           header="Artifactory" add="${%Add Artifactory Server}">
@@ -31,50 +32,43 @@
                     </f:entry>
 
                     <f:advanced>
-                        <f:entry>
-                            <table style="width:100%">
-                                <f:entry title="Connection Timeout" field="artifactory.timeout"
-                                         help="/plugin/artifactory/help/ArtifactoryBuilder/help-timeout.html">
-                                    <f:textbox clazz="number" value="${server.timeout}"/>
-                                </f:entry>
-                                <f:entry field="connectionRetry" title="Number of retries"
-                                         help="/plugin/artifactory/help/ArtifactoryBuilder/help-connectionRetry.html">
-                                    <select class="setting-input" name="connectionRetry">
-                                        <j:forEach var="r" items="${server.connectionRetries}">
-                                            <f:option selected="${r==server.connectionRetry}"
-                                                      value="${r}">${r}
-                                            </f:option>
-                                        </j:forEach>
-                                    </select>
-                                </f:entry>
-                                <f:entry field="deploymentThreads" title="Number of threads for Generic uploads"
-                                         help="/plugin/artifactory/help/ArtifactoryBuilder/help-deploymentThreads.html">
-                                    <select class="setting-input" name="deploymentThreads">
-                                        <j:forEach var="r" items="${server.deploymentsThreads}">
-                                            <f:option selected="${r==server.deploymentThreads}"
-                                                      value="${r}">${r}
-                                            </f:option>
-                                        </j:forEach>
-                                    </select>
-                                </f:entry>
-                                <f:optionalBlock name="artifactory.bypassProxy" title="Bypass HTTP Proxy" checked="${server.bypassProxy}" inline="true"
-                                                 help="/plugin/artifactory/help/ArtifactoryBuilder/help-bypassproxy.html">
-                                </f:optionalBlock>
-                            </table>
+                        <f:entry title="Connection Timeout" field="artifactory.timeout"
+                                 help="/plugin/artifactory/help/ArtifactoryBuilder/help-timeout.html">
+                            <f:textbox clazz="number" value="${server.timeout}"/>
                         </f:entry>
+                        <f:entry field="connectionRetry" title="Number of retries"
+                                 help="/plugin/artifactory/help/ArtifactoryBuilder/help-connectionRetry.html">
+                            <select class="setting-input" name="connectionRetry">
+                                <j:forEach var="r" items="${server.connectionRetries}">
+                                    <f:option selected="${r==server.connectionRetry}"
+                                              value="${r}">${r}
+                                    </f:option>
+                                </j:forEach>
+                            </select>
+                        </f:entry>
+                        <f:entry field="deploymentThreads" title="Number of threads for Generic uploads"
+                                 help="/plugin/artifactory/help/ArtifactoryBuilder/help-deploymentThreads.html">
+                            <select class="setting-input" name="deploymentThreads">
+                                <j:forEach var="r" items="${server.deploymentsThreads}">
+                                    <f:option selected="${r==server.deploymentThreads}"
+                                              value="${r}">${r}
+                                    </f:option>
+                                </j:forEach>
+                            </select>
+                        </f:entry>
+                        <f:optionalBlock name="artifactory.bypassProxy" title="Bypass HTTP Proxy" checked="${server.bypassProxy}" inline="true"
+                                         help="/plugin/artifactory/help/ArtifactoryBuilder/help-bypassproxy.html">
+                        </f:optionalBlock>
                     </f:advanced>
 
                     <f:section title="Default Deployer Credentials" field="deployerCredentialsConfig"
                                name="deployerCredentialsConfig">
                         <f:block>
                             <input type="hidden" name="stapler-class" value="org.jfrog.hudson.CredentialsConfig"/>
-                            <table style="width: 100%" id="deployerCredentialsId${server.url}">
                                 <f:entry title="${%Credentials}" name="credentialsId" field="credentialsId">
                                     <c:select default="${server.deployerCredentialsConfig.credentialsId}"/>
                                 </f:entry>
-                            </table>
 
-                            <table style="width: 100%" id="legacyDeployerCredentials${server.url}">
                                 <f:entry title="Username"
                                          help="/plugin/artifactory/help/common/help-deployerUserName.html">
                                     <f:textbox name="username" field="username"
@@ -85,7 +79,6 @@
                                     <f:password name="password" field="password"
                                                 value="${server.deployerCredentialsConfig.password}"/>
                                 </f:entry>
-                            </table>
                         </f:block>
                     </f:section>
                     <f:validateButton
@@ -102,13 +95,10 @@
                                 <input type="hidden" name="overridingCredentials" value="true"/>
                                 <input type="hidden" name="stapler-class"
                                        value="org.jfrog.hudson.CredentialsConfig"/>
-                                <table style="width: 100%" id="resolverCredentialsId${server.url}">
                                     <f:entry title="${%Credentials}" field="credentialsId">
                                         <c:select default="${server.resolverCredentialsConfig.credentialsId}"/>
                                     </f:entry>
-                                </table>
 
-                                <table style="width: 100%" id="legacyResolverCredentials${server.url}">
                                     <f:entry title="Username"
                                              help="/plugin/artifactory/help/ArtifactoryBuilder/help-resolverUserName.html">
                                         <f:textbox field="username"
@@ -119,16 +109,15 @@
                                         <f:password field="password"
                                                     value="${server.resolverCredentialsConfig.password}"/>
                                     </f:entry>
-                                </table>
                             </f:nested>
                         </f:block>
                     </f:optionalBlock>
 
-                     <f:entry title="">
+                    <f:block>
                         <div align="right">
-                            <f:repeatableDeleteButton/>
+                            <f:repeatableDeleteButton />
                         </div>
-                    </f:entry>
+                    </f:block>
 
                 </table>
             </f:repeatable>

--- a/src/main/resources/org/jfrog/hudson/ArtifactoryBuilder/global.jelly
+++ b/src/main/resources/org/jfrog/hudson/ArtifactoryBuilder/global.jelly
@@ -65,10 +65,13 @@
                                name="deployerCredentialsConfig">
                         <f:block>
                             <input type="hidden" name="stapler-class" value="org.jfrog.hudson.CredentialsConfig"/>
+                            <div id="deployerCredentialsId${server.url}">
                                 <f:entry title="${%Credentials}" name="credentialsId" field="credentialsId">
                                     <c:select default="${server.deployerCredentialsConfig.credentialsId}"/>
                                 </f:entry>
+                            </div>
 
+                            <div id="legacyDeployerCredentials${server.url}">
                                 <f:entry title="Username"
                                          help="/plugin/artifactory/help/common/help-deployerUserName.html">
                                     <f:textbox name="username" field="username"
@@ -79,6 +82,7 @@
                                     <f:password name="password" field="password"
                                                 value="${server.deployerCredentialsConfig.password}"/>
                                 </f:entry>
+                            </div>
                         </f:block>
                     </f:section>
                     <f:validateButton

--- a/src/main/resources/org/jfrog/hudson/ArtifactoryBuilder/global.jelly
+++ b/src/main/resources/org/jfrog/hudson/ArtifactoryBuilder/global.jelly
@@ -65,13 +65,13 @@
                                name="deployerCredentialsConfig">
                         <f:block>
                             <input type="hidden" name="stapler-class" value="org.jfrog.hudson.CredentialsConfig"/>
-                            <div id="deployerCredentialsId${server.url}">
+                            <r:blockWrapper id="deployerCredentialsId${server.url}">
                                 <f:entry title="${%Credentials}" name="credentialsId" field="credentialsId">
                                     <c:select default="${server.deployerCredentialsConfig.credentialsId}"/>
                                 </f:entry>
-                            </div>
+                            </r:blockWrapper>
 
-                            <div id="legacyDeployerCredentials${server.url}">
+                            <r:blockWrapper id="legacyDeployerCredentials${server.url}">
                                 <f:entry title="Username"
                                          help="/plugin/artifactory/help/common/help-deployerUserName.html">
                                     <f:textbox name="username" field="username"
@@ -82,7 +82,7 @@
                                     <f:password name="password" field="password"
                                                 value="${server.deployerCredentialsConfig.password}"/>
                                 </f:entry>
-                            </div>
+                            </r:blockWrapper>
                         </f:block>
                     </f:section>
                     <f:validateButton
@@ -99,13 +99,13 @@
                                 <input type="hidden" name="overridingCredentials" value="true"/>
                                 <input type="hidden" name="stapler-class"
                                        value="org.jfrog.hudson.CredentialsConfig"/>
-                                <div id="resolverCredentialsId${server.url}">
+                                <r:blockWrapper id="resolverCredentialsId${server.url}">
                                     <f:entry title="${%Credentials}" field="credentialsId">
                                         <c:select default="${server.resolverCredentialsConfig.credentialsId}"/>
                                     </f:entry>
-                                </div>
+                                </r:blockWrapper>
 
-                                <div id="legacyResolverCredentials${server.url}">
+                                <r:blockWrapper id="legacyResolverCredentials${server.url}">
                                      <f:entry title="Username"
                                              help="/plugin/artifactory/help/ArtifactoryBuilder/help-resolverUserName.html">
                                         <f:textbox field="username"
@@ -116,7 +116,7 @@
                                         <f:password field="password"
                                                     value="${server.resolverCredentialsConfig.password}"/>
                                     </f:entry>
-                                </div>
+                                </r:blockWrapper>
                             </f:nested>
                         </f:block>
                     </f:optionalBlock>


### PR DESCRIPTION
As part of the UI refresh of Jenkins we are modernising it's layout so
it can be better styled, this plugin is identified as the only major
plugin that will break, these changes make it work on both old and new
core versions

Ref: https://github.com/jenkinsci/jenkins/pull/3895

Screenshots:
<details>

<summary>2.159</summary>

![artifactory-2 159](https://user-images.githubusercontent.com/21194782/77147285-d0d3f300-6a84-11ea-8671-09fdc814d2db.png)


</details>

<details>

<summary>2.227-SNAPSHOT</summary>

<img width="1126" alt="artifactory-2 227-SNAPSHOT" src="https://user-images.githubusercontent.com/21194782/77147323-df220f00-6a84-11ea-9580-f53d7a4b0e32.png">


</details>

@jsoref
@eyalbe4