### PR TITLE
fix icon issue in build info result

### DIFF
--- a/src/main/resources/org/jfrog/hudson/BuildInfoResultAction/index.jelly
+++ b/src/main/resources/org/jfrog/hudson/BuildInfoResultAction/index.jelly
@@ -11,7 +11,7 @@
                     <tr>
                         <td>
                             <a href="${publishedBuildDetails.buildInfoUrl}" target="_blank">
-                                <img src="/jenkins/${it.iconFileName}" style="width: 48px; height: 48px; margin-right:1em;" alt="[Artifactory]"/>
+                                <img src="${it.iconFileName}" style="width: 48px; height: 48px; margin-right:1em;" alt="[Artifactory]"/>
                             </a>
                         </td>
                         <td style="vertical-align:middle">


### PR DESCRIPTION
- [V] I signed [JFrog's CLA](https://secure.echosign.com/public/hostedForm?formid=5IYKLZ2RXB543N).
- [ v] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [ v] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----
Fixed an icon issue on Artifactory Build Infos section

![image](https://user-images.githubusercontent.com/45933236/80975246-82a76300-8e2a-11ea-8d31-0b8a368a3453.png)
