### PR TITLE
Use HTTPS to resovle dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <packaging>hpi</packaging>
     <name>Jenkins Artifactory Plugin</name>
     <description>Integrates Artifactory to Jenkins</description>
-    <url>http://wiki.jenkins-ci.org/display/JENKINS/Artifactory+Plugin</url>
+    <url>https://wiki.jenkins-ci.org/display/JENKINS/Artifactory+Plugin</url>
 
     <properties>
         <!-- Minimal version required by Pipeline dependencies in 2.14.0 -->
@@ -61,18 +61,18 @@
 
     <organization>
         <name>JFrog</name>
-        <url>http://www.jfrog.org</url>
+        <url>https://jfrog.com</url>
     </organization>
 
     <issueManagement>
         <system>jira</system>
-        <url>http://issues.jfrog.org/jira/browse/HAP</url>
+        <url>https://www.jfrog.com/jira/browse/HAP</url>
     </issueManagement>
 
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
@@ -620,13 +620,13 @@
                 <repository>
                     <id>central</id>
                     <name>jfrog-dependencies</name>
-                    <url>http://oss.jfrog.org/artifactory/jfrog-dependencies</url>
+                    <url>https://oss.jfrog.org/artifactory/jfrog-dependencies</url>
                 </repository>
                 <repository>
                     <snapshots />
                     <id>snapshots</id>
                     <name>libs-snapshot</name>
-                    <url>http://oss.jfrog.org/artifactory/libs-snapshot</url>
+                    <url>https://oss.jfrog.org/artifactory/libs-snapshot</url>
                 </repository>
             </repositories>
             <pluginRepositories>
@@ -636,22 +636,15 @@
                     </snapshots>
                     <id>central</id>
                     <name>jfrog-dependencies</name>
-                    <url>http://oss.jfrog.org/artifactory/jfrog-dependencies</url>
+                    <url>https://oss.jfrog.org/artifactory/jfrog-dependencies</url>
                 </pluginRepository>
                 <pluginRepository>
                     <snapshots />
                     <id>snapshots</id>
                     <name>plugins-snapshot</name>
-                    <url>http://oss.jfrog.org/artifactory/plugins-snapshot</url>
+                    <url>https://oss.jfrog.org/artifactory/plugins-snapshot</url>
                 </pluginRepository>
             </pluginRepositories>
         </profile>
     </profiles>
-
-    <distributionManagement>
-        <repository>
-            <id>maven.jenkins-ci.org</id>
-            <url>http://maven.jenkins-ci.org:8081/content/repositories/releases/</url>
-        </repository>
-    </distributionManagement>
 </project>


### PR DESCRIPTION
- [x] I signed [JFrog's CLA](https://secure.echosign.com/public/hostedForm?formid=5IYKLZ2RXB543N).
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----

use HTTPS for dependencies.
fix various URLs to avoid redirects.
`distributionManagement` should be coming from parent pom: https://github.com/jenkinsci/plugin-pom/blob/plugin-3.56/pom.xml#L772-L782

fixes https://github.com/jenkinsci/artifactory-plugin/pull/41
