### PR TITLE
bump parent pom to v4, bump jenkins.version to 2.164.3, use plugin bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.56</version>
+        <version>4.2</version>
     </parent>
 
     <artifactId>artifactory</artifactId>
@@ -31,11 +31,9 @@
 
     <properties>
         <!-- Minimal version required by Pipeline dependencies in 2.14.0 -->
-        <jenkins.version>2.159</jenkins.version>
+        <jenkins.version>2.164.3</jenkins.version>
         <java.level>8</java.level>
-        <!-- TODO: enforcer is full of upper bound dependency issues, including real ones -->
-        <enforcer.skip>true</enforcer.skip>
-        <findbugs.failOnError>false</findbugs.failOnError>
+        <spotbugs.failOnError>false</spotbugs.failOnError>
         <!--Skip integration tests unless explicitly requested with -DskipITs=false-->
         <skipITs>true</skipITs>
 
@@ -45,6 +43,7 @@
         <buildinfo.ivy.version>2.17.1</buildinfo.ivy.version>
         <buildinfo.npm.version>2.17.1</buildinfo.npm.version>
         <buildinfo.go.version>2.17.1</buildinfo.go.version>
+        <jackson.version>2.10.1</jackson.version>
 
     </properties>
 
@@ -81,53 +80,30 @@
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>maven-plugin</artifactId>
-            <version>3.4</version>
+            <version>3.6</version>
             <exclusions>
                 <exclusion>
-                    <artifactId>httpcore</artifactId>
-                    <groupId>org.apache.httpcomponents</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>httpclient</artifactId>
-                    <groupId>org.apache.httpcomponents</groupId>
-                </exclusion>
-                <!-- An updated version of commons-lang3 is received from the buildinfo dependency -->
-                <exclusion>
-                    <artifactId>commons-lang3</artifactId>
-                    <groupId>org.apache.commons</groupId>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs-annotations</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
-            <version>1.28</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-credentials</artifactId>
-            <version>1.15</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
-            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>apache-httpcomponents-client-4-api</artifactId>
-            <version>4.5.5-3.0</version>
-            <exclusions>
-                <!-- An updated version of httpcomponents is received from the buildinfo dependency -->
-                <exclusion>
-                    <artifactId>httpcore</artifactId>
-                    <groupId>org.apache.httpcomponents</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>httpclient</artifactId>
-                    <groupId>org.apache.httpcomponents</groupId>
-                </exclusion>
-            </exclusions>
+            <version>4.5.10-2.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -144,19 +120,11 @@
             <!-- The git plugin is set as optional due to HAP-771 -->
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>2.5.0</version>
             <optional>true</optional>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-jdk14</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.32</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -166,7 +134,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>mailer</artifactId>
-            <version>1.24</version>
         </dependency>
         <dependency>
             <groupId>org.jvnet.hudson.plugins</groupId>
@@ -175,8 +142,9 @@
             <optional>true</optional>
             <exclusions>
                 <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-simple</artifactId>
+                    <!-- commons-codec is v1.12 coming from Jenkins Core, this uses v1.13 -->
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -194,7 +162,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
-            <version>1.14</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -215,12 +182,10 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.2.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>plain-credentials</artifactId>
-            <version>1.3</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -238,6 +203,11 @@
                     <groupId>com.thoughtworks.xstream</groupId>
                     <artifactId>xstream</artifactId>
                 </exclusion>
+                <!-- Avoid bundling, use jackson-api plugin -->
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -248,6 +218,20 @@
                 <exclusion>
                     <groupId>com.thoughtworks.xstream</groupId>
                     <artifactId>xstream</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- commons-codec is v1.12 coming from Jenkins Core, this uses v1.13 -->
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore</artifactId>
+                </exclusion>
+                <!-- Avoid bundling, use jackson-api plugin -->
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -273,18 +257,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <!--
-                ZStream is declared final in 1.0.7, which is what build-info-vcs pulls in.
-                This causes a conflict with jzlib-1.1.2 that newer Jenkins uses.
-                If we didn't put too many classes into plexus.core, this would have been a non-issue.
-                See JENKINS-18401
-             -->
-            <groupId>com.jcraft</groupId>
-            <artifactId>jzlib</artifactId>
-            <version>1.1.3</version>
-        </dependency>
-
         <dependency>
             <groupId>org.jfrog.buildinfo</groupId>
             <artifactId>build-info-extractor-ivy</artifactId>
@@ -317,6 +289,11 @@
                 <exclusion>
                     <groupId>org.codehaus.plexus</groupId>
                     <artifactId>*</artifactId>
+                </exclusion>
+                <!-- Higher version loaded from maven-plugin -->
+                <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-model</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -366,53 +343,6 @@
             <version>${buildinfo.go.version}</version>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.4</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>1.4</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.5</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
-            <version>1.19</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-            <version>${slf4jVersion}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4jVersion}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>18.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jdom</groupId>
-            <artifactId>jdom</artifactId>
-            <version>1.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ivy</groupId>
-            <artifactId>ivy</artifactId>
-            <version>2.4.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jira</artifactId>
             <version>3.0.6</version>
@@ -421,7 +351,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jenkins-multijob-plugin</artifactId>
-            <version>1.13</version>
+            <version>1.14</version>
             <exclusions>
                 <exclusion>
                     <artifactId>maven-plugin</artifactId>
@@ -433,43 +363,47 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.19</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.13</version>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-classworlds</artifactId>
-            <version>2.5.2</version>
-            <scope>compile</scope>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>docker-java-api</artifactId>
+            <version>3.1.5.2</version>
         </dependency>
         <dependency>
-            <groupId>com.github.docker-java</groupId>
-            <artifactId>docker-java</artifactId>
-            <version>3.1.2</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>jcl-over-slf4j</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jackson2-api</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
+        <!--Avoid bundling-->
         <dependency>
+            <!-- Provided by Jenkins Core, sadly not in Jenkins BOM yet
+            Will be available in newer cores: https://github.com/jenkinsci/jenkins/pull/4702 -->
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <version>2.4.12</version>
             <scope>provided</scope>
         </dependency>
-        <!--Tests-->
         <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-test-harness</artifactId>
-            <version>2.44</version>
-            <scope>test</scope>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <!--/Avoid bundling-->
+        <!--Tests-->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
@@ -487,16 +421,74 @@
             <artifactId>artifactory-java-client-services</artifactId>
             <version>2.6.2</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jdom</groupId>
+            <artifactId>jdom</artifactId>
+            <version>1.1.1</version>
+            <scope>test</scope>
         </dependency>
         <!--/Tests-->
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.164.x</artifactId>
+                <version>10</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>joda-time</groupId>
+                <artifactId>joda-time</artifactId>
+                <version>2.9.9</version>
+            </dependency>
+            <dependency>
+                <groupId>com.jcraft</groupId>
+                <artifactId>jsch</artifactId>
+                <version>0.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>1.19</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.9</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-artifact</artifactId>
+                <version>3.5.4</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-classworlds</artifactId>
+                <version>2.6.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
                 <configuration>
                     <additionalparam>-Xdoclint:none</additionalparam>
                 </configuration>
@@ -511,7 +503,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.1</version>
                 <configuration>
                     <systemPropertyVariables>
                         <!--This will disable JenkinsRule timeout-->
@@ -527,7 +518,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.1</version>
                 <configuration>
                     <systemPropertyVariables>
                         <!--This will disable JenkinsRule timeout-->
@@ -553,29 +543,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration combine.children="append">
-                            <rules>
-                                <bannedDependencies>
-                                    <excludes>
-                                        <!-- HAP-211 -->
-                                        <exclude>com.thoughtworks.xstream:xstream</exclude>
-                                        <exclude>org.slf4j:slf4j-jdk14:*:jar:compile</exclude>
-                                    </excludes>
-                                </bannedDependencies>
-                            </rules>
-                            <fail>true</fail>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.zeroturnaround</groupId>
                 <artifactId>jrebel-maven-plugin</artifactId>
                 <version>1.1.1</version>
@@ -593,15 +560,6 @@
                 </executions>
             </plugin>
         </plugins>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>animal-sniffer-maven-plugin</artifactId>
-                    <version>1.18</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
     </build>
 
     <scm>


### PR DESCRIPTION
fix upper bound dependencies by using both jenkins-bom and plugins-bom we can clean the pom

this solves upper bound dependency conflicts, some are solved by using dependencyManagement such as commons-lang3 it would need a lot of exclusions 🤯

This gets us to a better state, where bundling is our only concern.

```
[WARNING] Bundling transitive dependency backport-util-concurrent-3.1.jar (via build-info-extractor-maven3)
[WARNING] Bundling transitive dependency maven-deploy-plugin-2.8.2.jar (via build-info-extractor-maven3)
[WARNING] Bundling transitive dependency maven-artifact-manager-2.2.1.jar (via build-info-extractor-maven3)
[WARNING] Bundling transitive dependency maven-plugin-registry-2.2.1.jar (via build-info-extractor-maven3)
[WARNING] Bundling transitive dependency maven-profile-2.2.1.jar (via build-info-extractor-maven3)
[WARNING] Bundling transitive dependency maven-project-2.2.1.jar (via build-info-extractor-maven3)
[WARNING] Bundling transitive dependency aether-api-1.1.0.jar (via aether-impl)
[INFO] Bundling direct dependency aether-impl-1.1.0.jar
[WARNING] Bundling transitive dependency aether-spi-1.1.0.jar (via aether-impl)
[WARNING] Bundling transitive dependency aether-util-1.1.0.jar (via aether-impl)
[INFO] Bundling direct dependency build-info-api-2.17.1.jar
[INFO] Bundling direct dependency build-info-client-2.17.1.jar
[INFO] Bundling direct dependency build-info-extractor-go-2.17.1.jar
[INFO] Bundling direct dependency build-info-extractor-gradle-4.15.1.jar
[INFO] Bundling direct dependency build-info-extractor-ivy-2.17.1.jar
[INFO] Bundling direct dependency build-info-extractor-maven3-2.17.1.jar
[INFO] Bundling direct dependency build-info-extractor-npm-2.17.1.jar
[INFO] Bundling direct dependency build-info-extractor-2.17.1.jar
[INFO] Bundling direct dependency build-info-vcs-2.17.1.jar
[WARNING] Bundling transitive dependency aether-api-1.13.1.jar (via build-info-extractor-maven3)
[WARNING] Bundling transitive dependency aether-impl-1.13.1.jar (via build-info-extractor-maven3)
[WARNING] Bundling transitive dependency aether-spi-1.13.1.jar (via build-info-extractor-maven3)
[WARNING] Bundling transitive dependency aether-util-1.13.1.jar (via build-info-extractor-maven3)
[WARNING] Bundling transitive dependency plexus-container-default-1.0-alpha-6.jar (via build-info-extractor-maven3)
[WARNING] Bundling transitive dependency plexus-utils-1.0.2.jar (via build-info-extractor-maven3)
```

- [x] I signed [JFrog's CLA](https://secure.echosign.com/public/hostedForm?formid=5IYKLZ2RXB543N).
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----
