### PR TITLE
Add Declarative pipeline support for Conan - Make AddUserStep blocking 

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/conan/AddUserStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/conan/AddUserStep.java
@@ -2,13 +2,15 @@ package org.jfrog.hudson.pipeline.scripted.steps.conan;
 
 import com.google.inject.Inject;
 import hudson.Extension;
-import org.jenkinsci.plugins.workflow.steps.*;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jfrog.hudson.CredentialsConfig;
+import org.jfrog.hudson.pipeline.ArtifactorySynchronousStepExecution;
 import org.jfrog.hudson.pipeline.common.ArtifactoryConfigurator;
 import org.jfrog.hudson.pipeline.common.Utils;
 import org.jfrog.hudson.pipeline.common.executors.ConanExecutor;
 import org.jfrog.hudson.pipeline.common.types.ArtifactoryServer;
-import org.jfrog.hudson.pipeline.ArtifactorySynchronousNonBlockingStepExecution;
 import org.jfrog.hudson.util.CredentialManager;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -38,7 +40,7 @@ public class AddUserStep extends AbstractStepImpl {
         return conanHome;
     }
 
-    public static class Execution extends ArtifactorySynchronousNonBlockingStepExecution<Boolean> {
+    public static class Execution extends ArtifactorySynchronousStepExecution<Boolean> {
 
         private transient AddUserStep step;
 

--- a/src/test/resources/integration/pipelines/scripted/conan.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/conan.pipeline
@@ -1,9 +1,5 @@
 package integration.pipelines.scripted
 
-import org.apache.commons.io.FileUtils
-
-import java.nio.file.Paths
-
 node("TestSlave") {
     stage "Configure Artifactory"
     def rtServer = Artifactory.newServer url: "${env.JENKINS_ARTIFACTORY_URL}", username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
@@ -15,13 +11,13 @@ node("TestSlave") {
     def conanClient = Artifactory.newConanClient()
 
     stage "Add Conan Remote"
-    String serverName = conanClient.remote.add server: rtServer, repo: "${CONAN_LOCAL}"
+    String remoteName = conanClient.remote.add server: rtServer, repo: "${CONAN_LOCAL}"
 
     stage "Conan Install"
     conanClient.run(command: "install zlib/1.2.11@conan/stable --build missing", buildInfo: buildInfo)
 
     stage "Conan Upload"
-    conanClient.run(command: "upload zlib/1.2.11@conan/stable --all -r ${serverName} --confirm", buildInfo: buildInfo)
+    conanClient.run(command: "upload zlib/1.2.11@conan/stable --all -r " + remoteName + " --confirm", buildInfo: buildInfo)
 
     stage "Publish build info"
     rtServer.publishBuildInfo buildInfo

--- a/src/test/resources/integration/pipelines/scripted/conan.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/conan.pipeline
@@ -15,13 +15,13 @@ node("TestSlave") {
     def conanClient = Artifactory.newConanClient()
 
     stage "Add Conan Remote"
-    conanClient.remote.add server: rtServer, repo: "${CONAN_LOCAL}", remoteName: "conanTestRemote"
+    String serverName = conanClient.remote.add server: rtServer, repo: "${CONAN_LOCAL}"
 
     stage "Conan Install"
     conanClient.run(command: "install zlib/1.2.11@conan/stable --build missing", buildInfo: buildInfo)
 
     stage "Conan Upload"
-    conanClient.run(command: "upload zlib/1.2.11@conan/stable --all -r conanTestRemote --confirm", buildInfo: buildInfo)
+    conanClient.run(command: "upload zlib/1.2.11@conan/stable --all -r ${serverName} --confirm", buildInfo: buildInfo)
 
     stage "Publish build info"
     rtServer.publishBuildInfo buildInfo


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----

Make `conanClient.remote.add` step blocking to allow it to return String.