### PR TITLE
Conan Utils - Build the ConanHome path according to the node.

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
@@ -474,7 +474,7 @@ public class Utils {
     public static FilePath getConanHomeDirectory(String userPath, EnvVars env, Launcher launcher, FilePath ws) throws Exception {
         FilePath conanHomeDirectory;
         if (StringUtils.isEmpty(userPath)) {
-            conanHomeDirectory = env.containsKey(Utils.CONAN_USER_HOME) ? new FilePath(new File(env.get(Utils.CONAN_USER_HOME))) : createConanTempHome(ws);
+            conanHomeDirectory = env.containsKey(Utils.CONAN_USER_HOME) ? new FilePath(launcher.getChannel(), env.get(Utils.CONAN_USER_HOME)) : createConanTempHome(ws);
         } else {
             conanHomeDirectory = new FilePath(launcher.getChannel(), userPath);
         }


### PR DESCRIPTION
fix #281 