### PR TITLE
Append timestamp to the build-info cache

### DIFF
--- a/src/main/java/org/jfrog/hudson/action/ActionableHelper.java
+++ b/src/main/java/org/jfrog/hudson/action/ActionableHelper.java
@@ -30,6 +30,7 @@ import hudson.tasks.Publisher;
 import hudson.util.DescribableList;
 import jenkins.MasterToSlaveFileCallable;
 import jenkins.model.Jenkins;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jfrog.build.client.ArtifactoryHttpClient;
 import org.jfrog.hudson.DeployerOverrider;
@@ -305,8 +306,8 @@ public abstract class ActionableHelper implements Serializable {
      */
     public static void deleteFilePathOnExit(FilePath filePath) throws IOException, InterruptedException {
         filePath.act(new MasterToSlaveFileCallable<Void>() {
-            public Void invoke(File file, VirtualChannel virtualChannel) throws IOException, InterruptedException {
-                file.deleteOnExit();
+            public Void invoke(File file, VirtualChannel virtualChannel) throws IOException {
+                FileUtils.forceDeleteOnExit(file);
                 return null;
             }
         });


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----

* When the plugin version is snapshot, append timestamp to the build info cache. 
Before:
`workspace/<JOB_NAME>@tmp/artifactory/cache/artifactory-plugin/a.b.x-SNAPSHOT`
After:
`workspace/<JOB_NAME>@tmp/artifactory/cache/artifactory-plugin/a.b.x-SNAPSHOT-<TIMESTAMP>`
* DeleteOnExit - Use `FileUtils.forceDeleteOnExit` to ensure that it will work on directories.