### PR TITLE
Tests - inject jfPipelines param only in jfPipelines tests

### DIFF
--- a/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
@@ -54,7 +54,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
 
         Files.list(FILES_PATH).filter(Files::isRegularFile)
                 .forEach(file -> uploadFile(artifactoryClient, file, getRepoKey(TestRepository.LOCAL_REPO1)));
-        WorkflowRun build = runPipeline("downloadByPattern");
+        WorkflowRun build = runPipeline("downloadByPattern", false);
         try {
             for (String fileName : expectedDependencies) {
                 assertTrue(isExistInWorkspace(slave, build, "downloadByPattern-test", fileName));
@@ -73,7 +73,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
 
         Files.list(FILES_PATH).filter(Files::isRegularFile)
                 .forEach(file -> uploadFile(artifactoryClient, file, getRepoKey(TestRepository.LOCAL_REPO1)));
-        WorkflowRun build = runPipeline("downloadByAql");
+        WorkflowRun build = runPipeline("downloadByAql", false);
         try {
             for (String fileName : expectedDependencies) {
                 assertTrue(isExistInWorkspace(slave, build, "downloadByAql-test", fileName));
@@ -93,7 +93,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
         Set<String> unexpected = getTestFilesNamesByLayer(0);
         unexpected.addAll(getTestFilesNamesByLayer(1));
         unexpected.removeAll(expectedDependencies);
-        WorkflowRun build = runPipeline("downloadByPatternAndBuild");
+        WorkflowRun build = runPipeline("downloadByPatternAndBuild", false);
         try {
             assertTrue(isExistInWorkspace(slave, build, "downloadByPatternAndBuild-test", "a.in"));
             for (String fileName : unexpected) {
@@ -112,7 +112,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
         Set<String> unexpected = getTestFilesNamesByLayer(1);
         String buildNumber = "5";
 
-        WorkflowRun build = runPipeline("downloadByBuildOnly");
+        WorkflowRun build = runPipeline("downloadByBuildOnly", false);
         try {
             for (String fileName : expectedDependencies) {
                 assertTrue(isExistInWorkspace(slave, build, "downloadByBuildOnly-test", fileName));
@@ -130,7 +130,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
 
     void downloadNonExistingBuildTest(String buildName) throws Exception {
         try {
-            runPipeline("downloadNonExistingBuild");
+            runPipeline("downloadNonExistingBuild", false);
             fail("Job expected to fail");
         } catch (AssertionError t) {
             assertTrue(t.getMessage().contains("Fail-no-op: No files were affected in the download process."));
@@ -148,7 +148,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
         Set<String> unexpected = Sets.newHashSet("a4", "a5");
         String buildNumber = "6";
 
-        WorkflowRun build = runPipeline("downloadByShaAndBuild");
+        WorkflowRun build = runPipeline("downloadByShaAndBuild", false);
         try {
             // Only a.in should be in workspace
             assertTrue(isExistInWorkspace(slave, build, "downloadByShaAndBuild-test", "a3"));
@@ -173,7 +173,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
         Set<String> unexpected = Sets.newHashSet("a3", "a5");
         String buildNumber = "6";
 
-        WorkflowRun build = runPipeline("downloadByShaAndBuildName");
+        WorkflowRun build = runPipeline("downloadByShaAndBuildName", false);
         try {
             // Only a.in should be in workspace
             assertTrue(isExistInWorkspace(slave, build, "downloadByShaAndBuildName-test", "a4"));
@@ -193,7 +193,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
         Set<String> expectedArtifacts = getTestFilesNamesByLayer(0);
         String buildNumber = "3";
 
-        runPipeline("upload");
+        runPipeline("upload", false);
         try {
             expectedArtifacts.forEach(artifactName ->
                     assertTrue(artifactName + " doesn't exist in Artifactory", isExistInArtifactory(artifactoryClient, getRepoKey(TestRepository.LOCAL_REPO1), artifactName)));
@@ -209,7 +209,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
         Set<String> expectedArtifactsAndDependencies = getTestFilesNamesByLayer(0);
         String buildNumber = "3";
 
-        WorkflowRun build = runPipeline("uploadDownloadCustomModuleName");
+        WorkflowRun build = runPipeline("uploadDownloadCustomModuleName", false);
         try {
             expectedArtifactsAndDependencies.forEach(artifactName ->
                     assertTrue(artifactName + " doesn't exist in Artifactory", isExistInArtifactory(artifactoryClient, getRepoKey(TestRepository.LOCAL_REPO1), artifactName)));
@@ -231,7 +231,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
 
         Files.list(FILES_PATH).filter(Files::isRegularFile)
                 .forEach(file -> uploadFile(artifactoryClient, file, getRepoKey(TestRepository.LOCAL_REPO1)));
-        WorkflowRun build = runPipeline("promote");
+        WorkflowRun build = runPipeline("promote", false);
         try {
             for (String fileName : expectedDependencies) {
                 assertTrue(isExistInWorkspace(slave, build, "promotion-test", fileName));
@@ -252,7 +252,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
         Set<String> expectedArtifacts = Sets.newHashSet("multi-3.7-SNAPSHOT.pom");
         String buildNumber = "3";
         try {
-            runPipeline("maven");
+            runPipeline("maven", false);
             Build buildInfo = getBuildInfo(buildInfoClient, buildName, buildNumber);
             assertFilteredProperties(buildInfo);
             assertEquals(4, buildInfo.getModules().size());
@@ -271,7 +271,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
     void gradleTest(String buildName) throws Exception {
         String buildNumber = "3";
         try {
-            runPipeline("gradle");
+            runPipeline("gradle", false);
             Build buildInfo = getBuildInfo(buildInfoClient, buildName, buildNumber);
             assertFilteredProperties(buildInfo);
             assertEquals(4, buildInfo.getModules().size());
@@ -289,7 +289,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
         Set<String> expectedArtifacts = Sets.newHashSet(pipelineType.toString() + "-gradle-example-ci-server-1.0.jar", "ivy-1.0.xml", pipelineType.toString() + "-gradle-example-ci-server-1.0.pom");
         String buildNumber = "3";
         try {
-            runPipeline("gradleCiServer");
+            runPipeline("gradleCiServer", false);
             Build buildInfo = getBuildInfo(buildInfoClient, buildName, buildNumber);
             assertEquals(5, buildInfo.getModules().size());
 
@@ -311,7 +311,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
         Set<String> expectedDependencies = Sets.newHashSet("big-integer-1.6.40.tgz", "is-number-7.0.0.tgz");
         String buildNumber = "3";
         try {
-            runPipeline(pipelineName);
+            runPipeline(pipelineName, false);
             Build buildInfo = getBuildInfo(buildInfoClient, buildName, buildNumber);
             Module module = getAndAssertModule(buildInfo, moduleName);
             assertModuleDependencies(module, expectedDependencies);
@@ -326,7 +326,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
         Set<String> expectedDependencies = Sets.newHashSet("rsc.io/sampler:v1.3.0", "golang.org/x/text:v0.0.0-20170915032832-14c0d48ead0c", "rsc.io/quote:v1.5.2");
         String buildNumber = "7";
         try {
-            runPipeline(pipelineName);
+            runPipeline(pipelineName, false);
             Build buildInfo = getBuildInfo(buildInfoClient, buildName, buildNumber);
             Module module = getAndAssertModule(buildInfo, moduleName);
             assertModuleDependencies(module, expectedDependencies);
@@ -339,7 +339,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
     void conanTest(String pipelineName, String buildName) throws Exception {
         String buildNumber = "7";
         try {
-            runPipeline(pipelineName);
+            runPipeline(pipelineName, false);
             Build buildInfo = getBuildInfo(buildInfoClient, buildName, buildNumber);
             Module module = getAndAssertModule(buildInfo, "DownloadOnly");
             assertTrue(module.getDependencies().size() > 0);
@@ -353,7 +353,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
     @Test
     public void uploadFailNoOpTest() throws Exception {
         try {
-            runPipeline("uploadFailNoOp");
+            runPipeline("uploadFailNoOp", false);
             fail("Job expected to fail");
         } catch (AssertionError t) {
             assertTrue(t.getMessage().contains("Fail-no-op: No files were affected in the upload process."));
@@ -366,7 +366,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
     @Test
     public void downloadFailNoOpTest() throws Exception {
         try {
-            runPipeline("downloadFailNoOp");
+            runPipeline("downloadFailNoOp", false);
             fail("Job expected to fail");
         } catch (AssertionError t) {
             assertTrue(t.getMessage().contains("Fail-no-op: No files were affected in the download process."));
@@ -377,7 +377,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
         Set<String> expectedDependencies = Sets.newHashSet("a.in");
         String buildNumber = "3";
 
-        WorkflowRun build = runPipeline("setProps");
+        WorkflowRun build = runPipeline("setProps", false);
         try {
             // Only a.in is expected to exist in workspace
             assertTrue("a.in doesn't exist locally", isExistInWorkspace(slave, build, "setProps-test", "a.in"));
@@ -400,7 +400,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
         Set<String> expectedDependencies = Sets.newHashSet("b.in", "c.in");
         String buildNumber = "3";
 
-        WorkflowRun build = runPipeline("deleteProps");
+        WorkflowRun build = runPipeline("deleteProps", false);
         try {
             // Only b.in, c.in are expected to exist in workspace
             assertFalse("a.in exists locally", isExistInWorkspace(slave, build, "deleteProps-test", "a.in"));
@@ -440,7 +440,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
             BuildImageCmd buildImageCmd = dockerClient.buildImageCmd(Paths.get(projectPath).toFile()).withTags(new HashSet<>(Arrays.asList(imageName)));
             buildImageCmd.exec(new BuildImageResultCallback()).awaitImageId();
             // Run pipeline
-            runPipeline("dockerPush");
+            runPipeline("dockerPush", false);
             String buildNumber = "3";
 
             // Get build info
@@ -463,7 +463,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
 
     private void xrayScanTest(String buildName, String pipelineJobName, boolean failBuild) throws Exception {
         try {
-            runPipeline(pipelineJobName);
+            runPipeline(pipelineJobName, false);
             if (failBuild) {
                 fail("Job expected to fail");
             }
@@ -490,7 +490,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
         String buildNumber = "3";
         // Clear older build if exists
         deleteBuild(artifactoryClient, buildName);
-        runPipeline("collectIssues");
+        runPipeline("collectIssues", false);
         try {
             Build buildInfo = getBuildInfo(buildInfoClient, buildName, buildNumber);
             // Assert Issues
@@ -516,7 +516,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
         String buildNumber = "3";
         // Clear older build if exists
         deleteBuild(artifactoryClient, buildName);
-        WorkflowRun build = runPipeline("append");
+        WorkflowRun build = runPipeline("append", false);
         try {
             Build buildInfo = getBuildInfo(buildInfoClient, buildName, buildNumber);
             // Assert Issues
@@ -540,7 +540,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
 
     void jfPipelinesOutputResourcesTest() throws Exception {
         try (ClientAndServer mockServer = ClientAndServer.startClientAndServer(1080)) {
-            runPipeline("jfPipelinesResources");
+            runPipeline("jfPipelinesResources", true);
             HttpRequest[] requests = mockServer.retrieveRecordedRequests(null);
             assertEquals(2, ArrayUtils.getLength(requests));
 
@@ -583,7 +583,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
 
     public void jfPipelinesReportStatusTest() throws Exception {
         try (ClientAndServer mockServer = ClientAndServer.startClientAndServer(1080)) {
-            runPipeline("jfPipelinesReport");
+            runPipeline("jfPipelinesReport", true);
             // Get sent request from the mock server
             HttpRequest[] requests = mockServer.retrieveRecordedRequests(null);
             assertEquals(2, ArrayUtils.getLength(requests));

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/PipelineTestBase.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/PipelineTestBase.java
@@ -225,12 +225,15 @@ public class PipelineTestBase {
     /**
      * Run pipeline script.
      *
-     * @param name - Pipeline name from 'jenkins-artifactory-plugin/src/test/resources/integration/pipelines'.
+     * @param name                     - Pipeline name from 'jenkins-artifactory-plugin/src/test/resources/integration/pipelines'
+     * @param injectPipelinesParameter - True if this is a JFrog pipelines test
      * @return the Jenkins job
      */
-    WorkflowRun runPipeline(String name) throws Exception {
+    WorkflowRun runPipeline(String name, boolean injectPipelinesParameter) throws Exception {
         WorkflowJob project = jenkins.createProject(WorkflowJob.class);
-        Utils.injectJfPipelinesInfoParameter(project, "{\"stepId\":\"5\"}"); // For JFrog Pipelines tests
+        if (injectPipelinesParameter) {
+            Utils.injectJfPipelinesInfoParameter(project, "{\"stepId\":\"5\"}"); // For JFrog Pipelines tests
+        }
         FilePath slaveWs = slave.getWorkspaceFor(project);
         if (slaveWs == null) {
             throw new Exception("Slave workspace not found");


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----

Inject the JFrog Pipelines job parameter only in JFrog pipelines tests. This will prevent failed attempts to communicate with JFrog pipelines server.