### PR TITLE
HAP-1373 - Create build trigger using pipeline

### DIFF
--- a/src/main/java/org/jfrog/hudson/ArtifactoryServer.java
+++ b/src/main/java/org/jfrog/hudson/ArtifactoryServer.java
@@ -57,7 +57,7 @@ public class ArtifactoryServer implements Serializable {
     private static final int DEFAULT_CONNECTION_TIMEOUT = 300;    // 5 Minutes
     private static final int DEFAULT_DEPLOYMENT_THREADS_NUMBER = 3;
     private final String url;
-    private final String id;
+    private String id;
     // Network timeout in seconds to use both for connection establishment and for unanswered requests
     private int timeout = DEFAULT_CONNECTION_TIMEOUT;
     private boolean bypassProxy;
@@ -103,6 +103,10 @@ public class ArtifactoryServer implements Serializable {
 
     public String getServerId() {
         return id;
+    }
+
+    public void setServerId(String id) {
+        this.id = id;
     }
 
     public String getArtifactoryUrl() {

--- a/src/main/java/org/jfrog/hudson/pipeline/common/executors/BuildTriggerExecutor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/executors/BuildTriggerExecutor.java
@@ -1,0 +1,55 @@
+package org.jfrog.hudson.pipeline.common.executors;
+
+import antlr.ANTLRException;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jfrog.build.api.util.Log;
+import org.jfrog.hudson.ArtifactoryServer;
+import org.jfrog.hudson.ServerDetails;
+import org.jfrog.hudson.pipeline.common.Utils;
+import org.jfrog.hudson.trigger.ArtifactoryTrigger;
+import org.jfrog.hudson.trigger.ArtifactoryTriggerInfo;
+import org.jfrog.hudson.util.JenkinsBuildInfoLog;
+
+import java.io.IOException;
+
+/**
+ * @author yahavi
+ */
+public class BuildTriggerExecutor implements Executor {
+
+    private final ArtifactoryServer server;
+    private final Run<?, ?> build;
+    private final String paths;
+    private final String spec;
+    private final Log logger;
+
+    public BuildTriggerExecutor(Run<?, ?> build, TaskListener listener,
+                                org.jfrog.hudson.pipeline.common.types.ArtifactoryServer server, String paths, String spec) {
+        this.server = Utils.prepareArtifactoryServer(null, server);
+        this.server.setServerId(server.getServerName());
+        this.logger = new JenkinsBuildInfoLog(listener);
+        this.build = build;
+        this.paths = paths;
+        this.spec = spec;
+    }
+
+    @Override
+    public void execute() throws IOException {
+        WorkflowJob job = (WorkflowJob) build.getParent();
+        try {
+            logger.debug("Setting trigger for '" + server.getArtifactoryUrl() + "'. Paths: '" + paths + "' spec: '" + spec + "'");
+            ArtifactoryTrigger artifactoryTrigger = new ArtifactoryTrigger(paths, spec);
+            ServerDetails details = new ServerDetails(server.getServerId(), server.getArtifactoryUrl(), null, null, null, null);
+            artifactoryTrigger.setDetails(details);
+            if (details.getArtifactoryName() == null) {
+                // Save the Artifactory Server object in ArtifactoryTriggerInfo to use it during trigger runtime
+                build.getParent().addOrReplaceAction(new ArtifactoryTriggerInfo(server));
+            }
+            job.addTrigger(artifactoryTrigger);
+        } catch (ANTLRException e) {
+            throw new IOException(e);
+        }
+    }
+}

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/BuildTriggerStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/BuildTriggerStep.java
@@ -1,0 +1,74 @@
+package org.jfrog.hudson.pipeline.declarative.steps;
+
+import com.google.inject.Inject;
+import hudson.Extension;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jfrog.hudson.pipeline.ArtifactorySynchronousNonBlockingStepExecution;
+import org.jfrog.hudson.pipeline.common.executors.BuildTriggerExecutor;
+import org.jfrog.hudson.pipeline.common.types.ArtifactoryServer;
+import org.jfrog.hudson.pipeline.declarative.utils.DeclarativePipelineUtils;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.IOException;
+
+/**
+ * @author yahavi
+ */
+@SuppressWarnings("unused")
+public class BuildTriggerStep extends AbstractStepImpl {
+
+    public static final String STEP_NAME = "rtBuildTrigger";
+    private final String serverId;
+    private final String paths;
+    private final String spec;
+
+    @DataBoundConstructor
+    public BuildTriggerStep(String serverId, String paths, String spec) {
+        this.serverId = serverId;
+        this.paths = paths;
+        this.spec = spec;
+    }
+
+    public static class Execution extends ArtifactorySynchronousNonBlockingStepExecution<Void> {
+
+        private transient final BuildTriggerStep step;
+
+        @Inject
+        public Execution(BuildTriggerStep step, StepContext context) throws IOException, InterruptedException {
+            super(context);
+            this.step = step;
+        }
+
+        @Override
+        protected Void run() throws Exception {
+            ArtifactoryServer server = DeclarativePipelineUtils.getArtifactoryServer(build, ws, getContext(), step.serverId);
+            new BuildTriggerExecutor(build, listener, server, step.paths, step.spec).execute();
+            return null;
+        }
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+        public DescriptorImpl() {
+            super(BuildTriggerStep.Execution.class);
+        }
+
+        @Override
+        public String getFunctionName() {
+            return STEP_NAME;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Trigger Artifactory build";
+        }
+
+        @Override
+        public boolean isAdvanced() {
+            return true;
+        }
+    }
+}

--- a/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/BuildTriggerStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/BuildTriggerStep.java
@@ -1,0 +1,71 @@
+package org.jfrog.hudson.pipeline.scripted.steps;
+
+import com.google.inject.Inject;
+import hudson.Extension;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jfrog.hudson.pipeline.ArtifactorySynchronousNonBlockingStepExecution;
+import org.jfrog.hudson.pipeline.common.executors.BuildTriggerExecutor;
+import org.jfrog.hudson.pipeline.common.types.ArtifactoryServer;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.IOException;
+
+/**
+ * @author yahavi
+ */
+@SuppressWarnings("unused")
+public class BuildTriggerStep extends AbstractStepImpl {
+
+    private final ArtifactoryServer server;
+    private final String paths;
+    private final String spec;
+
+    @DataBoundConstructor
+    public BuildTriggerStep(ArtifactoryServer server, String paths, String spec) {
+        this.server = server;
+        this.paths = paths;
+        this.spec = spec;
+    }
+
+    public static class Execution extends ArtifactorySynchronousNonBlockingStepExecution<Void> {
+
+        private transient final BuildTriggerStep step;
+
+        @Inject
+        public Execution(BuildTriggerStep step, StepContext context) throws IOException, InterruptedException {
+            super(context);
+            this.step = step;
+        }
+
+        @Override
+        protected Void run() throws Exception {
+            new BuildTriggerExecutor(build, listener, step.server, step.paths, step.spec).execute();
+            return null;
+        }
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+        public DescriptorImpl() {
+            super(BuildTriggerStep.Execution.class);
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "artifactoryBuildTrigger";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Trigger Artifactory build";
+        }
+
+        @Override
+        public boolean isAdvanced() {
+            return true;
+        }
+    }
+}

--- a/src/main/java/org/jfrog/hudson/trigger/ArtifactoryTriggerInfo.java
+++ b/src/main/java/org/jfrog/hudson/trigger/ArtifactoryTriggerInfo.java
@@ -1,0 +1,22 @@
+package org.jfrog.hudson.trigger;
+
+import hudson.model.InvisibleAction;
+import org.jfrog.hudson.ArtifactoryServer;
+
+/**
+ * Use this job action to save the Artifactory server configured in pipeline jobs.
+ *
+ * @author yahavi
+ */
+public class ArtifactoryTriggerInfo extends InvisibleAction {
+
+    private final ArtifactoryServer server;
+
+    public ArtifactoryTriggerInfo(ArtifactoryServer server) {
+        this.server = server;
+    }
+
+    public ArtifactoryServer getServer() {
+        return server;
+    }
+}

--- a/src/main/resources/org/jfrog/hudson/trigger/ArtifactoryTrigger/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/trigger/ArtifactoryTrigger/config.jelly
@@ -1,26 +1,21 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:r="/lib/jfrog"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-
-         <f:dropdownList name="details" title="${%Artifactory server}">
-                         <j:forEach var="s" items="${descriptor.artifactoryServers}" varStatus="loop">
-                             <f:dropdownListBlock value="${s.serverId}" title="${s.artifactoryUrl}"
-                                                  selected="${s.serverId==instance.artifactoryName}">
-                                 <f:nested>
-                                     <input type="hidden" name="artifactoryName" value="${s.serverId}"/>
-                                     <input type="hidden" name="artifactoryUrl" id="artifactoryUrlDeploy${s.artifactoryUrl}"
-                                            value="${s.artifactoryUrl}"/>
-                                     <input type="hidden" name="stapler-class" value="org.jfrog.hudson.ServerDetails"/>
-
-                                 </f:nested>
-                             </f:dropdownListBlock>
-                         </j:forEach>
-                     </f:dropdownList>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:dropdownList name="details" title="${%Artifactory server}">
+        <j:forEach var="s" items="${instance.artifactoryServers ?: descriptor.artifactoryServers}" varStatus="loop">
+            <f:dropdownListBlock value="${s.serverId}" title="${s.serverId} (${s.artifactoryUrl})"
+                                 selected="${s.serverId==instance.selectedServerId}">
+                <f:nested>
+                    <input type="hidden" name="artifactoryName" value="${s.serverId}"/>
+                    <input type="hidden" name="stapler-class" value="org.jfrog.hudson.ServerDetails"/>
+                </f:nested>
+            </f:dropdownListBlock>
+        </j:forEach>
+    </f:dropdownList>
 
     <f:entry title="Schedule:"
              help="/descriptor/hudson.triggers.TimerTrigger/help/spec">
-        <f:textbox  field="spec" value="${instance.spec}"/>
+        <f:textbox field="spec" value="${instance.spec}"/>
     </f:entry>
-    <f:entry  title="Paths to watch:"
+    <f:entry title="Paths to watch:"
              help="/plugin/artifactory/help/Trigger/help-pathsToWatch.html">
         <f:textbox field="paths" value="${instance.paths}"/>
     </f:entry>

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
@@ -16,8 +16,11 @@ import org.apache.commons.lang3.SystemUtils;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jfrog.build.api.Build;
 import org.jfrog.build.api.Module;
+import org.jfrog.hudson.ArtifactoryServer;
 import org.jfrog.hudson.jfpipelines.JFrogPipelinesServer;
 import org.jfrog.hudson.pipeline.common.docker.utils.DockerUtils;
+import org.jfrog.hudson.trigger.ArtifactoryTrigger;
+import org.jfrog.hudson.util.RepositoriesUtils;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
@@ -637,5 +640,30 @@ public class CommonITestsPipeline extends PipelineTestBase {
                 assertFalse(requestTree.has("outputResources"));
             }
         }
+    }
+
+    public void buildTriggerGlobalServerTest() throws Exception {
+        // Run pipeline
+        WorkflowRun run = runPipeline("buildTriggerGlobalServer", false);
+
+        // Check trigger
+        ArtifactoryTrigger artifactoryTrigger = checkArtifactoryTrigger(run);
+
+        // Change something in Artifactory server
+        ArtifactoryServer server = RepositoriesUtils.getArtifactoryServer("LOCAL", RepositoriesUtils.getArtifactoryServers());
+        server.setConnectionRetry(4);
+
+        // Make sure the change took place
+        server = artifactoryTrigger.getArtifactoryServer();
+        assertNotNull(server);
+        assertEquals(4, server.getConnectionRetry());
+    }
+
+    public void buildTriggerNewServerTest() throws Exception {
+        // Run pipeline
+        WorkflowRun run = runPipeline("buildTriggerNewServer", false);
+
+        // Check trigger
+        checkArtifactoryTrigger(run);
     }
 }

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/DeclarativeITest.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/DeclarativeITest.java
@@ -155,4 +155,14 @@ public class DeclarativeITest extends CommonITestsPipeline {
     public void jfPipelinesReportStatusTest() throws Exception {
         super.jfPipelinesReportStatusTest();
     }
+
+    @Test
+    public void buildTriggerGlobalServerTest() throws Exception {
+        super.buildTriggerGlobalServerTest();
+    }
+
+    @Test
+    public void buildTriggerNewServerTest() throws Exception {
+        super.buildTriggerNewServerTest();
+    }
 }

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/PipelineTestBase.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/PipelineTestBase.java
@@ -21,6 +21,7 @@ import org.jfrog.artifactory.client.impl.ArtifactoryRequestImpl;
 import org.jfrog.build.api.util.NullLog;
 import org.jfrog.build.extractor.clientConfiguration.client.ArtifactoryBuildInfoClient;
 import org.jfrog.hudson.ArtifactoryBuilder;
+import org.jfrog.hudson.ArtifactoryServer;
 import org.jfrog.hudson.CredentialsConfig;
 import org.jfrog.hudson.jfpipelines.JFrogPipelinesServer;
 import org.jfrog.hudson.jfpipelines.Utils;
@@ -35,10 +36,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Stream;
 
 import static org.jfrog.hudson.pipeline.integration.ITestUtils.*;
@@ -85,7 +83,7 @@ public class PipelineTestBase {
         createSlave();
         setEnvVars();
         createClients();
-        createJFrogPipelinesServer();
+        setGlobalConfiguration();
         cleanUpArtifactory(artifactoryClient);
         createPipelineSubstitution();
         // Create repositories
@@ -174,13 +172,19 @@ public class PipelineTestBase {
     }
 
     /**
-     * Create JFrog Pipelines server in the Global configuration.
+     * For jfPipelines tests - Create JFrog Pipelines server in the Global configuration.
+     * For buildTrigger tests - Create an empty list of Artifactory servers.
      */
-    private static void createJFrogPipelinesServer() {
+    private static void setGlobalConfiguration() {
         ArtifactoryBuilder.DescriptorImpl artifactoryBuilder = (ArtifactoryBuilder.DescriptorImpl) jenkins.getInstance().getDescriptor(ArtifactoryBuilder.class);
         Assert.assertNotNull(artifactoryBuilder);
         JFrogPipelinesServer server = new JFrogPipelinesServer("http://127.0.0.1:1080", CredentialsConfig.EMPTY_CREDENTIALS_CONFIG, 300, false, 3);
         artifactoryBuilder.setJfrogPipelinesServer(server);
+        CredentialsConfig cred = new CredentialsConfig("admin", "password", "cred1");
+        List<ArtifactoryServer> artifactoryServers = new ArrayList<ArtifactoryServer>() {{
+            add(new ArtifactoryServer("LOCAL", "http://127.0.0.1:8081/artifactory", cred, cred, 0, false, 3, null));
+        }};
+        artifactoryBuilder.setArtifactoryServers(artifactoryServers);
     }
 
     /**

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/ScriptedITest.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/ScriptedITest.java
@@ -150,4 +150,14 @@ public class ScriptedITest extends CommonITestsPipeline {
     public void appendBuildInfoTest() throws Exception {
         super.appendBuildInfoTest("scripted:appendBuildInfo test");
     }
+
+    @Test
+    public void buildTriggerGlobalServerTest() throws Exception {
+        super.buildTriggerGlobalServerTest();
+    }
+
+    @Test
+    public void buildTriggerNewServerTest() throws Exception {
+        super.buildTriggerNewServerTest();
+    }
 }

--- a/src/test/resources/integration/pipelines/declarative/buildTriggerGlobalServer.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/buildTriggerGlobalServer.pipeline
@@ -1,0 +1,10 @@
+package integration.pipelines.declarative
+
+node("TestSlave") {
+    stage "Add build trigger"
+    rtBuildTrigger(
+            serverId: "LOCAL",
+            spec: "* * * * *",
+            paths: "libs-release-local"
+    )
+}

--- a/src/test/resources/integration/pipelines/declarative/buildTriggerNewServer.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/buildTriggerNewServer.pipeline
@@ -1,0 +1,20 @@
+package integration.pipelines.declarative
+
+node("TestSlave") {
+    def serverId = "Artifactory-1"
+
+    stage "Configure Artifactory"
+    rtServer(
+            id: serverId,
+            url: "http://127.0.0.1:8081/artifactory", // Dummy artifactory server
+            username: "admin",
+            password: "password"
+    )
+
+    stage "Add build trigger"
+    rtBuildTrigger(
+            serverId: serverId,
+            spec: "* * * * *",
+            paths: "libs-release-local"
+    )
+}

--- a/src/test/resources/integration/pipelines/scripted/buildTriggerGlobalServer.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/buildTriggerGlobalServer.pipeline
@@ -1,0 +1,9 @@
+package integration.pipelines.scripted
+
+node("TestSlave") {
+    stage "Configuration"
+    def rtServer = Artifactory.server "LOCAL"
+
+    stage "Add build trigger"
+    rtServer.setBuildTrigger spec: "* * * * *", paths: "libs-release-local"
+}

--- a/src/test/resources/integration/pipelines/scripted/buildTriggerNewServer.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/buildTriggerNewServer.pipeline
@@ -1,0 +1,10 @@
+package integration.pipelines.scripted
+
+node("TestSlave") {
+    stage "Configuration"
+    // Dummy artifactory server
+    def rtServer = Artifactory.newServer url: "http://127.0.0.1:8081/artifactory", username: "admin", password: "password"
+
+    stage "Add build trigger"
+    rtServer.setBuildTrigger spec: "* * * * *", paths: "libs-release-local"
+}


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----

Let's distinct between 2 cases:
1. Server from the Global configuration (UI + pipeline) - Save the server ID in the ServerDetails object in the ArtifactoryTrigger.
2. New Artifactory server configured in pipeline - Save the ArtifactoryServer object as an invisible action in the job. This will promise that once the user used the pipeline to create a new trigger server, the server will always be available to use.

Usage:
* Scripted pipeline
  ```groovy
  // Using global server
  def server = Artifactory.server 'my-server-id'
  server.setBuildTrigger spec: "* * * * *", paths: "libs-release-local" 
  
  // Using new server
  def server = Artifactory.newServer url: 'artifactory-url', username: 'username', password: 'password'
  server.setBuildTrigger spec: "* * * * *", paths: "libs-release-local" 
  ```
* Declarative pipeline
  ```groovy
   // Using global server
   rtBuildTrigger(
     serverId: "my-server-id",
     spec: "* * * * *",
     paths: "libs-release-local"
   )

  // Using new server
  rtServer (
     id: 'Artifactory-1',
     url: 'artifactory-url',
     username: 'user',
     password: 'password'
  )
  rtBuildTrigger(
    serverId: "Artifactory-1",
    spec: "* * * * *",
    paths: "libs-release-local"
  )
  ```