### PR TITLE
Use AbortException rather than exotic types

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/common/executors/GetArtifactoryServerExecutor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/executors/GetArtifactoryServerExecutor.java
@@ -1,8 +1,7 @@
 package org.jfrog.hudson.pipeline.common.executors;
 
+import hudson.AbortException;
 import hudson.model.Run;
-import org.acegisecurity.acls.NotFoundException;
-import org.apache.commons.cli.MissingArgumentException;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jfrog.hudson.ArtifactoryServer;
@@ -33,13 +32,13 @@ public class GetArtifactoryServerExecutor implements Executor {
     @Override
     public void execute() {
         if (StringUtils.isEmpty(artifactoryServerID)) {
-            stepContext.onFailure(new MissingArgumentException("Artifactory server name is mandatory"));
+            stepContext.onFailure(new AbortException("Artifactory server name is mandatory"));
         }
 
         List<ArtifactoryServer> artifactoryServers = new ArrayList<>();
         List<ArtifactoryServer> artifactoryConfiguredServers = RepositoriesUtils.getArtifactoryServers();
         if (artifactoryConfiguredServers == null) {
-            stepContext.onFailure(new NotFoundException("No Artifactory servers were configured"));
+            stepContext.onFailure(new AbortException("No Artifactory servers were configured"));
             return;
         }
         for (ArtifactoryServer server : artifactoryConfiguredServers) {
@@ -48,7 +47,7 @@ public class GetArtifactoryServerExecutor implements Executor {
             }
         }
         if (artifactoryServers.isEmpty()) {
-            stepContext.onFailure(new NotFoundException("Couldn't find Artifactory server with ID: " + artifactoryServerID));
+            stepContext.onFailure(new AbortException("Couldn't find Artifactory server with ID: " + artifactoryServerID));
         }
         if (artifactoryServers.size() > 1) {
             throw new RuntimeException("Duplicate configured Artifactory server ID: " + artifactoryServerID);


### PR DESCRIPTION
There is no good reason to use exotic exception types, especially since they will print stack traces and here it seems more likely that is unwanted. https://github.com/jenkinsci/jenkins/pull/4848 will delete `org.acegisecurity.acls.NotFoundException` so please do not use it.