### PR TITLE
Use GitHub as the source of documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <packaging>hpi</packaging>
     <name>Jenkins Artifactory Plugin</name>
     <description>Integrates Artifactory to Jenkins</description>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Artifactory+Plugin</url>
+    <url>https://github.com/jenkinsci/artifactory-plugin</url>
 
     <properties>
         <!-- Minimal version required by Pipeline dependencies in 2.14.0 -->


### PR DESCRIPTION
- [n/a] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----
This is part of the [Wiki to Github migration](https://issues.jenkins-ci.org/browse/WEBSITE-637) project. Even though the readme has a lot of dev-specific information, the first paragraph is already better than the current Wiki page. Note that for documentation the link must use `jenkinsci` and not `jfrog` organization so that it's displayed at https://plugins.jenkins.io/artifactory/
