### PR TITLE
plain-credentials cannot be an optional dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,6 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>plain-credentials</artifactId>
             <version>1.3</version>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Its types are linked to and loaded without any guards that I can see. Noticed from a warning in an acceptance test

```
…	WARNING	o.e.j.s.h.ContextHandler$Context#log: Error while serving http://…/descriptorByName/org.jfrog.hudson.ArtifactoryBuilder/fillCredentialsIdItems
jenkins.util.java.ClassNotFoundNoStackTraceException: org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl
Caused: java.lang.NoClassDefFoundError: org/jenkinsci/plugins/plaincredentials/impl/StringCredentialsImpl
	at org.jfrog.hudson.util.plugins.PluginsUtils.fillPluginCredentials(PluginsUtils.java:53)
	at org.jfrog.hudson.ArtifactoryBuilder$DescriptorImpl.doFillCredentialsIdItems(ArtifactoryBuilder.java:89)
	at java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:627)
	at org.kohsuke.stapler.Function$MethodFunction.invoke(Function.java:396)
Caused: java.lang.reflect.InvocationTargetException
	at …
```

Anyway this is a lightweight API plugin; there is no plausible advantage to allowing users to disable it.
