### PR TITLE
Bugfix - gradle fail to create temp 'ok' file

### DIFF
--- a/src/main/java/org/jfrog/hudson/util/PluginDependencyHelper.java
+++ b/src/main/java/org/jfrog/hudson/util/PluginDependencyHelper.java
@@ -39,7 +39,7 @@ public class PluginDependencyHelper {
         }
 
         //Check if the dependencies have already been transferred successfully
-        FilePath remoteDependencyMark = new FilePath(remoteDependencyDir, "ok");
+        FilePath remoteDependencyMark = new FilePath(remoteDependencyDir, "done");
         if (!remoteDependencyMark.exists()) {
 
             File[] localDependencies = localDependencyDir.listFiles();


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----
Gradle 6.6 and above add an extra cache layer to its internals(https://docs.gradle.org/6.6/release-notes.html) and as a result, it tries to cache the Artifactory plugins jars.
Among the jars, an `ok` file is found, which indicates that all the jars were copies successfully into the master/agent before running Gradle. Whenever Gradle runs it tries to cache the `ok` file using  `java.io.File.createTempFile` and since `java.io.File.createTempFile` required at least 3 characters to create a temp file it throws an exception.

Fixes : https://github.com/jfrog/jenkins-artifactory-plugin/issues/349