### PR TITLE
HAP-1246 - Get Artifactory trigger path which caused the build

### DIFF
--- a/src/main/java/org/jfrog/hudson/trigger/ArtifactoryCause.java
+++ b/src/main/java/org/jfrog/hudson/trigger/ArtifactoryCause.java
@@ -1,16 +1,22 @@
 package org.jfrog.hudson.trigger;
 
 import hudson.model.Cause;
+import org.kohsuke.stapler.export.Exported;
 
 /**
  * @author Alexei Vainshtein
  */
 public class ArtifactoryCause extends Cause {
 
-    private String url;
+    private final String url;
 
     public ArtifactoryCause(String url) {
         this.url = url;
+    }
+
+    @Exported(visibility = 3)
+    public String getUrl() {
+        return url;
     }
 
     @Override


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----

Expose the URL of the Artifactory trigger cause. With that, users will be able to get the path in Artifactory that triggered the build, for example:
```groovy
stage ('Print cause') {
    def artifactoryCauses = currentBuild.getBuildCauses('org.jfrog.hudson.trigger.ArtifactoryCause')
    if (artifactoryCauses.size() > 0) {
        println artifactoryCauses[0].url
    }
}
```