### PR TITLE
HAP-1401 - Builds scan does not support access tokens

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,15 +39,15 @@
         <!--Skip integration tests unless explicitly requested with -DskipITs=false-->
         <skipITs>true</skipITs>
 
-        <buildinfo.version>2.20.0</buildinfo.version>
-        <buildinfo.maven3.version>2.20.0</buildinfo.maven3.version>
-        <buildinfo.gradle.version>4.18.0</buildinfo.gradle.version>
-        <buildinfo.ivy.version>2.20.0</buildinfo.ivy.version>
-        <buildinfo.npm.version>2.20.0</buildinfo.npm.version>
-        <buildinfo.go.version>2.20.0</buildinfo.go.version>
-        <buildinfo.pip.version>2.20.0</buildinfo.pip.version>
-        <buildinfo.nuget.version>2.20.0</buildinfo.nuget.version>
-        <buildinfo.docker.version>2.20.0</buildinfo.docker.version>
+        <buildinfo.version>2.20.x-SNAPSHOT</buildinfo.version>
+        <buildinfo.maven3.version>2.20.x-SNAPSHOT</buildinfo.maven3.version>
+        <buildinfo.gradle.version>4.18.x-SNAPSHOT</buildinfo.gradle.version>
+        <buildinfo.ivy.version>2.20.x-SNAPSHOT</buildinfo.ivy.version>
+        <buildinfo.npm.version>2.20.x-SNAPSHOT</buildinfo.npm.version>
+        <buildinfo.go.version>2.20.x-SNAPSHOT</buildinfo.go.version>
+        <buildinfo.pip.version>2.20.x-SNAPSHOT</buildinfo.pip.version>
+        <buildinfo.nuget.version>2.20.x-SNAPSHOT</buildinfo.nuget.version>
+        <buildinfo.docker.version>2.20.x-SNAPSHOT</buildinfo.docker.version>
     </properties>
 
     <developers>

--- a/src/main/java/org/jfrog/hudson/pipeline/common/executors/XrayExecutor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/executors/XrayExecutor.java
@@ -21,13 +21,14 @@ import org.jfrog.hudson.XrayScanResultAction;
  */
 public class XrayExecutor implements Executor {
 
-    private XrayScanConfig xrayScanConfig;
-    private TaskListener listener;
-    private ArtifactoryServer server;
-    private final Run build;
+    private final XrayScanConfig xrayScanConfig;
+    private final ArtifactoryServer server;
+    private final TaskListener listener;
+    private final Run<?, ?> build;
+
     private XrayScanResult xrayScanResult;
 
-    public XrayExecutor(XrayScanConfig xrayScanConfig, TaskListener listener, ArtifactoryServer server, Run build) {
+    public XrayExecutor(XrayScanConfig xrayScanConfig, TaskListener listener, ArtifactoryServer server, Run<?, ?> build) {
         this.xrayScanConfig = xrayScanConfig;
         this.listener = listener;
         this.server = server;
@@ -39,7 +40,7 @@ public class XrayExecutor implements Executor {
         Log log = new JenkinsBuildInfoLog(listener);
         Credentials credentials = server.createCredentialsConfig().provideCredentials(build.getParent());
         ArtifactoryXrayClient client = new ArtifactoryXrayClient(server.getUrl(), credentials.getUsername(),
-                credentials.getPassword(), log);
+                credentials.getPassword(), credentials.getAccessToken(), log);
         ProxyConfiguration proxyConfiguration = Utils.getProxyConfiguration(Utils.prepareArtifactoryServer(null, server));
         if (proxyConfiguration != null) {
             client.setProxyConfiguration(proxyConfiguration);


### PR DESCRIPTION
- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----

Related to: https://github.com/jfrog/build-info/pull/405