### PR TITLE
HAP-1412 - New build append command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,15 +39,15 @@
         <!--Skip integration tests unless explicitly requested with -DskipITs=false-->
         <skipITs>true</skipITs>
 
-        <buildinfo.version>2.20.1</buildinfo.version>
-        <buildinfo.maven3.version>2.20.1</buildinfo.maven3.version>
-        <buildinfo.gradle.version>4.18.1</buildinfo.gradle.version>
-        <buildinfo.ivy.version>2.20.1</buildinfo.ivy.version>
-        <buildinfo.npm.version>2.20.1</buildinfo.npm.version>
-        <buildinfo.go.version>2.20.1</buildinfo.go.version>
-        <buildinfo.pip.version>2.20.1</buildinfo.pip.version>
-        <buildinfo.nuget.version>2.20.1</buildinfo.nuget.version>
-        <buildinfo.docker.version>2.20.1</buildinfo.docker.version>
+        <buildinfo.version>2.20.x-SNAPSHOT</buildinfo.version>
+        <buildinfo.maven3.version>2.20.x-SNAPSHOT</buildinfo.maven3.version>
+        <buildinfo.gradle.version>4.18.x-SNAPSHOT</buildinfo.gradle.version>
+        <buildinfo.ivy.version>2.20.x-SNAPSHOT</buildinfo.ivy.version>
+        <buildinfo.npm.version>2.20.x-SNAPSHOT</buildinfo.npm.version>
+        <buildinfo.go.version>2.20.x-SNAPSHOT</buildinfo.go.version>
+        <buildinfo.pip.version>2.20.x-SNAPSHOT</buildinfo.pip.version>
+        <buildinfo.nuget.version>2.20.x-SNAPSHOT</buildinfo.nuget.version>
+        <buildinfo.docker.version>2.20.x-SNAPSHOT</buildinfo.docker.version>
     </properties>
 
     <developers>

--- a/src/main/java/org/jfrog/hudson/pipeline/common/executors/BuildAppendExecutor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/executors/BuildAppendExecutor.java
@@ -1,0 +1,134 @@
+package org.jfrog.hudson.pipeline.common.executors;
+
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.jfrog.build.api.Build;
+import org.jfrog.build.api.builder.ModuleBuilder;
+import org.jfrog.build.api.builder.ModuleType;
+import org.jfrog.build.extractor.clientConfiguration.client.ArtifactoryBuildInfoClient;
+import org.jfrog.build.extractor.clientConfiguration.client.ArtifactoryDependenciesClient;
+import org.jfrog.hudson.CredentialsConfig;
+import org.jfrog.hudson.pipeline.common.Utils;
+import org.jfrog.hudson.pipeline.common.types.ArtifactoryServer;
+import org.jfrog.hudson.pipeline.common.types.buildInfo.BuildInfo;
+import org.jfrog.hudson.util.Credentials;
+import org.jfrog.hudson.util.JenkinsBuildInfoLog;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.jfrog.hudson.util.ProxyUtils.createProxyConfiguration;
+
+/**
+ * @author yahavi
+ **/
+public class BuildAppendExecutor implements Executor {
+
+    private static final String SHA1_HEADER_NAME = "X-Checksum-Sha1";
+    private static final String MD5_HEADER_NAME = "X-Checksum-Md5";
+
+    private final ArtifactoryServer pipelineServer;
+    private final TaskListener listener;
+    // The build info of the current build
+    private final BuildInfo buildInfo;
+    // The build number of the build to append
+    private final String buildNumber;
+    // The build name of the build to append
+    private final String buildName;
+    private final Run<?, ?> build;
+
+    public BuildAppendExecutor(ArtifactoryServer pipelineServer, BuildInfo buildInfo, String buildName,
+                               String buildNumber, Run<?, ?> build, TaskListener listener) {
+        this.pipelineServer = pipelineServer;
+        this.buildNumber = buildNumber;
+        this.buildName = buildName;
+        this.buildInfo = buildInfo;
+        this.listener = listener;
+        this.build = build;
+    }
+
+    @Override
+    public void execute() throws Exception {
+        ModuleBuilder moduleBuilder = new ModuleBuilder().id(buildName + "/" + buildNumber).type(ModuleType.BUILD);
+
+        // Prepare Artifactory server
+        org.jfrog.hudson.ArtifactoryServer server = Utils.prepareArtifactoryServer(null, pipelineServer);
+        CredentialsConfig credentialsConfig = server.getResolverCredentialsConfig();
+        Credentials credentials = credentialsConfig.provideCredentials(build.getParent());
+
+        // Calculate build timestamp
+        long timestamp = getBuildTimestamp(server, credentials);
+
+        // Get checksum headers from the build info artifact
+        addChecksumHeaders(server, credentials, moduleBuilder, timestamp);
+
+        // Add module to build info
+        buildInfo.getModules().add(moduleBuilder.build());
+    }
+
+    /**
+     * Get build timestamp of the build to append. The build timestamp have to be converted to seconds from epoch.
+     * For example, start time of: 2020-11-27T14:33:38.538+0200 should be converted to 1606480418538.
+     *
+     * @param server      - The Artifactory server
+     * @param credentials - The credentials of the Artifactory serer
+     * @return the build timestamp of the build to append.
+     * @throws IOException    in case of any communication error with Artifactory, wrong credentials or if the build if missing.
+     * @throws ParseException in case of the returned timestamp contains unexpected format.
+     */
+    private long getBuildTimestamp(org.jfrog.hudson.ArtifactoryServer server, Credentials credentials) throws IOException, ParseException {
+        try (ArtifactoryBuildInfoClient client = server.createBuildInfoClientBuilder(credentials, createProxyConfiguration(), new JenkinsBuildInfoLog(listener)).build()) {
+            Build build = client.getBuildInfo(buildName, buildNumber);
+            DateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+            Date date = format.parse(build.getStarted());
+            return date.getTime();
+        }
+    }
+
+    /**
+     * Download MD5 and SHA1 from the build info artifact. Add them to the current build info object.
+     *
+     * @param server        - The Artifactory server
+     * @param credentials   - Credential of the Artifactory server
+     * @param moduleBuilder - The module builder of the new module which will be added to the current build info object
+     * @param timestamp     - The build timestamp of the build to append
+     * @throws IOException if a header the build info object are missing.
+     */
+    private void addChecksumHeaders(org.jfrog.hudson.ArtifactoryServer server, Credentials credentials, ModuleBuilder moduleBuilder, long timestamp) throws IOException {
+        // To support build name and numbers with ':', encode ':' by '%3A'. Further encoding will take place in 'getArtifactMetadata'.
+        String encodedBuildName = buildName.replaceAll(":", "%3A");
+        String encodedBuildNumber = buildNumber.replaceAll(":", "%3A");
+
+        // Send HEAD request to <artifactory-url>/artifactory-build-info/<build-name>/<build-number>-timestamp.json to get the checksums
+        String buildInfoPath = server.getArtifactoryUrl() + "/artifactory-build-info/" + encodedBuildName + "/" + encodedBuildNumber + "-" + timestamp + ".json";
+        try (ArtifactoryDependenciesClient client = server.createArtifactoryDependenciesClient(credentials, createProxyConfiguration(), listener)) {
+            // getArtifactMetadata return null response entity - there's no need to consume it
+            HttpResponse response = client.getArtifactMetadata(buildInfoPath);
+            moduleBuilder
+                    .sha1(readHeader(response, buildInfoPath, SHA1_HEADER_NAME))
+                    .md5(readHeader(response, buildInfoPath, MD5_HEADER_NAME));
+        }
+    }
+
+    /**
+     * Read a header from the HTTP response.
+     *
+     * @param response   - The HTTP response
+     * @param path       - The path to the resource in Artifactory
+     * @param headerName - The header name to search for
+     * @return the header value.
+     * @throws IOException if the requested header is missing.
+     */
+    private String readHeader(HttpResponse response, String path, String headerName) throws IOException {
+        Header sha1 = response.getFirstHeader(headerName);
+        if (sha1 == null) {
+            throw new IOException("'" + headerName + "' header is missing in HEAD request to '" + path + "'");
+        }
+        return sha1.getValue();
+    }
+}

--- a/src/main/java/org/jfrog/hudson/pipeline/common/executors/BuildAppendExecutor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/executors/BuildAppendExecutor.java
@@ -22,15 +22,14 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import static org.jfrog.build.extractor.clientConfiguration.client.ArtifactoryBaseClient.MD5_HEADER_NAME;
+import static org.jfrog.build.extractor.clientConfiguration.client.ArtifactoryBaseClient.SHA1_HEADER_NAME;
 import static org.jfrog.hudson.util.ProxyUtils.createProxyConfiguration;
 
 /**
  * @author yahavi
  **/
 public class BuildAppendExecutor implements Executor {
-
-    private static final String SHA1_HEADER_NAME = "X-Checksum-Sha1";
-    private static final String MD5_HEADER_NAME = "X-Checksum-Md5";
 
     private final ArtifactoryServer pipelineServer;
     private final TaskListener listener;
@@ -72,7 +71,7 @@ public class BuildAppendExecutor implements Executor {
     }
 
     /**
-     * Get build timestamp of the build to append. The build timestamp have to be converted to seconds from epoch.
+     * Get build timestamp of the build to append. The build timestamp has to be converted to seconds from epoch.
      * For example, start time of: 2020-11-27T14:33:38.538+0200 should be converted to 1606480418538.
      *
      * @param server      - The Artifactory server

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/ArtifactoryServer.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/ArtifactoryServer.java
@@ -230,6 +230,18 @@ public class ArtifactoryServer implements Serializable {
     }
 
     @Whitelisted
+    public void buildAppend(BuildInfo buildInfo, String buildName, String buildNumber) {
+        Map<String, Object> stepVariables = Maps.newLinkedHashMap();
+        stepVariables.put(BUILD_INFO, buildInfo);
+        stepVariables.put(BUILD_NAME, buildName);
+        stepVariables.put(BUILD_NUMBER, buildNumber);
+        stepVariables.put(SERVER, this);
+
+        // Throws CpsCallableInvocation - Must be the last line in this method
+        cpsScript.invokeMethod("buildAppend", stepVariables);
+    }
+
+    @Whitelisted
     public void promote(Map<String, Object> promotionParams) {
         Map<String, Object> stepVariables = Maps.newLinkedHashMap();
         stepVariables.put("promotionConfig", Utils.createPromotionConfig(promotionParams, true));

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/BuildAppendStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/BuildAppendStep.java
@@ -1,0 +1,92 @@
+package org.jfrog.hudson.pipeline.declarative.steps;
+
+import com.google.inject.Inject;
+import hudson.Extension;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jfrog.hudson.pipeline.ArtifactorySynchronousStepExecution;
+import org.jfrog.hudson.pipeline.common.executors.BuildAppendExecutor;
+import org.jfrog.hudson.pipeline.common.types.ArtifactoryServer;
+import org.jfrog.hudson.pipeline.common.types.buildInfo.BuildInfo;
+import org.jfrog.hudson.pipeline.declarative.utils.DeclarativePipelineUtils;
+import org.jfrog.hudson.util.JenkinsBuildInfoLog;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import java.io.IOException;
+
+@SuppressWarnings("unused")
+public class BuildAppendStep extends AbstractStepImpl {
+
+    public static final String STEP_NAME = "rtBuildAppend";
+    private final String buildNumberToAppend;
+    private final String buildNameToAppend;
+    private final String serverId;
+    private String buildNumber;
+    private String buildName;
+
+    @DataBoundConstructor
+    public BuildAppendStep(String serverId, String buildNameToAppend, String buildNumberToAppend) {
+        this.serverId = serverId;
+        this.buildNameToAppend = buildNameToAppend;
+        this.buildNumberToAppend = buildNumberToAppend;
+    }
+
+    @DataBoundSetter
+    public void setBuildName(String buildName) {
+        this.buildName = buildName;
+    }
+
+    @DataBoundSetter
+    public void setBuildNumber(String buildNumber) {
+        this.buildNumber = buildNumber;
+    }
+
+    public static class Execution extends ArtifactorySynchronousStepExecution<Void> {
+
+        private final transient BuildAppendStep step;
+
+        @Inject
+        public Execution(BuildAppendStep step, StepContext context) throws IOException, InterruptedException {
+            super(context);
+            this.step = step;
+        }
+
+        @Override
+        protected Void run() throws Exception {
+            ArtifactoryServer server = DeclarativePipelineUtils.getArtifactoryServer(build, ws, getContext(), step.serverId);
+            BuildInfo buildInfo = DeclarativePipelineUtils.getBuildInfo(ws, build, step.buildName, step.buildNumber);
+            if (buildInfo == null) {
+                throw new RuntimeException("Build " + DeclarativePipelineUtils.createBuildInfoId(build, step.buildName, step.buildNumber) + " does not exist!");
+            }
+
+            new BuildAppendExecutor(server, buildInfo, step.buildNameToAppend, step.buildNumberToAppend, build, listener).execute();
+            DeclarativePipelineUtils.saveBuildInfo(buildInfo, ws, build, new JenkinsBuildInfoLog(listener));
+            return null;
+        }
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+        public DescriptorImpl() {
+            super(BuildAppendStep.Execution.class);
+        }
+
+        @Override
+        public String getFunctionName() {
+            return STEP_NAME;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Build append";
+        }
+
+        @Override
+        public boolean isAdvanced() {
+            return true;
+        }
+    }
+}

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/BuildAppendStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/BuildAppendStep.java
@@ -20,17 +20,17 @@ import java.io.IOException;
 public class BuildAppendStep extends AbstractStepImpl {
 
     public static final String STEP_NAME = "rtBuildAppend";
-    private final String buildNumberToAppend;
-    private final String buildNameToAppend;
+    private final String appendBuildNumber;
+    private final String appendBuildName;
     private final String serverId;
     private String buildNumber;
     private String buildName;
 
     @DataBoundConstructor
-    public BuildAppendStep(String serverId, String buildNameToAppend, String buildNumberToAppend) {
+    public BuildAppendStep(String serverId, String appendBuildName, String appendBuildNumber) {
         this.serverId = serverId;
-        this.buildNameToAppend = buildNameToAppend;
-        this.buildNumberToAppend = buildNumberToAppend;
+        this.appendBuildName = appendBuildName;
+        this.appendBuildNumber = appendBuildNumber;
     }
 
     @DataBoundSetter
@@ -61,7 +61,7 @@ public class BuildAppendStep extends AbstractStepImpl {
                 throw new RuntimeException("Build " + DeclarativePipelineUtils.createBuildInfoId(build, step.buildName, step.buildNumber) + " does not exist!");
             }
 
-            new BuildAppendExecutor(server, buildInfo, step.buildNameToAppend, step.buildNumberToAppend, build, listener).execute();
+            new BuildAppendExecutor(server, buildInfo, step.appendBuildName, step.appendBuildNumber, build, listener).execute();
             DeclarativePipelineUtils.saveBuildInfo(buildInfo, ws, build, new JenkinsBuildInfoLog(listener));
             return null;
         }

--- a/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/BuildAppendStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/BuildAppendStep.java
@@ -1,0 +1,80 @@
+package org.jfrog.hudson.pipeline.scripted.steps;
+
+import com.google.inject.Inject;
+import hudson.Extension;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jfrog.hudson.pipeline.ArtifactorySynchronousNonBlockingStepExecution;
+import org.jfrog.hudson.pipeline.common.executors.BuildAppendExecutor;
+import org.jfrog.hudson.pipeline.common.types.ArtifactoryServer;
+import org.jfrog.hudson.pipeline.common.types.buildInfo.BuildInfo;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.IOException;
+
+public class BuildAppendStep extends AbstractStepImpl {
+
+    private final String buildNumber;
+    private final String buildName;
+    private final ArtifactoryServer server;
+    private final BuildInfo buildInfo;
+
+    @DataBoundConstructor
+    public BuildAppendStep(BuildInfo buildInfo, String buildName, String buildNumber, ArtifactoryServer server) {
+        this.buildNumber = buildNumber;
+        this.buildName = buildName;
+        this.buildInfo = buildInfo;
+        this.server = server;
+    }
+
+    public BuildInfo getBuildInfo() {
+        return buildInfo;
+    }
+
+    public ArtifactoryServer getServer() {
+        return server;
+    }
+
+    public static class Execution extends ArtifactorySynchronousNonBlockingStepExecution<Void> {
+
+        private final transient BuildAppendStep step;
+
+        @Inject
+        public Execution(BuildAppendStep step, StepContext context) throws IOException, InterruptedException {
+            super(context);
+            this.step = step;
+        }
+
+        @Override
+        protected Void run() throws Exception {
+            new BuildAppendExecutor(step.server, step.buildInfo, step.buildName, step.buildNumber, build, listener).execute();
+            return null;
+        }
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+        public DescriptorImpl() {
+            super(BuildAppendStep.Execution.class);
+        }
+
+        @Override
+        // The step is invoked by ArtifactoryServer by the step name
+        public String getFunctionName() {
+            return "buildAppend";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Build append";
+        }
+
+        @Override
+        public boolean isAdvanced() {
+            return true;
+        }
+    }
+
+}

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
@@ -722,4 +722,23 @@ public class CommonITestsPipeline extends PipelineTestBase {
         // Check trigger
         checkArtifactoryTrigger(run);
     }
+
+    void buildAppendTest(String buildName) throws Exception {
+        String buildName1 = buildName + "-1";
+        String buildNumber1 = "1";
+        String buildName2 = buildName + "-2";
+        String buildNumber2 = "2";
+
+        // Clear older builds if exist
+        deleteBuild(artifactoryClient, buildName1);
+        deleteBuild(artifactoryClient, buildName2);
+        runPipeline("buildAppend", false);
+        try {
+            Build buildInfo = getBuildInfo(buildInfoClient, buildName2, buildNumber2);
+            getAndAssertModule(buildInfo, buildName1 + "/" + buildNumber1);
+        } finally {
+            deleteBuild(artifactoryClient, buildName1);
+            deleteBuild(artifactoryClient, buildName2);
+        }
+    }
 }

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/DeclarativeITest.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/DeclarativeITest.java
@@ -175,4 +175,9 @@ public class DeclarativeITest extends CommonITestsPipeline {
     public void buildTriggerNewServerTest() throws Exception {
         super.buildTriggerNewServerTest();
     }
+
+    @Test
+    public void buildAppendTest() throws Exception {
+        super.buildAppendTest("declarative:buildAppend test");
+    }
 }

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/ScriptedITest.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/ScriptedITest.java
@@ -170,4 +170,9 @@ public class ScriptedITest extends CommonITestsPipeline {
     public void buildTriggerNewServerTest() throws Exception {
         super.buildTriggerNewServerTest();
     }
+
+    @Test
+    public void buildAppendTest() throws Exception {
+        super.buildAppendTest("scripted:buildAppend test");
+    }
 }

--- a/src/test/resources/integration/pipelines/declarative/buildAppend.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/buildAppend.pipeline
@@ -39,8 +39,8 @@ node("TestSlave") {
             serverId: serverId,
             buildName: buildName2,
             buildNumber: buildNumber2,
-            buildNameToAppend: buildName1,
-            buildNumberToAppend: buildNumber1
+            appendBuildName: buildName1,
+            appendBuildNumber: buildNumber1
     )
 
     stage "Publish 2nd Build Info"

--- a/src/test/resources/integration/pipelines/declarative/buildAppend.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/buildAppend.pipeline
@@ -1,0 +1,52 @@
+package integration.pipelines.declarative
+
+node("TestSlave") {
+    def serverId = "Artifactory-1"
+    def buildName1 = "declarative:buildAppend test-1"
+    def buildNumber1 = "1"
+    def buildName2 = "declarative:buildAppend test-2"
+    def buildNumber2 = "2"
+
+    stage "Configuration"
+    rtServer(
+            id: serverId,
+            url: "${env.JENKINS_ARTIFACTORY_URL}",
+            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
+            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    )
+
+    stage "Create 1st Build Info"
+    rtBuildInfo(
+            buildName: buildName1,
+            buildNumber: buildNumber1
+    )
+
+    stage "Publish 1st Build Info"
+    rtPublishBuildInfo(
+            serverId: serverId,
+            buildName: buildName1,
+            buildNumber: buildNumber1
+    )
+
+    stage "Create 2nd Build Info"
+    rtBuildInfo(
+            buildName: buildName2,
+            buildNumber: buildNumber2
+    )
+
+    stage "Append build 1 to build 2"
+    rtBuildAppend(
+            serverId: serverId,
+            buildName: buildName2,
+            buildNumber: buildNumber2,
+            buildNameToAppend: buildName1,
+            buildNumberToAppend: buildNumber1
+    )
+
+    stage "Publish 2nd Build Info"
+    rtPublishBuildInfo(
+            serverId: serverId,
+            buildName: buildName2,
+            buildNumber: buildNumber2
+    )
+}

--- a/src/test/resources/integration/pipelines/scripted/buildAppend.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/buildAppend.pipeline
@@ -1,0 +1,25 @@
+package integration.pipelines.scripted
+
+node("TestSlave") {
+    stage "Configuration"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_ARTIFACTORY_URL}", username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+
+    stage "Create 1st Build Info"
+    def buildInfo1 = Artifactory.newBuildInfo()
+    buildInfo1.name = "scripted:buildAppend test-1"
+    buildInfo1.number = "1"
+
+    stage "Publish 1st Build Info"
+    rtServer.publishBuildInfo buildInfo1
+
+    stage "Create 2nd Build Info"
+    def buildInfo2 = Artifactory.newBuildInfo()
+    buildInfo2.name = "scripted:buildAppend test-2"
+    buildInfo2.number = "2"
+
+    stage "Append build 1 to build 2"
+    rtServer.buildAppend(buildInfo2, buildInfo1.name, buildInfo1.number)
+
+    stage "Publish 2nd Build Info"
+    rtServer.publishBuildInfo buildInfo2
+}


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----

Scripted Pipeline:
```groovy
rtServer.buildAppend(buildInfo, "Build name to append", "Build number to append")
```

Declarative Pipeline:
```groovy
rtBuildAppend(
    // Mandatory:
    serverId: "Artifactory-1"
    appendBuildName: "Build name to append",
    appendBuildNumber: "Build number to append",

    // Optional:
    buildName: "Current working build name",
    buildNumber: "Current working build number"
)
```
