### PR TITLE
Persist build name and number to buildinfo.properties file in resolution builds

### DIFF
--- a/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
@@ -168,13 +168,8 @@ public class ExtractorUtils {
             addBuildRootIfNeeded((AbstractBuild) build, configuration);
         }
 
-        if (publisherContext != null) {
-            setPublisherInfo(env, build, pipelineBuildInfo, publisherContext, configuration);
-            publisherContext.setArtifactoryPluginVersion(ActionableHelper.getArtifactoryPluginVersion());
-        }
-
-        if (resolverContext != null) {
-            setResolverInfo(configuration, build, resolverContext, env);
+        if (publisherContext != null || resolverContext != null) {
+            setPublisherResolverInfo(env, build, configuration, publisherContext, resolverContext, pipelineBuildInfo);
         }
 
         if (!shouldBypassProxy(resolverContext, publisherContext)) {
@@ -193,6 +188,27 @@ public class ExtractorUtils {
         }
         addEnvVars(env, build, configuration, envVarsPatterns, listener);
         return configuration;
+    }
+
+    private static void setPublisherResolverInfo(Map<String, String> env, Run build, ArtifactoryClientConfiguration configuration,
+                                                 PublisherContext publisherContext, ResolverContext resolverContext, BuildInfo pipelineBuildInfo) throws IOException {
+        String buildName = BuildUniqueIdentifierHelper.getBuildName(build);
+        String buildNumber = BuildUniqueIdentifierHelper.getBuildNumber(build);
+        if (pipelineBuildInfo != null) {
+            buildName = pipelineBuildInfo.getName();
+            buildNumber = pipelineBuildInfo.getNumber();
+        }
+        configuration.info.setBuildName(buildName);
+        configuration.info.setBuildNumber(buildNumber);
+
+        if (publisherContext != null) {
+            setPublisherInfo(env, build, pipelineBuildInfo, publisherContext, configuration, buildName, buildNumber);
+            publisherContext.setArtifactoryPluginVersion(ActionableHelper.getArtifactoryPluginVersion());
+        }
+
+        if (resolverContext != null) {
+            setResolverInfo(configuration, build, resolverContext, env);
+        }
     }
 
     private static boolean shouldBypassProxy(ResolverContext resolverContext, PublisherContext publisherContext) {
@@ -258,21 +274,14 @@ public class ExtractorUtils {
      * Set all the parameters relevant for publishing artifacts and build info
      */
     private static void setPublisherInfo(Map<String, String> env, Run build, BuildInfo pipelineBuildInfo, PublisherContext context,
-                                         ArtifactoryClientConfiguration configuration) throws IOException {
+                                         ArtifactoryClientConfiguration configuration, String buildName, String buildNumber) throws IOException {
         configuration.setActivateRecorder(Boolean.TRUE);
-        String buildName;
-        String buildNumber;
-        if (pipelineBuildInfo != null) {
-            buildName = pipelineBuildInfo.getName();
-            buildNumber = pipelineBuildInfo.getNumber();
-        } else {
-            buildName = context.isOverrideBuildName() ? context.getCustomBuildName() : BuildUniqueIdentifierHelper.getBuildName(build);
-            buildNumber = BuildUniqueIdentifierHelper.getBuildNumber(build);
-        }
 
-        configuration.info.setBuildName(buildName);
+        if (pipelineBuildInfo == null && context.isOverrideBuildName()) {
+            buildName = context.getCustomBuildName();
+            configuration.info.setBuildName(buildName);
+        }
         configuration.publisher.addMatrixParam(BuildInfoFields.BUILD_NAME, buildName);
-        configuration.info.setBuildNumber(buildNumber);
         configuration.publisher.addMatrixParam(BuildInfoFields.BUILD_NUMBER, buildNumber);
         configuration.info.setArtifactoryPluginVersion(ActionableHelper.getArtifactoryPluginVersion());
 

--- a/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
@@ -192,13 +192,9 @@ public class ExtractorUtils {
 
     private static void setPublisherResolverInfo(Map<String, String> env, Run build, ArtifactoryClientConfiguration configuration,
                                                  PublisherContext publisherContext, ResolverContext resolverContext, BuildInfo pipelineBuildInfo) throws IOException {
-        String buildName = BuildUniqueIdentifierHelper.getBuildName(build);
-        String buildNumber = BuildUniqueIdentifierHelper.getBuildNumber(build);
-        if (pipelineBuildInfo != null) {
-            buildName = pipelineBuildInfo.getName();
-            buildNumber = pipelineBuildInfo.getNumber();
-        }
+        String buildName = pipelineBuildInfo != null ? pipelineBuildInfo.getName() : BuildUniqueIdentifierHelper.getBuildName(build);
         configuration.info.setBuildName(buildName);
+        String buildNumber = pipelineBuildInfo != null ? pipelineBuildInfo.getNumber() : BuildUniqueIdentifierHelper.getBuildNumber(build);
         configuration.info.setBuildNumber(buildNumber);
 
         if (publisherContext != null) {


### PR DESCRIPTION
- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----
