### PR TITLE
HAP-1417 - Declarative pipeline fails when running step in a directory

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/ArtifactorySynchronousNonBlockingStepExecution.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/ArtifactorySynchronousNonBlockingStepExecution.java
@@ -1,36 +1,36 @@
 package org.jfrog.hudson.pipeline;
 
-import com.google.inject.Inject;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.model.Run;
 import hudson.model.TaskListener;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 
 import java.io.IOException;
 
+import static org.jfrog.hudson.pipeline.common.Utils.extractRootWorkspace;
+
 public abstract class ArtifactorySynchronousNonBlockingStepExecution<T> extends SynchronousNonBlockingStepExecution<T> {
     protected static final long serialVersionUID = 1L;
 
-    protected transient Run<?, ?> build;
-
     protected transient TaskListener listener;
-
     protected transient Launcher launcher;
-
+    protected transient WorkflowRun build;
+    // The step's root workspace
+    protected transient FilePath rootWs;
+    // The step's working directory
     protected transient FilePath ws;
-
     protected transient EnvVars env;
 
     protected ArtifactorySynchronousNonBlockingStepExecution(StepContext context) throws IOException, InterruptedException {
         super(context);
-        this.build = context.get(Run.class);
         this.listener = context.get(TaskListener.class);
+        this.build = context.get(WorkflowRun.class);
         this.launcher = context.get(Launcher.class);
         this.ws = context.get(FilePath.class);
+        this.rootWs = extractRootWorkspace(context, this.build, this.ws);
         this.env = context.get(EnvVars.class);
-
     }
 }

--- a/src/main/java/org/jfrog/hudson/pipeline/ArtifactorySynchronousStepExecution.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/ArtifactorySynchronousStepExecution.java
@@ -3,33 +3,34 @@ package org.jfrog.hudson.pipeline;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.model.Run;
 import hudson.model.TaskListener;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.SynchronousStepExecution;
 
 import java.io.IOException;
 
+import static org.jfrog.hudson.pipeline.common.Utils.extractRootWorkspace;
+
 public abstract class ArtifactorySynchronousStepExecution<T> extends SynchronousStepExecution<T> {
     protected static final long serialVersionUID = 1L;
 
-    protected transient Run<?, ?> build;
-
     protected transient TaskListener listener;
-
     protected transient Launcher launcher;
-
+    protected transient WorkflowRun build;
+    // The step's root workspace
+    protected transient FilePath rootWs;
+    // The step's working directory
     protected transient FilePath ws;
-
     protected transient EnvVars env;
 
     protected ArtifactorySynchronousStepExecution(StepContext context) throws IOException, InterruptedException {
         super(context);
-        this.build = context.get(Run.class);
         this.listener = context.get(TaskListener.class);
+        this.build = context.get(WorkflowRun.class);
         this.launcher = context.get(Launcher.class);
         this.ws = context.get(FilePath.class);
+        this.rootWs = extractRootWorkspace(context, this.build, this.ws);
         this.env = context.get(EnvVars.class);
-
     }
 }

--- a/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
@@ -19,8 +19,10 @@ import jenkins.plugins.nodejs.tools.NodeJSInstallation;
 import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jfrog.build.api.BuildInfoFields;
 import org.jfrog.build.api.Vcs;
@@ -52,6 +54,26 @@ public class Utils {
     public static final String CONAN_USER_HOME = "CONAN_USER_HOME"; // Conan user home environment variable name
     public static final String BUILD_INFO = "buildInfo"; // The build info argument used in pipeline
     private static final String UNIX_SPECIAL_CHARS = "`^<>| ,;!?'\"()[]{}$*\\&#"; // Unix special characters to escape in '/bin/sh' execution
+
+    /**
+     * Extract workspace FilePath from step context.
+     * This is necessary to get the actual subdirectory, which runs the pipeline.
+     *
+     * @param context - The step context
+     * @param build   - The workflow build
+     * @param cwd     - The current working directory
+     * @return the workspace base FilePath.
+     * @throws IOException          if context.get fails.
+     * @throws InterruptedException if context.get fails.
+     */
+    public static FilePath extractRootWorkspace(StepContext context, WorkflowRun build, FilePath cwd) throws IOException, InterruptedException {
+        Node node = context.get(Node.class);
+        if (node == null) {
+            return cwd;
+        }
+        FilePath ws = node.getWorkspaceFor(build.getParent());
+        return ObjectUtils.defaultIfNull(ws, cwd);
+    }
 
     /**
      * Prepares Artifactory server either from serverID or from ArtifactoryServer.

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/BuildAppendStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/BuildAppendStep.java
@@ -55,14 +55,14 @@ public class BuildAppendStep extends AbstractStepImpl {
 
         @Override
         protected Void run() throws Exception {
-            ArtifactoryServer server = DeclarativePipelineUtils.getArtifactoryServer(build, ws, getContext(), step.serverId);
-            BuildInfo buildInfo = DeclarativePipelineUtils.getBuildInfo(ws, build, step.buildName, step.buildNumber);
+            ArtifactoryServer server = DeclarativePipelineUtils.getArtifactoryServer(build, rootWs, getContext(), step.serverId);
+            BuildInfo buildInfo = DeclarativePipelineUtils.getBuildInfo(rootWs, build, step.buildName, step.buildNumber);
             if (buildInfo == null) {
                 throw new RuntimeException("Build " + DeclarativePipelineUtils.createBuildInfoId(build, step.buildName, step.buildNumber) + " does not exist!");
             }
 
             new BuildAppendExecutor(server, buildInfo, step.appendBuildName, step.appendBuildNumber, build, listener).execute();
-            DeclarativePipelineUtils.saveBuildInfo(buildInfo, ws, build, new JenkinsBuildInfoLog(listener));
+            DeclarativePipelineUtils.saveBuildInfo(buildInfo, rootWs, build, new JenkinsBuildInfoLog(listener));
             return null;
         }
     }

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/BuildInfoStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/BuildInfoStep.java
@@ -3,7 +3,9 @@ package org.jfrog.hudson.pipeline.declarative.steps;
 import com.google.inject.Inject;
 import hudson.Extension;
 import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.plugins.workflow.steps.*;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jfrog.hudson.pipeline.ArtifactorySynchronousStepExecution;
 import org.jfrog.hudson.pipeline.common.types.buildInfo.BuildInfo;
 import org.jfrog.hudson.pipeline.declarative.utils.DeclarativePipelineUtils;
@@ -23,7 +25,7 @@ import java.util.List;
 public class BuildInfoStep extends AbstractStepImpl {
 
     public static final String STEP_NAME = "rtBuildInfo";
-    private BuildInfo buildInfo;
+    private final BuildInfo buildInfo;
 
     @DataBoundConstructor
     public BuildInfoStep() {
@@ -87,7 +89,7 @@ public class BuildInfoStep extends AbstractStepImpl {
 
     public static class Execution extends ArtifactorySynchronousStepExecution<Void> {
 
-        private transient BuildInfoStep step;
+        private transient final BuildInfoStep step;
 
         @Inject
         public Execution(BuildInfoStep step, StepContext context) throws IOException, InterruptedException {
@@ -101,7 +103,7 @@ public class BuildInfoStep extends AbstractStepImpl {
             String buildNumber = StringUtils.isBlank(step.buildInfo.getNumber()) ? BuildUniqueIdentifierHelper.getBuildNumber(build) : step.buildInfo.getNumber();
             step.buildInfo.setName(buildName);
             step.buildInfo.setNumber(buildNumber);
-            DeclarativePipelineUtils.saveBuildInfo(step.buildInfo, ws, build, new JenkinsBuildInfoLog(listener));
+            DeclarativePipelineUtils.saveBuildInfo(step.buildInfo, rootWs, build, new JenkinsBuildInfoLog(listener));
             return null;
         }
     }

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/BuildTriggerStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/BuildTriggerStep.java
@@ -43,7 +43,7 @@ public class BuildTriggerStep extends AbstractStepImpl {
 
         @Override
         protected Void run() throws Exception {
-            ArtifactoryServer server = DeclarativePipelineUtils.getArtifactoryServer(build, ws, getContext(), step.serverId);
+            ArtifactoryServer server = DeclarativePipelineUtils.getArtifactoryServer(build, rootWs, getContext(), step.serverId);
             new BuildTriggerExecutor(build, listener, server, step.paths, step.spec).execute();
             return null;
         }

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/CreateServerStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/CreateServerStep.java
@@ -2,9 +2,11 @@ package org.jfrog.hudson.pipeline.declarative.steps;
 
 import com.google.inject.Inject;
 import hudson.Extension;
-import org.jenkinsci.plugins.workflow.steps.*;
-import org.jfrog.hudson.pipeline.common.types.ArtifactoryServer;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jfrog.hudson.pipeline.ArtifactorySynchronousStepExecution;
+import org.jfrog.hudson.pipeline.common.types.ArtifactoryServer;
 import org.jfrog.hudson.pipeline.declarative.BuildDataFile;
 import org.jfrog.hudson.pipeline.declarative.utils.DeclarativePipelineUtils;
 import org.jfrog.hudson.util.BuildUniqueIdentifierHelper;
@@ -18,8 +20,8 @@ import java.io.IOException;
 public class CreateServerStep extends AbstractStepImpl {
 
     public static final String STEP_NAME = "rtServer";
-    private BuildDataFile buildDataFile;
-    private ArtifactoryServer server;
+    private final BuildDataFile buildDataFile;
+    private final ArtifactoryServer server;
 
     @DataBoundConstructor
     public CreateServerStep(String id) {
@@ -65,7 +67,7 @@ public class CreateServerStep extends AbstractStepImpl {
 
     public static class Execution extends ArtifactorySynchronousStepExecution<Void> {
 
-        private transient CreateServerStep step;
+        private transient final CreateServerStep step;
 
         @Inject
         public Execution(CreateServerStep step, StepContext context) throws IOException, InterruptedException {
@@ -76,7 +78,7 @@ public class CreateServerStep extends AbstractStepImpl {
         @Override
         protected Void run() throws Exception {
             String buildNumber = BuildUniqueIdentifierHelper.getBuildNumber(build);
-            DeclarativePipelineUtils.writeBuildDataFile(ws, buildNumber, step.buildDataFile, new JenkinsBuildInfoLog(listener));
+            DeclarativePipelineUtils.writeBuildDataFile(rootWs, buildNumber, step.buildDataFile, new JenkinsBuildInfoLog(listener));
             return null;
         }
     }

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/InteractivePromotionStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/InteractivePromotionStep.java
@@ -4,10 +4,10 @@ import com.google.inject.Inject;
 import hudson.Extension;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jfrog.hudson.pipeline.ArtifactorySynchronousStepExecution;
 import org.jfrog.hudson.pipeline.common.ArtifactoryConfigurator;
 import org.jfrog.hudson.pipeline.common.Utils;
 import org.jfrog.hudson.pipeline.common.types.ArtifactoryServer;
-import org.jfrog.hudson.pipeline.ArtifactorySynchronousStepExecution;
 import org.jfrog.hudson.pipeline.common.types.PromotionConfig;
 import org.jfrog.hudson.pipeline.declarative.utils.DeclarativePipelineUtils;
 import org.jfrog.hudson.release.promotion.UnifiedPromoteBuildAction;
@@ -39,7 +39,7 @@ public class InteractivePromotionStep extends PromoteBuildStep {
 
     public static class Execution extends ArtifactorySynchronousStepExecution<Boolean> {
 
-        private transient InteractivePromotionStep step;
+        private transient final InteractivePromotionStep step;
 
         @Inject
         public Execution(InteractivePromotionStep step, StepContext context) throws IOException, InterruptedException {
@@ -49,7 +49,7 @@ public class InteractivePromotionStep extends PromoteBuildStep {
 
         @Override
         protected Boolean run() throws Exception {
-            ArtifactoryServer server = DeclarativePipelineUtils.getArtifactoryServer(build, ws, getContext(), step.serverId);
+            ArtifactoryServer server = DeclarativePipelineUtils.getArtifactoryServer(build, rootWs, getContext(), step.serverId);
             ArtifactoryConfigurator configurator = new ArtifactoryConfigurator(Utils.prepareArtifactoryServer(null, server));
             addPromotionAction(configurator);
             return true;

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/PromoteBuildStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/PromoteBuildStep.java
@@ -4,11 +4,13 @@ import com.google.inject.Inject;
 import hudson.Extension;
 import hudson.model.Run;
 import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.plugins.workflow.steps.*;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jfrog.hudson.pipeline.ArtifactorySynchronousNonBlockingStepExecution;
 import org.jfrog.hudson.pipeline.common.Utils;
 import org.jfrog.hudson.pipeline.common.executors.PromotionExecutor;
 import org.jfrog.hudson.pipeline.common.types.ArtifactoryServer;
-import org.jfrog.hudson.pipeline.ArtifactorySynchronousNonBlockingStepExecution;
 import org.jfrog.hudson.pipeline.common.types.PromotionConfig;
 import org.jfrog.hudson.pipeline.declarative.utils.DeclarativePipelineUtils;
 import org.jfrog.hudson.util.BuildUniqueIdentifierHelper;
@@ -73,7 +75,7 @@ public class PromoteBuildStep extends AbstractStepImpl {
         promotionConfig.setFailFast(failFast);
     }
 
-    PromotionConfig preparePromotionConfig(Run build) {
+    PromotionConfig preparePromotionConfig(Run<?, ?> build) {
         if (StringUtils.isBlank(promotionConfig.getBuildName())) {
             promotionConfig.setBuildName(BuildUniqueIdentifierHelper.getBuildName(build));
         }
@@ -85,7 +87,7 @@ public class PromoteBuildStep extends AbstractStepImpl {
 
     public static class Execution extends ArtifactorySynchronousNonBlockingStepExecution<Void> {
 
-        private transient PromoteBuildStep step;
+        private transient final PromoteBuildStep step;
 
         @Inject
         public Execution(PromoteBuildStep step, StepContext context) throws IOException, InterruptedException {
@@ -96,7 +98,7 @@ public class PromoteBuildStep extends AbstractStepImpl {
         @Override
         protected Void run() throws Exception {
             PromotionConfig promotionConfig = step.preparePromotionConfig(build);
-            ArtifactoryServer server = DeclarativePipelineUtils.getArtifactoryServer(build, ws, getContext(), step.serverId);
+            ArtifactoryServer server = DeclarativePipelineUtils.getArtifactoryServer(build, rootWs, getContext(), step.serverId);
             new PromotionExecutor(Utils.prepareArtifactoryServer(null, server), build, listener, getContext(), promotionConfig).execute();
             return null;
         }

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/common/DeployerResolverBase.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/common/DeployerResolverBase.java
@@ -35,7 +35,7 @@ public class DeployerResolverBase extends AbstractStepImpl {
 
     public static class Execution extends ArtifactorySynchronousNonBlockingStepExecution<Void> {
 
-        private transient DeployerResolverBase step;
+        private transient final DeployerResolverBase step;
 
         @Inject
         public Execution(DeployerResolverBase step, StepContext context) throws IOException, InterruptedException {
@@ -46,7 +46,7 @@ public class DeployerResolverBase extends AbstractStepImpl {
         @Override
         protected Void run() throws Exception {
             String buildNumber = BuildUniqueIdentifierHelper.getBuildNumber(build);
-            writeBuildDataFile(ws, buildNumber, step.buildDataFile, new JenkinsBuildInfoLog(listener));
+            writeBuildDataFile(rootWs, buildNumber, step.buildDataFile, new JenkinsBuildInfoLog(listener));
             return null;
         }
     }

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/conan/ConanClientStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/conan/ConanClientStep.java
@@ -3,10 +3,12 @@ package org.jfrog.hudson.pipeline.declarative.steps.conan;
 import com.google.inject.Inject;
 import hudson.Extension;
 import hudson.FilePath;
-import org.jenkinsci.plugins.workflow.steps.*;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jfrog.hudson.pipeline.ArtifactorySynchronousNonBlockingStepExecution;
 import org.jfrog.hudson.pipeline.common.Utils;
 import org.jfrog.hudson.pipeline.common.executors.ConanExecutor;
-import org.jfrog.hudson.pipeline.ArtifactorySynchronousNonBlockingStepExecution;
 import org.jfrog.hudson.pipeline.declarative.BuildDataFile;
 import org.jfrog.hudson.pipeline.declarative.utils.DeclarativePipelineUtils;
 import org.jfrog.hudson.util.BuildUniqueIdentifierHelper;
@@ -19,8 +21,8 @@ import java.io.IOException;
 public class ConanClientStep extends AbstractStepImpl {
 
     static final String STEP_NAME = "rtConanClient";
+    private final BuildDataFile buildDataFile;
     private String userHome;
-    private BuildDataFile buildDataFile;
 
     @DataBoundConstructor
     public ConanClientStep(String id) {
@@ -35,7 +37,7 @@ public class ConanClientStep extends AbstractStepImpl {
 
     public static class Execution extends ArtifactorySynchronousNonBlockingStepExecution<Void> {
 
-        private transient ConanClientStep step;
+        private transient final ConanClientStep step;
 
         @Inject
         public Execution(ConanClientStep step, StepContext context) throws IOException, InterruptedException {
@@ -50,7 +52,7 @@ public class ConanClientStep extends AbstractStepImpl {
             ConanExecutor conanExecutor = new ConanExecutor(conanHomeDirectory.getRemote(), ws, launcher, listener, env, build);
             conanExecutor.execClientInit();
             String buildNumber = BuildUniqueIdentifierHelper.getBuildNumber(build);
-            DeclarativePipelineUtils.writeBuildDataFile(ws, buildNumber, step.buildDataFile, new JenkinsBuildInfoLog(listener));
+            DeclarativePipelineUtils.writeBuildDataFile(rootWs, buildNumber, step.buildDataFile, new JenkinsBuildInfoLog(listener));
             return null;
         }
     }

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/conan/ConanRemoteStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/conan/ConanRemoteStep.java
@@ -2,13 +2,15 @@ package org.jfrog.hudson.pipeline.declarative.steps.conan;
 
 import com.google.inject.Inject;
 import hudson.Extension;
-import org.jenkinsci.plugins.workflow.steps.*;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jfrog.hudson.CredentialsConfig;
+import org.jfrog.hudson.pipeline.ArtifactorySynchronousNonBlockingStepExecution;
 import org.jfrog.hudson.pipeline.common.ArtifactoryConfigurator;
 import org.jfrog.hudson.pipeline.common.Utils;
 import org.jfrog.hudson.pipeline.common.executors.ConanExecutor;
 import org.jfrog.hudson.pipeline.common.types.ArtifactoryServer;
-import org.jfrog.hudson.pipeline.ArtifactorySynchronousNonBlockingStepExecution;
 import org.jfrog.hudson.pipeline.common.types.ConanClient;
 import org.jfrog.hudson.pipeline.declarative.utils.DeclarativePipelineUtils;
 import org.jfrog.hudson.util.BuildUniqueIdentifierHelper;
@@ -20,10 +22,10 @@ import java.io.IOException;
 
 public class ConanRemoteStep extends AbstractStepImpl {
 
-    private String clientId;
-    private String name;
-    private String serverId;
-    private String repo;
+    private final String clientId;
+    private final String name;
+    private final String serverId;
+    private final String repo;
     private boolean force;
     private boolean verifySSL = true;
 
@@ -67,7 +69,7 @@ public class ConanRemoteStep extends AbstractStepImpl {
 
     public static class Execution extends ArtifactorySynchronousNonBlockingStepExecution<Void> {
 
-        private transient ConanRemoteStep step;
+        private transient final ConanRemoteStep step;
 
         @Inject
         public Execution(ConanRemoteStep step, StepContext context) throws IOException, InterruptedException {
@@ -78,9 +80,9 @@ public class ConanRemoteStep extends AbstractStepImpl {
         @Override
         protected Void run() throws Exception {
             String buildNumber = BuildUniqueIdentifierHelper.getBuildNumber(build);
-            ConanClient conanClient = DeclarativePipelineUtils.buildConanClient(step.getClientId(), buildNumber, ConanClientStep.STEP_NAME, launcher, ws, env);
+            ConanClient conanClient = DeclarativePipelineUtils.buildConanClient(step.getClientId(), buildNumber, ConanClientStep.STEP_NAME, launcher, ws, rootWs, env);
             ConanExecutor conanExecutor = new ConanExecutor(conanClient.getUserPath(), ws, launcher, listener, env, build);
-            ArtifactoryServer server = DeclarativePipelineUtils.getArtifactoryServer(build, ws, getContext(), step.serverId);
+            ArtifactoryServer server = DeclarativePipelineUtils.getArtifactoryServer(build, rootWs, getContext(), step.serverId);
             // Run conan add remote
             String serverUrl = Utils.buildConanRemoteUrl(server, step.getRepo());
             conanExecutor.execRemoteAdd(step.getName(), serverUrl, step.getForce(), step.getVerifySSL());

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/conan/ConanRunStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/conan/ConanRunStep.java
@@ -2,9 +2,11 @@ package org.jfrog.hudson.pipeline.declarative.steps.conan;
 
 import com.google.inject.Inject;
 import hudson.Extension;
-import org.jenkinsci.plugins.workflow.steps.*;
-import org.jfrog.hudson.pipeline.common.executors.ConanExecutor;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jfrog.hudson.pipeline.ArtifactorySynchronousNonBlockingStepExecution;
+import org.jfrog.hudson.pipeline.common.executors.ConanExecutor;
 import org.jfrog.hudson.pipeline.common.types.ConanClient;
 import org.jfrog.hudson.pipeline.common.types.buildInfo.BuildInfo;
 import org.jfrog.hudson.pipeline.declarative.utils.DeclarativePipelineUtils;
@@ -17,8 +19,8 @@ import java.io.IOException;
 
 public class ConanRunStep extends AbstractStepImpl {
 
-    private String clientId;
-    private String command;
+    private final String clientId;
+    private final String command;
     private String customBuildNumber;
     private String customBuildName;
 
@@ -48,7 +50,7 @@ public class ConanRunStep extends AbstractStepImpl {
 
     public static class Execution extends ArtifactorySynchronousNonBlockingStepExecution<Void> {
 
-        private transient ConanRunStep step;
+        private transient final ConanRunStep step;
 
         @Inject
         public Execution(ConanRunStep step, StepContext context) throws IOException, InterruptedException {
@@ -59,11 +61,11 @@ public class ConanRunStep extends AbstractStepImpl {
         @Override
         protected Void run() throws Exception {
             String buildNumber = BuildUniqueIdentifierHelper.getBuildNumber(build);
-            ConanClient conanClient = DeclarativePipelineUtils.buildConanClient(step.getClientId(), buildNumber, ConanClientStep.STEP_NAME, launcher, ws, env);
-            BuildInfo buildInfo = DeclarativePipelineUtils.getBuildInfo(ws, build, step.customBuildName, step.customBuildNumber);
+            ConanClient conanClient = DeclarativePipelineUtils.buildConanClient(step.getClientId(), buildNumber, ConanClientStep.STEP_NAME, launcher, ws, rootWs, env);
+            BuildInfo buildInfo = DeclarativePipelineUtils.getBuildInfo(rootWs, build, step.customBuildName, step.customBuildNumber);
             ConanExecutor conanExecutor = new ConanExecutor(buildInfo, conanClient.getUserPath(), ws, launcher, listener, env, build);
             conanExecutor.execCommand(step.getCommand());
-            DeclarativePipelineUtils.saveBuildInfo(conanExecutor.getBuildInfo(), ws, build, new JenkinsBuildInfoLog(listener));
+            DeclarativePipelineUtils.saveBuildInfo(conanExecutor.getBuildInfo(), rootWs, build, new JenkinsBuildInfoLog(listener));
             return null;
         }
 

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/docker/DockerPullStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/docker/DockerPullStep.java
@@ -55,7 +55,7 @@ public class DockerPullStep extends AbstractStepImpl {
 
     public static class Execution extends ArtifactorySynchronousNonBlockingStepExecution<Void> {
 
-        private transient DockerPullStep step;
+        private transient final DockerPullStep step;
 
         @Inject
         public Execution(DockerPullStep step, StepContext context) throws IOException, InterruptedException {
@@ -65,11 +65,11 @@ public class DockerPullStep extends AbstractStepImpl {
 
         @Override
         protected Void run() throws Exception {
-            BuildInfo buildInfo = DeclarativePipelineUtils.getBuildInfo(ws, build, step.buildName, step.buildNumber);
-            ArtifactoryServer pipelineServer = DeclarativePipelineUtils.getArtifactoryServer(build, ws, getContext(), step.serverId);
+            BuildInfo buildInfo = DeclarativePipelineUtils.getBuildInfo(rootWs, build, step.buildName, step.buildNumber);
+            ArtifactoryServer pipelineServer = DeclarativePipelineUtils.getArtifactoryServer(build, rootWs, getContext(), step.serverId);
             DockerPullExecutor dockerExecutor = new DockerPullExecutor(pipelineServer, buildInfo, build, step.image, step.sourceRepo, step.host, step.javaArgs, launcher, listener, ws, env);
             dockerExecutor.execute();
-            DeclarativePipelineUtils.saveBuildInfo(dockerExecutor.getBuildInfo(), ws, build, new JenkinsBuildInfoLog(listener));
+            DeclarativePipelineUtils.saveBuildInfo(dockerExecutor.getBuildInfo(), rootWs, build, new JenkinsBuildInfoLog(listener));
             return null;
         }
     }

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/docker/DockerPushStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/docker/DockerPushStep.java
@@ -23,13 +23,13 @@ import java.io.IOException;
 @SuppressWarnings("unused")
 public class DockerPushStep extends AbstractStepImpl {
 
-    private String serverId;
-    private String image;
+    private final ArrayListMultimap<String, String> properties = ArrayListMultimap.create();
+    private final String serverId;
+    private final String image;
+    private final String targetRepo;
     private String host;
     private String buildNumber;
     private String buildName;
-    private String targetRepo;
-    private ArrayListMultimap<String, String> properties = ArrayListMultimap.create();
     private String javaArgs;
 
     @DataBoundConstructor
@@ -74,7 +74,7 @@ public class DockerPushStep extends AbstractStepImpl {
 
     public static class Execution extends ArtifactorySynchronousNonBlockingStepExecution<Void> {
 
-        private transient DockerPushStep step;
+        private transient final DockerPushStep step;
 
         @Inject
         public Execution(DockerPushStep step, StepContext context) throws IOException, InterruptedException {
@@ -84,11 +84,11 @@ public class DockerPushStep extends AbstractStepImpl {
 
         @Override
         protected Void run() throws Exception {
-            BuildInfo buildInfo = DeclarativePipelineUtils.getBuildInfo(ws, build, step.buildName, step.buildNumber);
-            org.jfrog.hudson.pipeline.common.types.ArtifactoryServer pipelineServer = DeclarativePipelineUtils.getArtifactoryServer(build, ws, getContext(), step.serverId);
+            BuildInfo buildInfo = DeclarativePipelineUtils.getBuildInfo(rootWs, build, step.buildName, step.buildNumber);
+            org.jfrog.hudson.pipeline.common.types.ArtifactoryServer pipelineServer = DeclarativePipelineUtils.getArtifactoryServer(build, rootWs, getContext(), step.serverId);
             DockerPushExecutor dockerExecutor = new DockerPushExecutor(pipelineServer, buildInfo, build, step.image, step.targetRepo, step.host, step.javaArgs, launcher, step.properties, listener, ws, env);
             dockerExecutor.execute();
-            DeclarativePipelineUtils.saveBuildInfo(dockerExecutor.getBuildInfo(), ws, build, new JenkinsBuildInfoLog(listener));
+            DeclarativePipelineUtils.saveBuildInfo(dockerExecutor.getBuildInfo(), rootWs, build, new JenkinsBuildInfoLog(listener));
             return null;
         }
     }

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/generic/DeletePropsStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/generic/DeletePropsStep.java
@@ -1,14 +1,9 @@
 package org.jfrog.hudson.pipeline.declarative.steps.generic;
 
 import com.google.inject.Inject;
-import hudson.EnvVars;
 import hudson.Extension;
-import hudson.FilePath;
-import hudson.model.Run;
-import hudson.model.TaskListener;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
@@ -32,7 +27,7 @@ public class DeletePropsStep extends EditPropsStep {
 
         @Override
         protected Void run() throws Exception {
-            super.editPropsRun(build, listener, step, ws, env);
+            super.editPropsRun();
             return null;
         }
     }

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/generic/DownloadStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/generic/DownloadStep.java
@@ -1,14 +1,9 @@
 package org.jfrog.hudson.pipeline.declarative.steps.generic;
 
 import com.google.inject.Inject;
-import hudson.EnvVars;
 import hudson.Extension;
-import hudson.FilePath;
-import hudson.model.Run;
-import hudson.model.TaskListener;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 import org.jfrog.hudson.pipeline.common.executors.GenericDownloadExecutor;
 import org.jfrog.hudson.pipeline.common.types.buildInfo.BuildInfo;
 import org.jfrog.hudson.pipeline.common.types.buildInfo.BuildInfoAccessor;
@@ -35,12 +30,12 @@ public class DownloadStep extends GenericStep {
 
         @Override
         protected Void run() throws Exception {
-            setGenericParameters(listener, build, ws, env, step, getContext());
+            setGenericParameters(step, getContext());
             GenericDownloadExecutor genericDownloadExecutor = new GenericDownloadExecutor(artifactoryServer, listener, build, ws, buildInfo, spec, step.failNoOp, step.module);
             genericDownloadExecutor.execute();
             BuildInfo buildInfo = genericDownloadExecutor.getBuildInfo();
             new BuildInfoAccessor(buildInfo).captureVariables(env, build, listener);
-            DeclarativePipelineUtils.saveBuildInfo(buildInfo, ws, build, new JenkinsBuildInfoLog(listener));
+            DeclarativePipelineUtils.saveBuildInfo(buildInfo, rootWs, build, new JenkinsBuildInfoLog(listener));
             return null;
         }
     }

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/generic/EditPropsStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/generic/EditPropsStep.java
@@ -22,12 +22,12 @@ import static org.jfrog.build.extractor.clientConfiguration.util.EditPropertiesH
 
 @SuppressWarnings("unused")
 public class EditPropsStep extends AbstractStepImpl {
+    private final EditPropertiesActionType editType;
     protected String serverId;
     protected String spec;
     private String props;
     private String specPath;
     private boolean failNoOp;
-    private EditPropertiesActionType editType;
 
     EditPropsStep(String serverId, EditPropertiesActionType editType) {
         this.serverId = serverId;
@@ -66,10 +66,10 @@ public class EditPropsStep extends AbstractStepImpl {
             this.step = step;
         }
 
-        void editPropsRun(Run build, TaskListener listener, EditPropsStep step, FilePath ws, EnvVars env) throws IOException, InterruptedException {
+        void editPropsRun() throws IOException, InterruptedException {
             // Set Artifactory server
             org.jfrog.hudson.pipeline.common.types.ArtifactoryServer pipelineServer = DeclarativePipelineUtils
-                    .getArtifactoryServer(build, ws, getContext(), step.serverId);
+                    .getArtifactoryServer(build, rootWs, getContext(), step.serverId);
             artifactoryServer = Utils.prepareArtifactoryServer(null, pipelineServer);
 
             // Set spec

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/generic/GenericStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/generic/GenericStep.java
@@ -1,16 +1,12 @@
 package org.jfrog.hudson.pipeline.declarative.steps.generic;
 
 import com.google.inject.Inject;
-import hudson.EnvVars;
-import hudson.FilePath;
-import hudson.model.Run;
-import hudson.model.TaskListener;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jfrog.hudson.ArtifactoryServer;
 import org.jfrog.hudson.SpecConfiguration;
-import org.jfrog.hudson.pipeline.common.Utils;
 import org.jfrog.hudson.pipeline.ArtifactorySynchronousNonBlockingStepExecution;
+import org.jfrog.hudson.pipeline.common.Utils;
 import org.jfrog.hudson.pipeline.common.types.buildInfo.BuildInfo;
 import org.jfrog.hudson.pipeline.declarative.utils.DeclarativePipelineUtils;
 import org.jfrog.hudson.util.BuildUniqueIdentifierHelper;
@@ -81,7 +77,7 @@ public class GenericStep extends AbstractStepImpl {
             this.step = step;
         }
 
-        void setGenericParameters(TaskListener listener, Run build, FilePath ws, EnvVars env, GenericStep step, StepContext context) throws IOException, InterruptedException {
+        void setGenericParameters(GenericStep step, StepContext context) throws IOException, InterruptedException {
             String buildNumber = BuildUniqueIdentifierHelper.getBuildNumber(build);
 
             // Set spec
@@ -89,10 +85,10 @@ public class GenericStep extends AbstractStepImpl {
             spec = SpecUtils.getSpecStringFromSpecConf(specConfiguration, env, ws, listener.getLogger());
 
             // Set Build Info
-            buildInfo = DeclarativePipelineUtils.getBuildInfo(ws, build, step.customBuildName, step.customBuildNumber);
+            buildInfo = DeclarativePipelineUtils.getBuildInfo(rootWs, build, step.customBuildName, step.customBuildNumber);
 
             // Set Artifactory server
-            org.jfrog.hudson.pipeline.common.types.ArtifactoryServer pipelineServer = DeclarativePipelineUtils.getArtifactoryServer(build, ws, context, step.serverId);
+            org.jfrog.hudson.pipeline.common.types.ArtifactoryServer pipelineServer = DeclarativePipelineUtils.getArtifactoryServer(build, rootWs, context, step.serverId);
             artifactoryServer = Utils.prepareArtifactoryServer(null, pipelineServer);
         }
     }

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/generic/SetPropsStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/generic/SetPropsStep.java
@@ -1,14 +1,9 @@
 package org.jfrog.hudson.pipeline.declarative.steps.generic;
 
 import com.google.inject.Inject;
-import hudson.EnvVars;
 import hudson.Extension;
-import hudson.FilePath;
-import hudson.model.Run;
-import hudson.model.TaskListener;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
@@ -32,7 +27,7 @@ public class SetPropsStep extends EditPropsStep {
 
         @Override
         protected Void run() throws Exception {
-            super.editPropsRun(build, listener, step, ws, env);
+            super.editPropsRun();
             return null;
         }
     }

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/generic/UploadStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/generic/UploadStep.java
@@ -30,12 +30,12 @@ public class UploadStep extends GenericStep {
 
         @Override
         protected Void run() throws Exception {
-            setGenericParameters(listener, build, ws, env, step, getContext());
+            setGenericParameters(step, getContext());
             GenericUploadExecutor genericUploadExecutor = new GenericUploadExecutor(artifactoryServer, listener, build, ws, buildInfo, getContext(), spec, step.failNoOp, step.module);
             genericUploadExecutor.execute();
             BuildInfo buildInfo = genericUploadExecutor.getBuildInfo();
             new BuildInfoAccessor(buildInfo).captureVariables(env, build, listener);
-            DeclarativePipelineUtils.saveBuildInfo(buildInfo, ws, build, new JenkinsBuildInfoLog(listener));
+            DeclarativePipelineUtils.saveBuildInfo(buildInfo, rootWs, build, new JenkinsBuildInfoLog(listener));
             return null;
         }
     }

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/go/GoPublishStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/go/GoPublishStep.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 @SuppressWarnings("unused")
 public class GoPublishStep extends AbstractStepImpl {
 
-    private GoBuild goBuild;
+    private final GoBuild goBuild;
     private String customBuildNumber;
     private String customBuildName;
     private String deployerId;
@@ -75,7 +75,7 @@ public class GoPublishStep extends AbstractStepImpl {
 
     public static class Execution extends ArtifactorySynchronousNonBlockingStepExecution<Void> {
 
-        private transient GoPublishStep step;
+        private transient final GoPublishStep step;
 
         @Inject
         public Execution(GoPublishStep step, StepContext context) throws IOException, InterruptedException {
@@ -85,11 +85,11 @@ public class GoPublishStep extends AbstractStepImpl {
 
         @Override
         protected Void run() throws Exception {
-            BuildInfo buildInfo = DeclarativePipelineUtils.getBuildInfo(ws, build, step.customBuildName, step.customBuildNumber);
+            BuildInfo buildInfo = DeclarativePipelineUtils.getBuildInfo(rootWs, build, step.customBuildName, step.customBuildNumber);
             setDeployer(BuildUniqueIdentifierHelper.getBuildNumber(build));
             GoPublishExecutor goPublishExecutor = new GoPublishExecutor(getContext(), buildInfo, step.goBuild, step.path, step.version, step.module, ws, listener, build);
             goPublishExecutor.execute();
-            DeclarativePipelineUtils.saveBuildInfo(goPublishExecutor.getBuildInfo(), ws, build, new JenkinsBuildInfoLog(listener));
+            DeclarativePipelineUtils.saveBuildInfo(goPublishExecutor.getBuildInfo(), rootWs, build, new JenkinsBuildInfoLog(listener));
             return null;
         }
 
@@ -97,7 +97,7 @@ public class GoPublishStep extends AbstractStepImpl {
             if (StringUtils.isBlank(step.deployerId)) {
                 return;
             }
-            BuildDataFile buildDataFile = DeclarativePipelineUtils.readBuildDataFile(ws, buildNumber, GoDeployerStep.STEP_NAME, step.deployerId);
+            BuildDataFile buildDataFile = DeclarativePipelineUtils.readBuildDataFile(rootWs, buildNumber, GoDeployerStep.STEP_NAME, step.deployerId);
             if (buildDataFile == null) {
                 throw new IOException("Deployer " + step.deployerId + " doesn't exist!");
             }
@@ -119,7 +119,7 @@ public class GoPublishStep extends AbstractStepImpl {
             if (serverId.isNull()) {
                 throw new IllegalArgumentException("server ID is missing");
             }
-            return DeclarativePipelineUtils.getArtifactoryServer(build, ws, getContext(), serverId.asText());
+            return DeclarativePipelineUtils.getArtifactoryServer(build, rootWs, getContext(), serverId.asText());
         }
     }
 

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/gradle/GradleDeployerResolver.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/gradle/GradleDeployerResolver.java
@@ -34,7 +34,7 @@ public class GradleDeployerResolver extends AbstractStepImpl {
 
     public static class Execution extends ArtifactorySynchronousNonBlockingStepExecution<Void> {
 
-        private transient GradleDeployerResolver step;
+        private transient final GradleDeployerResolver step;
 
         @Inject
         public Execution(GradleDeployerResolver step, StepContext context) throws IOException, InterruptedException {
@@ -46,7 +46,7 @@ public class GradleDeployerResolver extends AbstractStepImpl {
         protected Void run() throws Exception {
             String buildNumber = BuildUniqueIdentifierHelper.getBuildNumber(build);
             BuildDataFile buildDataFile = step.buildDataFile;
-            writeBuildDataFile(ws, buildNumber, buildDataFile, new JenkinsBuildInfoLog(listener));
+            writeBuildDataFile(rootWs, buildNumber, buildDataFile, new JenkinsBuildInfoLog(listener));
             return null;
         }
     }

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/maven/MavenDeployerResolver.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/maven/MavenDeployerResolver.java
@@ -27,7 +27,7 @@ public class MavenDeployerResolver extends AbstractStepImpl {
 
     public static class Execution extends ArtifactorySynchronousNonBlockingStepExecution<Void> {
 
-        private transient MavenDeployerResolver step;
+        private transient final MavenDeployerResolver step;
 
         @Inject
         public Execution(MavenDeployerResolver step, StepContext context) throws IOException, InterruptedException {
@@ -39,7 +39,7 @@ public class MavenDeployerResolver extends AbstractStepImpl {
         protected Void run() throws Exception {
             String buildNumber = BuildUniqueIdentifierHelper.getBuildNumber(build);
             BuildDataFile buildDataFile = step.buildDataFile;
-            DeclarativePipelineUtils.writeBuildDataFile(ws, buildNumber, buildDataFile, new JenkinsBuildInfoLog(listener));
+            DeclarativePipelineUtils.writeBuildDataFile(rootWs, buildNumber, buildDataFile, new JenkinsBuildInfoLog(listener));
             return null;
         }
     }

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/nuget/NugetRunStepBase.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/nuget/NugetRunStepBase.java
@@ -68,7 +68,7 @@ abstract public class NugetRunStepBase extends AbstractStepImpl {
 
     public static class Execution extends ArtifactorySynchronousNonBlockingStepExecution<Void> {
 
-        private transient NugetRunStepBase step;
+        private transient final NugetRunStepBase step;
 
         @Inject
         public Execution(NugetRunStepBase step, StepContext context) throws IOException, InterruptedException {
@@ -78,11 +78,11 @@ abstract public class NugetRunStepBase extends AbstractStepImpl {
 
         @Override
         protected Void run() throws Exception {
-            BuildInfo buildInfo = DeclarativePipelineUtils.getBuildInfo(ws, build, step.customBuildName, step.customBuildNumber);
+            BuildInfo buildInfo = DeclarativePipelineUtils.getBuildInfo(rootWs, build, step.customBuildName, step.customBuildNumber);
             setResolver(BuildUniqueIdentifierHelper.getBuildNumber(build));
             NugetRunExecutor nugetRunExecutor = new NugetRunExecutor(buildInfo, launcher, step.nugetBuild, step.javaArgs, step.args, ws, step.module, env, listener, build);
             nugetRunExecutor.execute();
-            DeclarativePipelineUtils.saveBuildInfo(nugetRunExecutor.getBuildInfo(), ws, build, new JenkinsBuildInfoLog(listener));
+            DeclarativePipelineUtils.saveBuildInfo(nugetRunExecutor.getBuildInfo(), rootWs, build, new JenkinsBuildInfoLog(listener));
             return null;
         }
 
@@ -90,7 +90,7 @@ abstract public class NugetRunStepBase extends AbstractStepImpl {
             if (StringUtils.isBlank(step.resolverId)) {
                 return;
             }
-            BuildDataFile buildDataFile = DeclarativePipelineUtils.readBuildDataFile(ws, buildNumber, step.getResolverStepName(), step.resolverId);
+            BuildDataFile buildDataFile = DeclarativePipelineUtils.readBuildDataFile(rootWs, buildNumber, step.getResolverStepName(), step.resolverId);
             if (buildDataFile == null) {
                 throw new IOException("Resolver " + step.resolverId + " doesn't exist!");
             }
@@ -104,7 +104,7 @@ abstract public class NugetRunStepBase extends AbstractStepImpl {
             if (serverId.isNull()) {
                 throw new IllegalArgumentException("server ID is missing");
             }
-            return DeclarativePipelineUtils.getArtifactoryServer(build, ws, getContext(), serverId.asText());
+            return DeclarativePipelineUtils.getArtifactoryServer(build, rootWs, getContext(), serverId.asText());
         }
     }
 }

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/pip/PipInstallStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/pip/PipInstallStep.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  */
 public class PipInstallStep extends AbstractStepImpl {
 
-    private PipBuild pipBuild;
+    private final PipBuild pipBuild;
     private String customBuildNumber;
     private String customBuildName;
     private String resolverId;
@@ -79,7 +79,7 @@ public class PipInstallStep extends AbstractStepImpl {
 
     public static class Execution extends ArtifactorySynchronousNonBlockingStepExecution<Void> {
 
-        private transient PipInstallStep step;
+        private transient final PipInstallStep step;
 
         @Inject
         public Execution(PipInstallStep step, StepContext context) throws IOException, InterruptedException {
@@ -89,11 +89,11 @@ public class PipInstallStep extends AbstractStepImpl {
 
         @Override
         protected Void run() throws Exception {
-            BuildInfo buildInfo = DeclarativePipelineUtils.getBuildInfo(ws, build, step.customBuildName, step.customBuildNumber);
+            BuildInfo buildInfo = DeclarativePipelineUtils.getBuildInfo(rootWs, build, step.customBuildName, step.customBuildNumber);
             setResolver(BuildUniqueIdentifierHelper.getBuildNumber(build));
             PipInstallExecutor pipInstallExecutor = new PipInstallExecutor(buildInfo, launcher, step.pipBuild, step.javaArgs, step.args, ws, step.envActivation, step.module, env, listener, build);
             pipInstallExecutor.execute();
-            DeclarativePipelineUtils.saveBuildInfo(pipInstallExecutor.getBuildInfo(), ws, build, new JenkinsBuildInfoLog(listener));
+            DeclarativePipelineUtils.saveBuildInfo(pipInstallExecutor.getBuildInfo(), rootWs, build, new JenkinsBuildInfoLog(listener));
             return null;
         }
 
@@ -101,7 +101,7 @@ public class PipInstallStep extends AbstractStepImpl {
             if (StringUtils.isBlank(step.resolverId)) {
                 return;
             }
-            BuildDataFile buildDataFile = DeclarativePipelineUtils.readBuildDataFile(ws, buildNumber, PipResolverStep.STEP_NAME, step.resolverId);
+            BuildDataFile buildDataFile = DeclarativePipelineUtils.readBuildDataFile(rootWs, buildNumber, PipResolverStep.STEP_NAME, step.resolverId);
             if (buildDataFile == null) {
                 throw new IOException("Resolver " + step.resolverId + " doesn't exist!");
             }
@@ -115,7 +115,7 @@ public class PipInstallStep extends AbstractStepImpl {
             if (serverId.isNull()) {
                 throw new IllegalArgumentException("server ID is missing");
             }
-            return DeclarativePipelineUtils.getArtifactoryServer(build, ws, getContext(), serverId.asText());
+            return DeclarativePipelineUtils.getArtifactoryServer(build, rootWs, getContext(), serverId.asText());
         }
     }
 

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/xray/XrayScanStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/xray/XrayScanStep.java
@@ -4,10 +4,12 @@ import com.google.inject.Inject;
 import hudson.Extension;
 import hudson.model.Run;
 import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.plugins.workflow.steps.*;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jfrog.hudson.pipeline.ArtifactorySynchronousNonBlockingStepExecution;
 import org.jfrog.hudson.pipeline.common.executors.XrayExecutor;
 import org.jfrog.hudson.pipeline.common.types.ArtifactoryServer;
-import org.jfrog.hudson.pipeline.ArtifactorySynchronousNonBlockingStepExecution;
 import org.jfrog.hudson.pipeline.common.types.XrayScanConfig;
 import org.jfrog.hudson.pipeline.declarative.utils.DeclarativePipelineUtils;
 import org.jfrog.hudson.util.BuildUniqueIdentifierHelper;
@@ -23,8 +25,8 @@ import java.io.IOException;
 public class XrayScanStep extends AbstractStepImpl {
 
     public static final String STEP_NAME = "xrayScan";
-    private XrayScanConfig xrayScanConfig;
-    private String serverId;
+    private final XrayScanConfig xrayScanConfig;
+    private final String serverId;
 
     @DataBoundConstructor
     public XrayScanStep(String serverId) {
@@ -52,7 +54,7 @@ public class XrayScanStep extends AbstractStepImpl {
         xrayScanConfig.setPrintTable(printTable);
     }
 
-    private XrayScanConfig prepareXrayScanConfig(Run build) {
+    private XrayScanConfig prepareXrayScanConfig(Run<?, ?> build) {
         if (StringUtils.isBlank(xrayScanConfig.getBuildName())) {
             xrayScanConfig.setBuildName(BuildUniqueIdentifierHelper.getBuildName(build));
         }
@@ -64,7 +66,7 @@ public class XrayScanStep extends AbstractStepImpl {
 
     public static class Execution extends ArtifactorySynchronousNonBlockingStepExecution<Void> {
 
-        private transient XrayScanStep step;
+        private transient final XrayScanStep step;
 
         @Inject
         public Execution(XrayScanStep step, StepContext context) throws IOException, InterruptedException {
@@ -75,7 +77,7 @@ public class XrayScanStep extends AbstractStepImpl {
         @Override
         protected Void run() throws Exception {
             XrayScanConfig xrayScanConfig = step.prepareXrayScanConfig(build);
-            ArtifactoryServer server = DeclarativePipelineUtils.getArtifactoryServer(build, ws, getContext(), step.serverId);
+            ArtifactoryServer server = DeclarativePipelineUtils.getArtifactoryServer(build, rootWs, getContext(), step.serverId);
             XrayExecutor xrayExecutor = new XrayExecutor(xrayScanConfig, listener, server, build);
             xrayExecutor.execute();
             return null;


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----

Resolves #377 

Declarative steps can't work when 2 steps run in 2 different directories.
Currently, the workspace we use in the declarative and scripted steps is the actual directory the step run within.
~In this PR, the root workspace of the step will be used to store the information of the step (The "BuildDataFile").~
~There are 2 exceptions -~
~1. Collecting issues is still supposed to run in the actual sub-directory.~
~2. Collect VCS information during publishing build info should take place either in the sub-directory and the root workspace. That's to allow users to run a complete pipeline flow within a sub-directory and simultaneously support nested git repositories.~

In this PR, declarative pipeline temporary files will be under the root workspace dir