### PR TITLE
HAP - 1422 - Failed to report status to JFrog Pipelines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,15 +39,15 @@
         <!--Skip integration tests unless explicitly requested with -DskipITs=false-->
         <skipITs>true</skipITs>
 
-        <buildinfo.version>2.21.0</buildinfo.version>
-        <buildinfo.maven3.version>2.21.0</buildinfo.maven3.version>
-        <buildinfo.gradle.version>4.18.2</buildinfo.gradle.version>
-        <buildinfo.ivy.version>2.21.0</buildinfo.ivy.version>
-        <buildinfo.npm.version>2.21.0</buildinfo.npm.version>
-        <buildinfo.go.version>2.21.0</buildinfo.go.version>
-        <buildinfo.pip.version>2.21.0</buildinfo.pip.version>
-        <buildinfo.nuget.version>2.21.0</buildinfo.nuget.version>
-        <buildinfo.docker.version>2.21.0</buildinfo.docker.version>
+        <buildinfo.version>2.21.x-SNAPSHOT</buildinfo.version>
+        <buildinfo.maven3.version>2.21.x-SNAPSHOT</buildinfo.maven3.version>
+        <buildinfo.gradle.version>4.18.x-SNAPSHOT</buildinfo.gradle.version>
+        <buildinfo.ivy.version>2.21.x-SNAPSHOT</buildinfo.ivy.version>
+        <buildinfo.npm.version>2.21.x-SNAPSHOT</buildinfo.npm.version>
+        <buildinfo.go.version>2.21.x-SNAPSHOT</buildinfo.go.version>
+        <buildinfo.pip.version>2.21.x-SNAPSHOT</buildinfo.pip.version>
+        <buildinfo.nuget.version>2.21.x-SNAPSHOT</buildinfo.nuget.version>
+        <buildinfo.docker.version>2.21.x-SNAPSHOT</buildinfo.docker.version>
     </properties>
 
     <developers>

--- a/src/main/java/org/jfrog/hudson/generic/DependenciesDownloaderImpl.java
+++ b/src/main/java/org/jfrog/hudson/generic/DependenciesDownloaderImpl.java
@@ -71,8 +71,6 @@ public class DependenciesDownloaderImpl implements DependenciesDownloader {
             return child.act(new DownloadFileCallable(log));
         } catch (InterruptedException e) {
             log.warn("Caught interrupted exception: " + e.getLocalizedMessage());
-        } finally {
-            IOUtils.closeQuietly(is);
         }
 
         return null;
@@ -90,7 +88,7 @@ public class DependenciesDownloaderImpl implements DependenciesDownloader {
             }
 
             Map<String, String> checksumsMap = child.act(new DownloadFileCallable(log));
-            boolean isExists =  checksumsMap != null &&
+            boolean isExists = checksumsMap != null &&
                     StringUtils.isNotBlank(md5) && StringUtils.equals(md5, checksumsMap.get("md5")) &&
                     StringUtils.isNotBlank(sha1) && StringUtils.equals(sha1, checksumsMap.get("sha1"));
             if (isExists) {
@@ -133,7 +131,7 @@ public class DependenciesDownloaderImpl implements DependenciesDownloader {
         }
     }
 
-    public void setFlatDownload(boolean flat){
+    public void setFlatDownload(boolean flat) {
         this.flatDownload = flat;
     }
 

--- a/src/main/java/org/jfrog/hudson/pipeline/common/executors/BuildAppendExecutor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/executors/BuildAppendExecutor.java
@@ -4,6 +4,7 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.jfrog.build.api.Build;
 import org.jfrog.build.api.builder.ModuleBuilder;
 import org.jfrog.build.api.builder.ModuleType;
@@ -107,10 +108,11 @@ public class BuildAppendExecutor implements Executor {
         String buildInfoPath = server.getArtifactoryUrl() + "/artifactory-build-info/" + encodedBuildName + "/" + encodedBuildNumber + "-" + timestamp + ".json";
         try (ArtifactoryDependenciesClient client = server.createArtifactoryDependenciesClient(credentials, createProxyConfiguration(), listener)) {
             // getArtifactMetadata return null response entity - there's no need to consume it
-            HttpResponse response = client.getArtifactMetadata(buildInfoPath);
-            moduleBuilder
-                    .sha1(readHeader(response, buildInfoPath, SHA1_HEADER_NAME))
-                    .md5(readHeader(response, buildInfoPath, MD5_HEADER_NAME));
+            try (CloseableHttpResponse response = client.getArtifactMetadata(buildInfoPath)) {
+                moduleBuilder
+                        .sha1(readHeader(response, buildInfoPath, SHA1_HEADER_NAME))
+                        .md5(readHeader(response, buildInfoPath, MD5_HEADER_NAME));
+            }
         }
     }
 

--- a/src/test/java/org/jfrog/hudson/jfpipelines/JFrogPipelinesHttpClientTest.java
+++ b/src/test/java/org/jfrog/hudson/jfpipelines/JFrogPipelinesHttpClientTest.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import hudson.model.Result;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.jfrog.build.client.Version;
 import org.jfrog.build.util.VersionCompatibilityType;
 import org.jfrog.build.util.VersionException;
@@ -131,8 +131,8 @@ public class JFrogPipelinesHttpClientTest {
         Map<String, String> jobInfo = new HashMap<String, String>() {{
             put("a", "b");
         }};
-        try (JFrogPipelinesHttpClient client = createClient("http://httpbin.org/post")) {
-            HttpResponse response = client.sendStatus(new JobStatusPayload(Result.SUCCESS.toExportedObject(), "5", jobInfo, null));
+        try (JFrogPipelinesHttpClient client = createClient("http://httpbin.org/post");
+             CloseableHttpResponse response = client.sendStatus(new JobStatusPayload(Result.SUCCESS.toExportedObject(), "5", jobInfo, null))) {
             assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
             try (InputStream content = response.getEntity().getContent()) {
                 JsonNode requestTree = createMapper().readTree(content);
@@ -165,8 +165,8 @@ public class JFrogPipelinesHttpClientTest {
     @Test
     public void sendStatusOutputResourcesTest() {
         String outputResources = "[{\"content\":{\"a\":\"b\"},\"name\":\"resource1\"},{\"content\":{\"c\":\"d\"},\"name\":\"resource2\"}]";
-        try (JFrogPipelinesHttpClient client = createClient("http://httpbin.org/post")) {
-            HttpResponse response = client.sendStatus(new JobStatusPayload(Result.SUCCESS.toExportedObject(), "5", new HashMap<>(), OutputResource.fromString(outputResources)));
+        try (JFrogPipelinesHttpClient client = createClient("http://httpbin.org/post");
+             CloseableHttpResponse response = client.sendStatus(new JobStatusPayload(Result.SUCCESS.toExportedObject(), "5", new HashMap<>(), OutputResource.fromString(outputResources)))) {
             assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
             try (InputStream content = response.getEntity().getContent()) {
                 JsonNode requestTree = createMapper().readTree(content);


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----

Depends on: https://github.com/jfrog/build-info/pull/424

The root cause of this issue is closing the HTTP client before closing the HTTP response.

HttpResponse and HttpEntity should be closed before closing the HttpClient. I changed all HTTP requests to make sure all responses are closed properly.
 