### PR TITLE
HAP-1423 - Deployed Maven Artifacts summary is missing repository in path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,15 +39,15 @@
         <!--Skip integration tests unless explicitly requested with -DskipITs=false-->
         <skipITs>true</skipITs>
 
-        <buildinfo.version>2.21.0</buildinfo.version>
-        <buildinfo.maven3.version>2.21.0</buildinfo.maven3.version>
-        <buildinfo.gradle.version>4.18.2</buildinfo.gradle.version>
-        <buildinfo.ivy.version>2.21.0</buildinfo.ivy.version>
-        <buildinfo.npm.version>2.21.0</buildinfo.npm.version>
-        <buildinfo.go.version>2.21.0</buildinfo.go.version>
-        <buildinfo.pip.version>2.21.0</buildinfo.pip.version>
-        <buildinfo.nuget.version>2.21.0</buildinfo.nuget.version>
-        <buildinfo.docker.version>2.21.0</buildinfo.docker.version>
+        <buildinfo.version>2.21.x-SNAPSHOT</buildinfo.version>
+        <buildinfo.maven3.version>2.21.x-SNAPSHOT</buildinfo.maven3.version>
+        <buildinfo.gradle.version>4.18.x-SNAPSHOT</buildinfo.gradle.version>
+        <buildinfo.ivy.version>2.21.x-SNAPSHOT</buildinfo.ivy.version>
+        <buildinfo.npm.version>2.21.x-SNAPSHOT</buildinfo.npm.version>
+        <buildinfo.go.version>2.21.x-SNAPSHOT</buildinfo.go.version>
+        <buildinfo.pip.version>2.21.x-SNAPSHOT</buildinfo.pip.version>
+        <buildinfo.nuget.version>2.21.x-SNAPSHOT</buildinfo.nuget.version>
+        <buildinfo.docker.version>2.21.x-SNAPSHOT</buildinfo.docker.version>
     </properties>
 
     <developers>

--- a/src/main/java/org/jfrog/hudson/pipeline/action/DeployedMavenArtifact.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/action/DeployedMavenArtifact.java
@@ -6,17 +6,19 @@ public class DeployedMavenArtifact implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private final String artifactoryUrl;
+    private final String repository;
     private final String remotePath;
     private final String name;
 
-    public DeployedMavenArtifact(String artifactoryUrl, String remotePath, String name) {
+    public DeployedMavenArtifact(String artifactoryUrl, String repository, String remotePath, String name) {
         this.artifactoryUrl = artifactoryUrl;
+        this.repository = repository;
         this.remotePath = remotePath;
         this.name = name;
     }
 
     public String getUrl() {
-        return this.artifactoryUrl + "/" + this.remotePath;
+        return this.artifactoryUrl + "/" + this.repository + "/" + this.remotePath;
     }
 
     public String getDisplayName() {

--- a/src/main/java/org/jfrog/hudson/pipeline/action/DeployedMavenArtifactsAction.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/action/DeployedMavenArtifactsAction.java
@@ -2,7 +2,6 @@ package org.jfrog.hudson.pipeline.action;
 
 import hudson.model.Run;
 import jenkins.model.RunAction2;
-import org.jfrog.build.api.Artifact;
 
 import javax.annotation.Nonnull;
 import java.util.Collection;
@@ -11,7 +10,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Adds a list of the deployed maven artifacts in the summary of a pipeline job.
- * */
+ */
 public class DeployedMavenArtifactsAction implements RunAction2 {
     private Run build;
     private final List<DeployedMavenArtifact> deployedMavenArtifacts = new CopyOnWriteArrayList<>();
@@ -54,8 +53,7 @@ public class DeployedMavenArtifactsAction implements RunAction2 {
         return this.deployedMavenArtifacts;
     }
 
-    public void addDeployedMavenArtifacts(String artifactoryUrl, List<Artifact> deployed) {
-       deployed.forEach(artifact ->
-           deployedMavenArtifacts.add(new DeployedMavenArtifact(artifactoryUrl, artifact.getRemotePath(), artifact.getName())));
+    public void appendDeployedMavenArtifacts(List<DeployedMavenArtifact> deployed) {
+        deployedMavenArtifacts.addAll(deployed);
     }
 }

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/deployers/MavenDeployer.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/deployers/MavenDeployer.java
@@ -8,15 +8,14 @@ import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jfrog.build.api.Artifact;
 import org.jfrog.build.api.Module;
-import org.jfrog.build.api.builder.ArtifactBuilder;
 import org.jfrog.build.extractor.clientConfiguration.deploy.DeployDetails;
 import org.jfrog.build.extractor.clientConfiguration.util.DeploymentUrlUtils;
 import org.jfrog.hudson.RepositoryConf;
 import org.jfrog.hudson.ServerDetails;
 import org.jfrog.hudson.action.ActionableHelper;
+import org.jfrog.hudson.pipeline.action.DeployedMavenArtifact;
 import org.jfrog.hudson.pipeline.action.DeployedMavenArtifactsAction;
 import org.jfrog.hudson.pipeline.common.types.ArtifactoryServer;
-import org.jfrog.hudson.util.ExtractorUtils;
 import org.jfrog.hudson.util.publisher.PublisherContext;
 
 import java.io.UnsupportedEncodingException;
@@ -31,7 +30,7 @@ public class MavenDeployer extends Deployer {
     private String snapshotRepo;
     private String releaseRepo;
     private boolean deployEvenIfUnstable = false;
-    public final static MavenDeployer EMPTY_DEPLOYER;
+    public static final MavenDeployer EMPTY_DEPLOYER;
 
     static {
         EMPTY_DEPLOYER = createEmptyDeployer();
@@ -121,11 +120,17 @@ public class MavenDeployer extends Deployer {
      * Adds artifacts from the provided modules to the Deployed Maven Artifacts Summary Action.
      */
     public static void addDeployedArtifactsActionFromModules(Run build, String artifactoryUrl, List<Module> modules) {
+        List<DeployedMavenArtifact> curArtifacts = Lists.newArrayList();
         for (Module module : modules) {
-            if (module.getArtifacts() != null) {
-                addDeployedArtifactsAction(build, artifactoryUrl, module.getArtifacts());
+            if (module.getArtifacts() == null) {
+                continue;
+            }
+            for (Artifact artifact : module.getArtifacts()) {
+                curArtifacts.add(new DeployedMavenArtifact(artifactoryUrl, module.getRepository(),
+                        artifact.getRemotePath(), artifact.getName()));
             }
         }
+        addDeployedArtifactsToAction(build, curArtifacts);
     }
 
     /**
@@ -133,20 +138,16 @@ public class MavenDeployer extends Deployer {
      */
     public static void addDeployedArtifactsActionFromDetails(Run build, String artifactoryUrl, Map<String, Set<DeployDetails>> deployableArtifactsByModule) {
         deployableArtifactsByModule.forEach((module, detailsSet) -> {
+            // Add only if whole module contains maven artifacts.
             boolean isMaven = true;
-            List<Artifact> curArtifacts = Lists.newArrayList();
+            List<DeployedMavenArtifact> curArtifacts = Lists.newArrayList();
             for (DeployDetails curDetails : detailsSet) {
                 isMaven = (curDetails.getPackageType() == DeployDetails.PackageType.MAVEN) && isMaven;
-                Artifact artifact = new ArtifactBuilder(FilenameUtils.getName(curDetails.getArtifactPath()))
-                        .md5(curDetails.getMd5())
-                        .sha1(curDetails.getSha1())
-                        .type(FilenameUtils.getExtension(curDetails.getArtifactPath()))
-                        .remotePath(curDetails.getTargetRepository() + "/" + curDetails.getArtifactPath())
-                        .build();
-                curArtifacts.add(artifact);
+                curArtifacts.add(new DeployedMavenArtifact(artifactoryUrl, curDetails.getTargetRepository(),
+                        curDetails.getArtifactPath(), FilenameUtils.getName(curDetails.getArtifactPath())));
             }
             if (isMaven) {
-                addDeployedArtifactsAction(build, artifactoryUrl, curArtifacts);
+                addDeployedArtifactsToAction(build, curArtifacts);
             }
         });
     }
@@ -155,7 +156,10 @@ public class MavenDeployer extends Deployer {
      * Adds the provided artifacts to the Deployed Maven Artifacts Summary Action.
      * If such action was not initialized yet, initialize a new one.
      */
-    public static void addDeployedArtifactsAction(Run build, String artifactoryUrl, List<Artifact> mavenArtifacts) {
+    public static void addDeployedArtifactsToAction(Run build, List<DeployedMavenArtifact> mavenArtifacts) {
+        if (mavenArtifacts.isEmpty()) {
+            return;
+        }
         synchronized (build.getAllActions()) {
             DeployedMavenArtifactsAction action = build.getAction(DeployedMavenArtifactsAction.class);
             // Initialize action if haven't done so yet.
@@ -163,7 +167,7 @@ public class MavenDeployer extends Deployer {
                 action = new DeployedMavenArtifactsAction(build);
                 build.addAction(action);
             }
-            action.addDeployedMavenArtifacts(artifactoryUrl, mavenArtifacts);
+            action.appendDeployedMavenArtifacts(mavenArtifacts);
         }
     }
 }

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/deployers/MavenDeployer.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/deployers/MavenDeployer.java
@@ -139,16 +139,15 @@ public class MavenDeployer extends Deployer {
     public static void addDeployedArtifactsActionFromDetails(Run build, String artifactoryUrl, Map<String, Set<DeployDetails>> deployableArtifactsByModule) {
         deployableArtifactsByModule.forEach((module, detailsSet) -> {
             // Add only if whole module contains maven artifacts.
-            boolean isMaven = true;
             List<DeployedMavenArtifact> curArtifacts = Lists.newArrayList();
             for (DeployDetails curDetails : detailsSet) {
-                isMaven = (curDetails.getPackageType() == DeployDetails.PackageType.MAVEN) && isMaven;
+                if (curDetails.getPackageType() != DeployDetails.PackageType.MAVEN) {
+                    return;
+                }
                 curArtifacts.add(new DeployedMavenArtifact(artifactoryUrl, curDetails.getTargetRepository(),
                         curDetails.getArtifactPath(), FilenameUtils.getName(curDetails.getArtifactPath())));
             }
-            if (isMaven) {
-                addDeployedArtifactsToAction(build, curArtifacts);
-            }
+            addDeployedArtifactsToAction(build, curArtifacts);
         });
     }
 


### PR DESCRIPTION
Due to the removal of the repository from the remote path of artifacts in [jfrog/build-info#398](https://github.com/jfrog/build-info/pull/398), the repository was missing in the path of the artifacts in the summary.
Fixes #391.