### PR TITLE
Conan - Fix incorrect quotation marks

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/common/executors/ConanExecutor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/executors/ConanExecutor.java
@@ -61,8 +61,7 @@ public class ConanExecutor implements Executor {
     public void execClientInit() throws Exception {
         this.conanCmdArgs = new ArgumentListBuilder();
         conanCmdArgs.addTokenized(CONAN_CONFIG_SET_CMD);
-        // We need to add quotation marks before we save the log file path
-        conanCmdArgs.add("log.trace_file=\"" + StringUtils.trim(getLogFilePath()) + "\"");
+        conanCmdArgs.add("log.trace_file=" + StringUtils.trim(getLogFilePath()));
         execute();
     }
 


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----
When running Artifactory.newConanClient() on docker in Jenkins the pipeline fails. 
Fixes: https://github.com/jfrog/jenkins-artifactory-plugin/issues/378