### PR TITLE
Added "All Builds" in promotion

### DIFF
--- a/src/main/resources/lib/jfrog/promotions/promotions.js
+++ b/src/main/resources/lib/jfrog/promotions/promotions.js
@@ -15,6 +15,12 @@ function loadBuild(buildData) {
     if (!buildId) {
         displayErrorResponse(spinner, target, "Please choose a build");
     } else {
+        if (buildId === "all") {
+            showForm(false)
+            return;
+        } else {
+            showForm(true);
+        }
         res = JSON.parse(buildData);
         if (!res.success) {
             displayErrorResponse(spinner, target, res["responseMessage"]);
@@ -48,6 +54,31 @@ function loadBuild(buildData) {
         fillNonePluginFormDefaultValues(promotionConfig, selectTarget, selectSource);
         selectPlugin.onchange();
         spinner.style.display = "none";
+    }
+}
+
+function showForm(show) {
+    var elements = [
+        document.getElementById("pluginList"),
+        document.getElementById("targetStatus"),
+        document.getElementById("promotionComment"),
+        document.getElementById("targetRepositoryKey"),
+        document.getElementById("sourceRepositoryKey"),
+        document.getElementById("includeDependencies"),
+        document.getElementById("useCopy"),
+        document.getElementById("failFast")
+    ];
+
+    if (show) {
+        elements.forEach(function (value, index, array){
+            value.removeAttribute("field-disabled");
+            value.removeAttribute("disabled");
+        });
+    } else {
+        elements.forEach(function (value, index, array){
+            value.setAttribute("field-disabled", "true");
+            value.setAttribute("disabled", "true");
+        });
     }
 }
 

--- a/src/main/resources/org/jfrog/hudson/release/promotion/UnifiedPromoteBuildAction/form.jelly
+++ b/src/main/resources/org/jfrog/hudson/release/promotion/UnifiedPromoteBuildAction/form.jelly
@@ -20,6 +20,7 @@
                                      help="/plugin/artifactory/help/release/PromoteBuildAction/help-build.html">
                                 <select class="setting-input" name="promotionCandidates"
                                         id="buildId" onchange="loadBuild('${it.buildsData}')">
+                                    <option value="all">All Builds</option>
                                     <j:forEach var="promotionCandidate"
                                                items="${it.promotionCandidates}">
                                         <option value="${promotionCandidate.id}">


### PR DESCRIPTION
When building packages for multiple operating systems i need to upload artifacts to multiple repositories, this leads to multiple promotions configs. I would like to have a "one click" promotion even for these cases, to avoid human error as much as possible.

This commit adds a "All Builds" option in the promotion form when multiple builds are available. When "all" is selected you cannot change any configuration and will promote every saved configuration sequentially, you can still select any specific build and modify any configuration.

On the technical side, the code changes the `PromoteWorkerThread` to accept a list of `PromotionInstruction`, in "all" case all the builds are passed to thread while in the single build case only the specific build is passed.

- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----
