### PR TITLE
Improve root workspace detection from flow

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
@@ -83,21 +83,29 @@ public class Utils {
         return ObjectUtils.defaultIfNull(ws, cwd);
     }
 
+    /**
+     * Walk all flow nodes and find the top most workspace action. This
+     * action would represent the root workspace for the workflow run.
+     *
+     * @param execution the execution of the workflow run.
+     * @return the root workspace from the flow node tree, or null if none exist.
+     */
     private static FilePath extractRootWorkspaceFromFlow(FlowExecution execution) {
         if (execution == null) {
             return null;
         }
         FlowGraphWalker flowWalker = new FlowGraphWalker(execution);
+        FilePath rootPath = null;
         for (FlowNode node : flowWalker) {
             WorkspaceAction workspaceAction = node.getAction(WorkspaceAction.class);
             if (workspaceAction != null) {
                 FilePath rootWorkspace = workspaceAction.getWorkspace();
                 if (rootWorkspace != null) {
-                    return rootWorkspace;
+                    rootPath = rootWorkspace;
                 }
             }
         }
-        return null;
+        return rootPath;
     }
 
     /**

--- a/src/test/resources/integration/pipelines/declarative/maven.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/maven.pipeline
@@ -37,13 +37,17 @@ node("TestSlave") {
     stage "Copy project example"
     FileUtils.copyDirectory(Paths.get("${MAVEN_PROJECT_PATH}").toFile(), Paths.get(pwd(), "declarative-maven-example").toFile())
 
-    stage "Config Build Info"
-    rtBuildInfo(
-            buildName: buildName,
-            buildNumber: buildNumber,
-            captureEnv: true,
-            excludeEnvPatterns: ["DONT_COLLECT"]
-    )
+
+    // Should still locate the build info for this run
+    dir('inner') {
+        stage "Config Build Info"
+        rtBuildInfo(
+                buildName: buildName,
+                buildNumber: buildNumber,
+                captureEnv: true,
+                excludeEnvPatterns: ["DONT_COLLECT"]
+        )
+    }
 
     stage "Run maven"
     rtMavenRun(


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----

This [change](https://github.com/jfrog/jenkins-artifactory-plugin/pull/382) broke some workflows we have when the declarative build info for a workflow run is run multiple times in parallel.

This is due to a [lease process](https://github.com/jenkinsci/workflow-durable-task-step-plugin/blob/9b1f30448d565ad49ddabd1faa2624557ca81582/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java#L830) that builds a dynamic workspace path for each workflow run. When this allocation happens the current root workspace is discovered as the same for all build runs. When this happens our pipeline then deletes all of the temp directories created in the pipeline and one build run then deletes the build info from another and we get a failure.

```
org.jfrog.hudson.pipeline.common.executors.GetArtifactoryServerExecutor$ServerNotFoundException: Couldn't find Artifactory server with ID: cernerrepos-kc-corp
```