### PR TITLE
HAP-1457 - Repositories not saved in freestyle legacy pattern jobs

### DIFF
--- a/src/main/resources/lib/jfrog/dynamicRepos.jelly
+++ b/src/main/resources/lib/jfrog/dynamicRepos.jelly
@@ -43,6 +43,7 @@
                  help="${helpUrl}">
             <j:choose>
                 <j:when test="${s.serverId==instance.deployerDetails.artifactoryName ||
+                                s.serverId==instance.legacyDeployerDetails.artifactoryName ||
                                 s.serverId==instance.resolverDetails.artifactoryName}">
                     <input type="text" name="keyFromText" style="float: left; width: 85%; display: none;"
                            class="setting-input"

--- a/src/main/resources/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator/config.jelly
@@ -233,7 +233,6 @@
                             </f:entry>
                         </r:blockWrapper>
                         <st:adjunct includes="lib.jfrog.repos.repos"/>
-                        <st:adjunct includes="lib.jfrog.repos.genericConfig"/>
                     </f:block>
                 </j:otherwise>
             </j:choose>


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----

Resolves #434 