### PR TITLE
Fix - tests fail after upgrade go version to 1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Before running the integration tests, set the following environment variables.
 *GRADLE_HOME* - The local gradle installation path).<br>
 
 To disable build scan with Xray integration tests, set *JENKINS_XRAY_TEST_ENABLE* to *false*.
+Go tests require Go v1.14 or above.
 
 Run the integration tests.
 ```

--- a/src/test/resources/integration/pipelines/declarative/go.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/go.pipeline
@@ -39,7 +39,7 @@ node("TestSlave") {
             buildNumber: buildNumber,
             path: 'declarative-go-example',
             resolverId: "GO_RESOLVER",
-            args: "build"
+            args: "build -mod=mod"
     )
 
     stage "Go Publish"

--- a/src/test/resources/integration/pipelines/declarative/goCustomModuleName.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/goCustomModuleName.pipeline
@@ -39,7 +39,7 @@ node("TestSlave") {
             buildNumber: buildNumber,
             path: 'declarative-go-example',
             resolverId: "GO_RESOLVER",
-            args: "build",
+            args: "build -mod=mod",
             module: "my-Go-module"
     )
 

--- a/src/test/resources/integration/pipelines/scripted/go.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/go.pipeline
@@ -21,7 +21,7 @@ node("TestSlave") {
     FileUtils.copyDirectory(Paths.get("${GO_PROJECT_PATH}").toFile(), Paths.get(pwd(), "scripted-go-example").toFile())
 
     stage "Go build"
-    rtGo.run args: "build", buildInfo: buildInfo, path: "scripted-go-example"
+    rtGo.run args: "build -mod=mod", buildInfo: buildInfo, path: "scripted-go-example"
 
 
     stage "Go publish"

--- a/src/test/resources/integration/pipelines/scripted/goCustomModuleName.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/goCustomModuleName.pipeline
@@ -21,7 +21,7 @@ node("TestSlave") {
     FileUtils.copyDirectory(Paths.get("${GO_PROJECT_PATH}").toFile(), Paths.get(pwd(), "scripted-go-example").toFile())
 
     stage "Go build"
-    rtGo.run args: "build", buildInfo: buildInfo, path: "scripted-go-example", module: "my-Go-module"
+    rtGo.run args: "build -mod=mod", buildInfo: buildInfo, path: "scripted-go-example", module: "my-Go-module"
 
 
     stage "Go publish"


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----
Related PR: https://github.com/jfrog/build-info/pull/464