### PR TITLE
[JENKINS-65424] - Maven descriptor step arguments documentation

### DIFF
--- a/src/main/resources/org/jfrog/hudson/pipeline/scripted/steps/MavenDescriptorStep/help-dryRun.html
+++ b/src/main/resources/org/jfrog/hudson/pipeline/scripted/steps/MavenDescriptorStep/help-dryRun.html
@@ -1,0 +1,4 @@
+<div>
+    If set to <code>true</code>, changes will not take effect.
+    Simulated only, not real.
+</div>

--- a/src/main/resources/org/jfrog/hudson/pipeline/scripted/steps/MavenDescriptorStep/help-failOnSnapshot.html
+++ b/src/main/resources/org/jfrog/hudson/pipeline/scripted/steps/MavenDescriptorStep/help-failOnSnapshot.html
@@ -1,0 +1,3 @@
+<div>
+    If set to <code>true</code>, the build should be failed if a snapshot is found.
+</div>

--- a/src/main/resources/org/jfrog/hudson/pipeline/scripted/steps/MavenDescriptorStep/help-pomFile.html
+++ b/src/main/resources/org/jfrog/hudson/pipeline/scripted/steps/MavenDescriptorStep/help-pomFile.html
@@ -1,0 +1,10 @@
+<div>
+    If your workspace has the top-level <code>pom.xml</code> in somewhere other than the 1st module's root directory, specify the path (relative to the module root) here, such as <code>parent/pom.xml</code>.
+    If left empty, defaults to <code>pom.xml</code>.
+    <p>
+        Example:
+        <pre>
+            <code>maven-example/pom.xml</code>
+        </pre>
+    </p>
+</div>

--- a/src/main/resources/org/jfrog/hudson/pipeline/scripted/steps/MavenDescriptorStep/help-version.html
+++ b/src/main/resources/org/jfrog/hudson/pipeline/scripted/steps/MavenDescriptorStep/help-version.html
@@ -1,0 +1,6 @@
+<div>
+    Specify the Maven version.
+    <p>
+        Example: <pre>M3</pre>
+    </p>
+</div>

--- a/src/main/resources/org/jfrog/hudson/pipeline/scripted/steps/MavenDescriptorStep/help-versionPerModule.html
+++ b/src/main/resources/org/jfrog/hudson/pipeline/scripted/steps/MavenDescriptorStep/help-versionPerModule.html
@@ -1,0 +1,3 @@
+<div>
+    For each module, specify the target versions.
+</div>


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.

- [x] Please describe what you did
- Created `help-pomFile.html` file to add `pomFile` argument's description.
- Created `help-version.html` file to add `version` argument's description. 
- Created `help-versionPerModule.html` file to add `versionPerModule` argument's description. 
- Created `help-failOnSnapshot.html` file to add `failOnSnapshot` argument's description. 
- Created `help-dryRun.html` file to add `dryRun` argument's description. 

- [x] Link to relevant issues in GitHub or Jira
- [JENKINS-65424](https://issues.jenkins.io/browse/JENKINS-65424)

  @MarkEWaite @oleg-nenashev @kwhetstone @StackScribe
-----
