### PR TITLE
[JENKINS-65441] - Add online help for rtGradleRun arguments

### DIFF
--- a/src/main/resources/org/jfrog/hudson/pipeline/declarative/steps/gradle/GradleStep/help-buildFile.html
+++ b/src/main/resources/org/jfrog/hudson/pipeline/declarative/steps/gradle/GradleStep/help-buildFile.html
@@ -1,0 +1,3 @@
+<div>
+    If your Gradle build script is not named <code>build.gradle</code>, specify the gradle build name script.
+</div>

--- a/src/main/resources/org/jfrog/hudson/pipeline/declarative/steps/gradle/GradleStep/help-buildName.html
+++ b/src/main/resources/org/jfrog/hudson/pipeline/declarative/steps/gradle/GradleStep/help-buildName.html
@@ -1,0 +1,4 @@
+<div>
+    Optional build name.
+    If not set, the Jenkins job's build name is used.
+</div>

--- a/src/main/resources/org/jfrog/hudson/pipeline/declarative/steps/gradle/GradleStep/help-buildNumber.html
+++ b/src/main/resources/org/jfrog/hudson/pipeline/declarative/steps/gradle/GradleStep/help-buildNumber.html
@@ -1,0 +1,4 @@
+<div>
+    Optional build number.
+    If not set, the Jenkins job's build number is used.
+</div>

--- a/src/main/resources/org/jfrog/hudson/pipeline/declarative/steps/gradle/GradleStep/help-deployerId.html
+++ b/src/main/resources/org/jfrog/hudson/pipeline/declarative/steps/gradle/GradleStep/help-deployerId.html
@@ -1,0 +1,3 @@
+<div>
+    The deployer's unique ID.
+</div>

--- a/src/main/resources/org/jfrog/hudson/pipeline/declarative/steps/gradle/GradleStep/help-resolverId.html
+++ b/src/main/resources/org/jfrog/hudson/pipeline/declarative/steps/gradle/GradleStep/help-resolverId.html
@@ -1,0 +1,3 @@
+<div>
+    The resolver's unique ID.
+</div>

--- a/src/main/resources/org/jfrog/hudson/pipeline/declarative/steps/gradle/GradleStep/help-rootDir.html
+++ b/src/main/resources/org/jfrog/hudson/pipeline/declarative/steps/gradle/GradleStep/help-rootDir.html
@@ -1,0 +1,5 @@
+<div>
+    Specify the root directory of the build file.
+    If your workspace has the top-level <code>build.gradle</code> in somewhere other than the module root directory, specify the path (relative to the module root) here, as parent where <code>${WORKSPACE}/parent</code> is the absolute.
+    If left empty, defaults to <code>build.gradle</code> in <code>${WORKSPACE}</code> directory.
+</div>

--- a/src/main/resources/org/jfrog/hudson/pipeline/declarative/steps/gradle/GradleStep/help-switches.html
+++ b/src/main/resources/org/jfrog/hudson/pipeline/declarative/steps/gradle/GradleStep/help-switches.html
@@ -1,0 +1,3 @@
+<div>
+    Optional list of Gradle switches to be invoked.
+</div>

--- a/src/main/resources/org/jfrog/hudson/pipeline/declarative/steps/gradle/GradleStep/help-tasks.html
+++ b/src/main/resources/org/jfrog/hudson/pipeline/declarative/steps/gradle/GradleStep/help-tasks.html
@@ -1,0 +1,8 @@
+<div>
+    Specify a gradle task to be invoked.
+    <br/>
+    If more than one task is available, separate them with space. For example:
+    <pre>
+        <code>'clean artifactoryPublish'</code>
+  </pre>
+</div>

--- a/src/main/resources/org/jfrog/hudson/pipeline/declarative/steps/gradle/GradleStep/help-tool.html
+++ b/src/main/resources/org/jfrog/hudson/pipeline/declarative/steps/gradle/GradleStep/help-tool.html
@@ -1,0 +1,3 @@
+<div>
+    Tool name from Jenkins configuration.
+</div>

--- a/src/main/resources/org/jfrog/hudson/pipeline/declarative/steps/gradle/GradleStep/help-useWrapper.html
+++ b/src/main/resources/org/jfrog/hudson/pipeline/declarative/steps/gradle/GradleStep/help-useWrapper.html
@@ -1,0 +1,3 @@
+<div>
+    Set to true if you'd like the build to use the Gradle Wrapper.
+</div>

--- a/src/main/resources/org/jfrog/hudson/pipeline/declarative/steps/gradle/GradleStep/help-usesPlugin.html
+++ b/src/main/resources/org/jfrog/hudson/pipeline/declarative/steps/gradle/GradleStep/help-usesPlugin.html
@@ -1,0 +1,3 @@
+<div>
+    Set to true if the Artifactory Plugin is already defined in build script.
+</div>

--- a/src/main/resources/org/jfrog/hudson/pipeline/declarative/steps/gradle/GradleStep/help.html
+++ b/src/main/resources/org/jfrog/hudson/pipeline/declarative/steps/gradle/GradleStep/help.html
@@ -1,0 +1,3 @@
+<div>
+    This allows your Gradle build to run, referencing resolver and deployer.
+</div>


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.

- [x] Please describe what you did
- Created `help.html` file to add a description to `rtGradleRun ` on [Jenkins Artifactory Plugin](https://www.jenkins.io/doc/pipeline/steps/artifactory/).
- Created `help-buildFile.html` file to add `buildFile` argument description.
- Created `help-buildName.html` file to add `buildName` argument description. 
- Created `help-buildNumber.html` file to add `buildNumber` argument description. 
- Created `help-deployerId.html` file to add `deployerId` argument description. 
- Created `help-resolverId.html` file to add `resolverId ` copy description. 
- Created `help-rootDir.html` file to add `rootDir` argument description. 
- Created `help-switches.html` file to add `switches` argument description. 
- Created `help-tasks.html` file to add `tasks` argument description. 
- Created `help-tool.html` file to add `tool` argument description. 
- Created `help-useWrapper.html` file to add `useWrapper` copy description. 
- Created `help-usesPlugin.html` file to add `usesPlugin` argument description. 

- [x] Link to relevant issues in GitHub or Jira
- [JENKINS-65441](https://issues.jenkins.io/browse/JENKINS-65441)

  @eyalbe4 @yahavi 
  @MarkEWaite @oleg-nenashev @kwhetstone @StackScribe
-----
