### PR TITLE
Bugfix - env not collected in npm, Go, Pip, and NuGet builds

### DIFF
--- a/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
@@ -52,6 +52,7 @@ import org.jfrog.hudson.release.ReleaseAction;
 import org.jfrog.hudson.util.plugins.MultiConfigurationUtils;
 import org.jfrog.hudson.util.publisher.PublisherContext;
 
+import javax.annotation.Nullable;
 import java.io.*;
 import java.util.*;
 
@@ -182,11 +183,7 @@ public class ExtractorUtils {
                     publisherContext.getAggregationBuildStatus()).setIssueTrackerInfo(configuration);
         }
 
-        IncludesExcludes envVarsPatterns = new IncludesExcludes("", "");
-        if (publisherContext != null && publisherContext.getEnvVarsPatterns() != null) {
-            envVarsPatterns = publisherContext.getEnvVarsPatterns();
-        }
-        addEnvVars(env, build, configuration, envVarsPatterns, listener);
+        addEnvVars(env, build, pipelineBuildInfo, publisherContext, configuration, listener);
         return configuration;
     }
 
@@ -398,12 +395,6 @@ public class ExtractorUtils {
         configuration.publisher.setFilterExcludedArtifactsFromBuild(context.isFilterExcludedArtifactsFromBuild());
         configuration.publisher.setPublishBuildInfo(!context.isSkipBuildInfoDeploy());
         configuration.publisher.setRecordAllDependencies(context.isRecordAllDependencies());
-        configuration.setIncludeEnvVars(context.isIncludeEnvVars());
-        IncludesExcludes envVarsPatterns = context.getEnvVarsPatterns();
-        if (envVarsPatterns != null) {
-            configuration.setEnvVarsIncludePatterns(Util.replaceMacro(envVarsPatterns.getIncludePatterns(), env));
-            configuration.setEnvVarsExcludePatterns(Util.replaceMacro(envVarsPatterns.getExcludePatterns(), env));
-        }
         List<String> gradlePublications = context.getGradlePublications();
         if (gradlePublications != null) {
             String publications = String.join(",", gradlePublications);
@@ -513,12 +504,11 @@ public class ExtractorUtils {
         publisher.addMatrixParams(params);
     }
 
-    private static void addEnvVars(Map<String, String> env, Run<?, ?> build,
-                                   ArtifactoryClientConfiguration configuration, IncludesExcludes envVarsPatterns, TaskListener listener) {
-        IncludeExcludePatterns patterns = new IncludeExcludePatterns(
-                Util.replaceMacro(envVarsPatterns.getIncludePatterns(), env),
-                Util.replaceMacro(envVarsPatterns.getExcludePatterns(), env)
-        );
+    private static void addEnvVars(Map<String, String> env, Run<?, ?> build, BuildInfo pipelineBuildInfo, PublisherContext publisherContext,
+                                   ArtifactoryClientConfiguration configuration, TaskListener listener) {
+
+        // Allow capturing env during extractors processing and get the calculated patterns
+        IncludeExcludePatterns patterns = setAndGetEnvPatterns(pipelineBuildInfo, publisherContext, env, configuration);
 
         // Add only the jenkins specific environment variables
         MapDifference<String, String> envDifference = Maps.difference(env, System.getenv());
@@ -540,6 +530,38 @@ public class ExtractorUtils {
         }
 
         MultiConfigurationUtils.addMatrixCombination(build, configuration);
+    }
+
+    /**
+     * Allow capturing environment variables during extractor process by configuring the ArtifactoryClientConfiguration.
+     *
+     * @param pipelineBuildInfo - Pipelines build info object or null
+     * @param publisherContext  - Publisher in UI jobs
+     * @param env               - Job's environment variables
+     * @param configuration     - The target artifactory client configuration
+     * @return calculated include-exclude patterns.
+     */
+    private static IncludeExcludePatterns setAndGetEnvPatterns(@Nullable BuildInfo pipelineBuildInfo,
+                                                               @Nullable PublisherContext publisherContext,
+                                                               Map<String, String> env, ArtifactoryClientConfiguration configuration) {
+        IncludesExcludes includesExcludes;
+        if (pipelineBuildInfo != null) {
+            // Pipelines jobs
+            includesExcludes = Utils.getArtifactsIncludeExcludeForDeyployment(pipelineBuildInfo.getEnv().getFilter().getPatternFilter());
+            configuration.setIncludeEnvVars(pipelineBuildInfo.getEnv().isCapture());
+        } else if (publisherContext != null && publisherContext.getEnvVarsPatterns() != null) {
+            // UI based jobs
+            includesExcludes = publisherContext.getEnvVarsPatterns();
+            configuration.setIncludeEnvVars(publisherContext.isIncludeEnvVars());
+        } else {
+            return new IncludeExcludePatterns("", "");
+        }
+
+        String includePatterns = Util.replaceMacro(includesExcludes.getIncludePatterns(), env);
+        String excludePatterns = Util.replaceMacro(includesExcludes.getExcludePatterns(), env);
+        configuration.setEnvVarsIncludePatterns(includePatterns);
+        configuration.setEnvVarsExcludePatterns(excludePatterns);
+        return new IncludeExcludePatterns(includePatterns, excludePatterns);
     }
 
     private static EnvVars getEnvVars(Run<?, ?> build, TaskListener listener) {

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
@@ -327,7 +327,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
             Module module = getAndAssertModule(buildInfo, "org.jfrog.example.gradle:" + pipelineType.toString() + "-gradle-example-ci-server-publication:1.0");
             // Gradle 6 and above produce an extra artifact of type "module".
             // In order to allow the test to run on Gradle 6 and above, we remove it.
-            module.setArtifacts(module.getArtifacts().stream().filter(art -> !art.getType().toLowerCase().equals("module")).collect(Collectors.toList()));
+            module.setArtifacts(module.getArtifacts().stream().filter(art -> !art.getType().equalsIgnoreCase("module")).collect(Collectors.toList()));
             assertModuleArtifacts(module, expectedArtifacts);
             assertTrue(CollectionUtils.isEmpty(module.getDependencies()));
 
@@ -346,6 +346,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
         try {
             runPipeline(pipelineName, false);
             Build buildInfo = getBuildInfo(buildInfoClient, buildName, buildNumber);
+            assertFilteredProperties(buildInfo);
             Module module = getAndAssertModule(buildInfo, moduleName);
             assertModuleDependencies(module, expectedDependencies);
             assertModuleArtifacts(module, expectedArtifact);
@@ -361,6 +362,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
         try {
             runPipeline(pipelineName, false);
             Build buildInfo = getBuildInfo(buildInfoClient, buildName, buildNumber);
+            assertFilteredProperties(buildInfo);
             Module module = getAndAssertModule(buildInfo, moduleName);
             assertModuleDependencies(module, expectedDependencies);
             assertModuleArtifacts(module, expectedArtifact);
@@ -389,6 +391,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
         try {
             runPipeline(pipelineName, false);
             Build buildInfo = getBuildInfo(buildInfoClient, buildName, buildNumber);
+            assertFilteredProperties(buildInfo);
             Module module = getAndAssertModule(buildInfo, moduleName);
             assertEquals(expectedDependencies, module.getDependencies().size());
         } finally {
@@ -401,6 +404,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
         try {
             runPipeline(pipelineName, false);
             Build buildInfo = getBuildInfo(buildInfoClient, buildName, buildNumber);
+            assertFilteredProperties(buildInfo);
             Module module = getAndAssertModule(buildInfo, moduleName);
             assertTrue(module.getDependencies() != null && module.getDependencies().size() > 0);
         } finally {
@@ -413,6 +417,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
         try {
             runPipeline(pipelineName, false);
             Build buildInfo = getBuildInfo(buildInfoClient, buildName, buildNumber);
+            assertFilteredProperties(buildInfo);
             Module module = getAndAssertModule(buildInfo, moduleName);
             assertTrue(module.getDependencies() != null && module.getDependencies().size() > 0);
         } finally {
@@ -510,6 +515,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
 
             // Get build info
             Build buildInfo = getBuildInfo(buildInfoClient, buildName, buildNumber);
+            assertFilteredProperties(buildInfo);
             assertEquals(1, buildInfo.getModules().size());
             List<Module> modules = buildInfo.getModules();
             Module module = modules.get(0);
@@ -623,7 +629,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
         String buildNumber = "3";
         // Clear older build if exists
         deleteBuild(artifactoryClient, buildName);
-        WorkflowRun build = runPipeline("append", false);
+        runPipeline("append", false);
         try {
             Build buildInfo = getBuildInfo(buildInfoClient, buildName, buildNumber);
             // Assert Issues

--- a/src/test/resources/integration/pipelines/declarative/dockerPush.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/dockerPush.pipeline
@@ -1,5 +1,7 @@
 package integration.pipelines.declarative
 
+env.DONT_COLLECT='FOO'
+env.COLLECT='BAR'
 node("TestSlave") {
     def buildName = "declarative:dockerPush test"
     def buildNumber = "3"
@@ -11,7 +13,8 @@ node("TestSlave") {
     }
     def imageName = domainName + "jfrog_artifactory_jenkins_tests:2"
     def targetRepo = "${env.JENKINS_ARTIFACTORY_DOCKER_PUSH_REPO}"
-    stage "rtserverconfig"
+
+    stage "Configure Artifactory"
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
@@ -19,7 +22,15 @@ node("TestSlave") {
             password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
     )
 
-    stage('docker push stage')
+    stage "Config Build Info"
+    rtBuildInfo(
+            buildName: buildName,
+            buildNumber: buildNumber,
+            captureEnv: true,
+            excludeEnvPatterns: ["DONT_COLLECT"]
+    )
+
+    stage "Run docker push"
     rtDockerPush(
             serverId: serverId,
             image: imageName,
@@ -30,7 +41,7 @@ node("TestSlave") {
     )
 
 
-    stage('publish build info')
+    stage "Publish build info"
     rtPublishBuildInfo(
             serverId: serverId,
             buildName: buildName,

--- a/src/test/resources/integration/pipelines/declarative/dotnet.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/dotnet.pipeline
@@ -4,6 +4,8 @@ import org.apache.commons.io.FileUtils
 
 import java.nio.file.Paths
 
+env.DONT_COLLECT='FOO'
+env.COLLECT='BAR'
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:dotnet test"
@@ -26,6 +28,14 @@ node("TestSlave") {
 
     stage "Copy project example"
     FileUtils.copyDirectory(Paths.get("${DOTNET_PROJECT_PATH}").toFile(), Paths.get(pwd(), "declarative-dotnet-example").toFile())
+
+    stage "Config Build Info"
+    rtBuildInfo(
+            buildName: buildName,
+            buildNumber: buildNumber,
+            captureEnv: true,
+            excludeEnvPatterns: ["DONT_COLLECT"]
+    )
 
     stage "NuGet Restore"
     rtDotnetRun(

--- a/src/test/resources/integration/pipelines/declarative/go.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/go.pipeline
@@ -4,6 +4,8 @@ import org.apache.commons.io.FileUtils
 
 import java.nio.file.Paths
 
+env.DONT_COLLECT='FOO'
+env.COLLECT='BAR'
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:go test"
@@ -32,6 +34,14 @@ node("TestSlave") {
 
     stage "Copy project example"
     FileUtils.copyDirectory(Paths.get("${GO_PROJECT_PATH}").toFile(), Paths.get(pwd(), "declarative-go-example").toFile())
+
+    stage "Config Build Info"
+    rtBuildInfo(
+            buildName: buildName,
+            buildNumber: buildNumber,
+            captureEnv: true,
+            excludeEnvPatterns: ["DONT_COLLECT"]
+    )
 
     stage "Go Build"
     rtGoRun(

--- a/src/test/resources/integration/pipelines/declarative/npmCi.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/npmCi.pipeline
@@ -4,6 +4,8 @@ import org.apache.commons.io.FileUtils
 
 import java.nio.file.Paths
 
+env.DONT_COLLECT='FOO'
+env.COLLECT='BAR'
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:npm ci test"
@@ -32,6 +34,14 @@ node("TestSlave") {
 
     stage "Copy project example"
     FileUtils.copyDirectory(Paths.get("${NPM_PROJECT_PATH}").toFile(), Paths.get(pwd(), "declarative-npm-example").toFile())
+
+    stage "Config Build Info"
+    rtBuildInfo(
+            buildName: buildName,
+            buildNumber: buildNumber,
+            captureEnv: true,
+            excludeEnvPatterns: ["DONT_COLLECT"]
+    )
 
     stage "Run npm ci"
     rtNpmCi(

--- a/src/test/resources/integration/pipelines/declarative/npmInstall.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/npmInstall.pipeline
@@ -4,6 +4,8 @@ import org.apache.commons.io.FileUtils
 
 import java.nio.file.Paths
 
+env.DONT_COLLECT='FOO'
+env.COLLECT='BAR'
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:npm install test"
@@ -32,6 +34,14 @@ node("TestSlave") {
 
     stage "Copy project example"
     FileUtils.copyDirectory(Paths.get("${NPM_PROJECT_PATH}").toFile(), Paths.get(pwd(), "declarative-npm-example").toFile())
+
+    stage "Config Build Info"
+    rtBuildInfo(
+            buildName: buildName,
+            buildNumber: buildNumber,
+            captureEnv: true,
+            excludeEnvPatterns: ["DONT_COLLECT"]
+    )
 
     stage "Run npm install"
     rtNpmInstall(

--- a/src/test/resources/integration/pipelines/declarative/nuget.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/nuget.pipeline
@@ -4,6 +4,8 @@ import org.apache.commons.io.FileUtils
 
 import java.nio.file.Paths
 
+env.DONT_COLLECT='FOO'
+env.COLLECT='BAR'
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:nuget test"
@@ -26,6 +28,14 @@ node("TestSlave") {
 
     stage "Copy project example"
     FileUtils.copyDirectory(Paths.get("${NUGET_PROJECT_PATH}").toFile(), Paths.get(pwd(), "declarative-nuget-example").toFile())
+
+    stage "Config Build Info"
+    rtBuildInfo(
+            buildName: buildName,
+            buildNumber: buildNumber,
+            captureEnv: true,
+            excludeEnvPatterns: ["DONT_COLLECT"]
+    )
 
     stage "NuGet Restore"
     rtNugetRun(

--- a/src/test/resources/integration/pipelines/declarative/pip.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/pip.pipeline
@@ -4,6 +4,8 @@ import org.apache.commons.io.FileUtils
 
 import java.nio.file.Paths
 
+env.DONT_COLLECT='FOO'
+env.COLLECT='BAR'
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:pip test"
@@ -27,6 +29,14 @@ node("TestSlave") {
 
     stage "Copy project example"
     FileUtils.copyDirectory(Paths.get("${PIP_PROJECT_PATH}").toFile(), Paths.get(pwd(), "declarative-pip-example").toFile())
+
+    stage "Config Build Info"
+    rtBuildInfo(
+            buildName: buildName,
+            buildNumber: buildNumber,
+            captureEnv: true,
+            excludeEnvPatterns: ["DONT_COLLECT"]
+    )
 
     stage "Run pip install"
     rtPipInstall(

--- a/src/test/resources/integration/pipelines/scripted/dockerPush.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/dockerPush.pipeline
@@ -1,5 +1,7 @@
 package integration.pipelines.scripted
 
+env.DONT_COLLECT='FOO'
+env.COLLECT='BAR'
 node("TestSlave") {
     def domainName = "${env.JENKINS_ARTIFACTORY_DOCKER_PUSH_DOMAIN}"
     if (!domainName.endsWith("/")) {
@@ -8,12 +10,15 @@ node("TestSlave") {
     def imageName = domainName + "jfrog_artifactory_jenkins_tests:2"
     def targetRepo = "${env.JENKINS_ARTIFACTORY_DOCKER_PUSH_REPO}"
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def buildInfo = Artifactory.newBuildInfo()
+    buildInfo.env.capture = true
+    buildInfo.env.filter.addExclude("DONT_COLLECT")
+    buildInfo.name = "scripted:dockerPush test"
+    buildInfo.number = "3"
 
     stage "dockerPush"
     def rtDocker = Artifactory.docker (rtServer, "${env.JENKINS_ARTIFACTORY_DOCKER_HOST}")
-    def buildInfo = rtDocker.push imageName, targetRepo
-    buildInfo.name = "scripted:dockerPush test"
-    buildInfo.number = "3"
+    rtDocker.push imageName, targetRepo, buildInfo
 
     stage "Publish Build Info"
     rtServer.publishBuildInfo buildInfo

--- a/src/test/resources/integration/pipelines/scripted/dotnet.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/dotnet.pipeline
@@ -4,10 +4,14 @@ import org.apache.commons.io.FileUtils
 
 import java.nio.file.Paths
 
+env.DONT_COLLECT='FOO'
+env.COLLECT='BAR'
 node("TestSlave") {
     stage "Configure Artifactory"
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
     def buildInfo = Artifactory.newBuildInfo()
+    buildInfo.env.capture = true
+    buildInfo.env.filter.addExclude("DONT_COLLECT")
     buildInfo.name = "scripted:dotnet test"
     buildInfo.number = "13"
 

--- a/src/test/resources/integration/pipelines/scripted/go.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/go.pipeline
@@ -4,10 +4,14 @@ import org.apache.commons.io.FileUtils
 
 import java.nio.file.Paths
 
+env.DONT_COLLECT='FOO'
+env.COLLECT='BAR'
 node("TestSlave") {
     stage "Configure Artifactory"
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
     def buildInfo = Artifactory.newBuildInfo()
+    buildInfo.env.capture = true
+    buildInfo.env.filter.addExclude("DONT_COLLECT")
     buildInfo.name = "scripted:go test"
     buildInfo.number = "7"
 
@@ -16,17 +20,14 @@ node("TestSlave") {
     rtGo.deployer repo: "${GO_LOCAL}", server: rtServer
     rtGo.resolver repo: "${GO_VIRTUAL}", server: rtServer
 
-
     stage "Copy project example"
     FileUtils.copyDirectory(Paths.get("${GO_PROJECT_PATH}").toFile(), Paths.get(pwd(), "scripted-go-example").toFile())
 
     stage "Go build"
     rtGo.run args: "build -mod=mod", buildInfo: buildInfo, path: "scripted-go-example"
 
-
     stage "Go publish"
     rtGo.publish version:"1.0.0", buildInfo: buildInfo, path: "scripted-go-example"
-
 
     stage "Publish build info"
     rtServer.publishBuildInfo buildInfo

--- a/src/test/resources/integration/pipelines/scripted/npmCi.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/npmCi.pipeline
@@ -4,10 +4,14 @@ import org.apache.commons.io.FileUtils
 
 import java.nio.file.Paths
 
+env.DONT_COLLECT='FOO'
+env.COLLECT='BAR'
 node("TestSlave") {
     stage "Configure Artifactory"
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
     def buildInfo = Artifactory.newBuildInfo()
+    buildInfo.env.capture = true
+    buildInfo.env.filter.addExclude("DONT_COLLECT")
     buildInfo.name = "scripted:npm ci test"
     buildInfo.number = "4"
 

--- a/src/test/resources/integration/pipelines/scripted/npmInstall.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/npmInstall.pipeline
@@ -4,10 +4,14 @@ import org.apache.commons.io.FileUtils
 
 import java.nio.file.Paths
 
+env.DONT_COLLECT='FOO'
+env.COLLECT='BAR'
 node("TestSlave") {
     stage "Configure Artifactory"
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
     def buildInfo = Artifactory.newBuildInfo()
+    buildInfo.env.capture = true
+    buildInfo.env.filter.addExclude("DONT_COLLECT")
     buildInfo.name = "scripted:npm install test"
     buildInfo.number = "3"
 

--- a/src/test/resources/integration/pipelines/scripted/nuget.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/nuget.pipeline
@@ -4,10 +4,14 @@ import org.apache.commons.io.FileUtils
 
 import java.nio.file.Paths
 
+env.DONT_COLLECT='FOO'
+env.COLLECT='BAR'
 node("TestSlave") {
     stage "Configure Artifactory"
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
     def buildInfo = Artifactory.newBuildInfo()
+    buildInfo.env.capture = true
+    buildInfo.env.filter.addExclude("DONT_COLLECT")
     buildInfo.name = "scripted:nuget test"
     buildInfo.number = "12"
 

--- a/src/test/resources/integration/pipelines/scripted/pip.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/pip.pipeline
@@ -4,10 +4,14 @@ import org.apache.commons.io.FileUtils
 
 import java.nio.file.Paths
 
+env.DONT_COLLECT='FOO'
+env.COLLECT='BAR'
 node("TestSlave") {
     stage "Configure Artifactory"
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
     def buildInfo = Artifactory.newBuildInfo()
+    buildInfo.env.capture = true
+    buildInfo.env.filter.addExclude("DONT_COLLECT")
     buildInfo.name = "scripted:pip test"
     buildInfo.number = "4"
 


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----

Depends on https://github.com/jfrog/build-info/pull/491.

When building npm, Go, Pip, and NuGet projects, we should allow collecting the environment during the extractor process.