### PR TITLE
Bugfix - Gradle init script with space in path causes failure

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/common/executors/GradleExecutor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/executors/GradleExecutor.java
@@ -120,7 +120,7 @@ public class GradleExecutor implements Executor {
         if (!gradleBuild.isUsesPlugin()) {
             try {
                 initScriptPath = createInitScript();
-                switches += " --init-script " + initScriptPath;
+                switches += " --init-script \"" + initScriptPath + "\"";
             } catch (Exception e) {
                 listener.getLogger().println("Error occurred while writing Gradle Init Script: " + e.getMessage());
                 throw new Run.RunnerAbortedException();


### PR DESCRIPTION
- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----

Resolves https://github.com/jfrog/jenkins-artifactory-plugin/issues/443#issuecomment-839933263 

**Steps to reproduce:**
Create a pipeline Gradle job with the following params:
1. A space in the job's name, for example `gradle example`.
2. rtGradle.usesPlugin = false
3. rtGradle.useWrapper = true

