### PR TITLE
Bugfix - override npm cache dir to make sure the artifacts exist in Artifactory

### DIFF
--- a/src/test/resources/integration/pipelines/declarative/npmCi.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/npmCi.pipeline
@@ -33,7 +33,8 @@ node("TestSlave") {
     )
 
     stage "Copy project example"
-    FileUtils.copyDirectory(Paths.get("${NPM_PROJECT_PATH}").toFile(), Paths.get(pwd(), "declarative-npm-example").toFile())
+    def npmProjectPath = Paths.get(pwd(), "declarative-npm-example").toFile()
+    FileUtils.copyDirectory(Paths.get("${NPM_PROJECT_PATH}").toFile(), npmProjectPath)
 
     stage "Config Build Info"
     rtBuildInfo(
@@ -48,7 +49,10 @@ node("TestSlave") {
             buildName: buildName,
             buildNumber: buildNumber,
             path: 'declarative-npm-example',
-            resolverId: "NPM_RESOLVER"
+            resolverId: "NPM_RESOLVER",
+            // Run install with -cache argument to download the artifacts from Artifactory
+            // This done to be sure the artifacts exist in Artifactory
+            args: "-cache="+npmProjectPath.toString()
     )
 
     stage "Run npm publish"

--- a/src/test/resources/integration/pipelines/declarative/npmCustomModuleName.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/npmCustomModuleName.pipeline
@@ -33,7 +33,8 @@ node("TestSlave") {
     )
 
     stage "Copy project example"
-    FileUtils.copyDirectory(Paths.get("${NPM_PROJECT_PATH}").toFile(), Paths.get(pwd(), "declarative-npm-example").toFile())
+    def npmProjectPath = Paths.get(pwd(), "declarative-npm-example").toFile()
+    FileUtils.copyDirectory(Paths.get("${NPM_PROJECT_PATH}").toFile(), npmProjectPath)
 
     stage "Config Build Info"
     rtBuildInfo(
@@ -49,7 +50,10 @@ node("TestSlave") {
             buildNumber: buildNumber,
             path: 'declarative-npm-example',
             resolverId: "NPM_RESOLVER",
-            module: "my-npm-module"
+            module: "my-npm-module",
+            // Run install with -cache argument to download the artifacts from Artifactory
+            // This done to be sure the artifacts exist in Artifactory
+            args: "-cache="+npmProjectPath.toString()
     )
 
     stage "Run npm publish"

--- a/src/test/resources/integration/pipelines/declarative/npmInstall.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/npmInstall.pipeline
@@ -33,7 +33,8 @@ node("TestSlave") {
     )
 
     stage "Copy project example"
-    FileUtils.copyDirectory(Paths.get("${NPM_PROJECT_PATH}").toFile(), Paths.get(pwd(), "declarative-npm-example").toFile())
+    def npmProjectPath = Paths.get(pwd(), "declarative-npm-example").toFile()
+    FileUtils.copyDirectory(Paths.get("${NPM_PROJECT_PATH}").toFile(), npmProjectPath)
 
     stage "Config Build Info"
     rtBuildInfo(
@@ -48,7 +49,10 @@ node("TestSlave") {
             buildName: buildName,
             buildNumber: buildNumber,
             path: 'declarative-npm-example',
-            resolverId: "NPM_RESOLVER"
+            resolverId: "NPM_RESOLVER",
+            // Run install with -cache argument to download the artifacts from Artifactory
+            // This done to be sure the artifacts exist in Artifactory
+            args: "-cache="+npmProjectPath.toString()
     )
 
     stage "Run npm publish"

--- a/src/test/resources/integration/pipelines/scripted/npmCi.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/npmCi.pipeline
@@ -20,11 +20,15 @@ node("TestSlave") {
     rtNpm.deployer repo: "${NPM_LOCAL}", server: rtServer
     rtNpm.resolver repo: "${NPM_REMOTE}", server: rtServer
 
+    def npmProjectPath = Paths.get(pwd(), "scripted-npm-example").toFile()
+
     stage "Copy project example"
-    FileUtils.copyDirectory(Paths.get("${NPM_PROJECT_PATH}").toFile(), Paths.get(pwd(), "scripted-npm-example").toFile())
+    FileUtils.copyDirectory(Paths.get("${NPM_PROJECT_PATH}").toFile(), npmProjectPath)
 
     stage "Rum npm ci"
-    rtNpm.ci buildInfo: buildInfo, path: "scripted-npm-example"
+    // Run install with -cache argument to download the artifacts from Artifactory
+    // This done to be sure the artifacts exist in Artifactory
+    rtNpm.ci buildInfo: buildInfo, path: "scripted-npm-example", args: "-cache="+npmProjectPath.toString()
 
     stage "Publish npm"
     rtNpm.publish buildInfo: buildInfo, path: "scripted-npm-example"

--- a/src/test/resources/integration/pipelines/scripted/npmCustomModuleName.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/npmCustomModuleName.pipeline
@@ -20,11 +20,15 @@ node("TestSlave") {
     rtNpm.deployer repo: "${NPM_LOCAL}", server: rtServer
     rtNpm.resolver repo: "${NPM_REMOTE}", server: rtServer
 
+    def npmProjectPath = Paths.get(pwd(), "scripted-npm-example").toFile()
+
     stage "Copy project example"
-    FileUtils.copyDirectory(Paths.get("${NPM_PROJECT_PATH}").toFile(), Paths.get(pwd(), "scripted-npm-example").toFile())
+    FileUtils.copyDirectory(Paths.get("${NPM_PROJECT_PATH}").toFile(), npmProjectPath)
 
     stage "Install npm"
-    rtNpm.install buildInfo: buildInfo, path: "scripted-npm-example", module: "my-npm-module"
+    // Run install with -cache argument to download the artifacts from Artifactory
+    // This done to be sure the artifacts exist in Artifactory
+    rtNpm.install buildInfo: buildInfo, path: "scripted-npm-example", module: "my-npm-module", args: "-cache="+npmProjectPath.toString()
 
     stage "Publish npm"
     rtNpm.publish buildInfo: buildInfo, path: "scripted-npm-example", module: "my-npm-module"

--- a/src/test/resources/integration/pipelines/scripted/npmInstall.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/npmInstall.pipeline
@@ -20,12 +20,15 @@ node("TestSlave") {
     rtNpm.deployer repo: "${NPM_LOCAL}", server: rtServer
     rtNpm.resolver repo: "${NPM_REMOTE}", server: rtServer
 
+    def npmProjectPath = Paths.get(pwd(), "scripted-npm-example").toFile()
 
     stage "Copy project example"
-    FileUtils.copyDirectory(Paths.get("${NPM_PROJECT_PATH}").toFile(), Paths.get(pwd(), "scripted-npm-example").toFile())
+    FileUtils.copyDirectory(Paths.get("${NPM_PROJECT_PATH}").toFile(), npmProjectPath)
 
     stage "Install npm"
-    rtNpm.install buildInfo: buildInfo, path: "scripted-npm-example"
+    // Run install with -cache argument to download the artifacts from Artifactory
+    // This done to be sure the artifacts exist in Artifactory
+    rtNpm.install buildInfo: buildInfo, path: "scripted-npm-example", args: "-cache="+npmProjectPath.toString()
 
 
     stage "Publish npm"


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----
