### PR TITLE
Bugfix - Saving the same server id as in Jenkins configuration fails …

### DIFF
--- a/src/main/java/org/jfrog/hudson/ArtifactoryBuilder.java
+++ b/src/main/java/org/jfrog/hudson/ArtifactoryBuilder.java
@@ -33,6 +33,7 @@ import jenkins.model.Jenkins;
 import net.sf.json.JSONNull;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
+import org.apache.http.client.ClientProtocolException;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.jfrog.build.api.util.NullLog;
 import org.jfrog.build.client.ArtifactoryVersion;
@@ -172,9 +173,9 @@ public class ArtifactoryBuilder extends GlobalConfiguration {
 
             ArtifactoryManager artifactoryManager;
             if (StringUtils.isNotEmpty(username) || StringUtils.isNotEmpty(accessToken)) {
-                artifactoryManager = new ArtifactoryManager(url, username, password, accessToken, new NullLog());
+                artifactoryManager = new ArtifactoryManager(targetArtUrl, username, password, accessToken, new NullLog());
             } else {
-                artifactoryManager = new ArtifactoryManager(url, new NullLog());
+                artifactoryManager = new ArtifactoryManager(targetArtUrl, new NullLog());
             }
 
             try {
@@ -192,6 +193,8 @@ public class ArtifactoryBuilder extends GlobalConfiguration {
                     version = artifactoryManager.getVersion();
                 } catch (UnsupportedOperationException uoe) {
                     return FormValidation.warning(uoe.getMessage());
+                } catch (ClientProtocolException e) {
+                    return FormValidation.error(e.getCause().getMessage());
                 } catch (Exception e) {
                     return FormValidation.error(e.getMessage());
                 }

--- a/src/main/java/org/jfrog/hudson/ArtifactoryBuilder.java
+++ b/src/main/java/org/jfrog/hudson/ArtifactoryBuilder.java
@@ -194,6 +194,8 @@ public class ArtifactoryBuilder extends GlobalConfiguration {
                 } catch (UnsupportedOperationException uoe) {
                     return FormValidation.warning(uoe.getMessage());
                 } catch (ClientProtocolException e) {
+                    // If http/https are missing, ClientProtocolException will be thrown.
+                    // Since this kind of exception hold the error message inside 'cause' we must catch it to show a proper error message on Jenkins UI.
                     return FormValidation.error(e.getCause().getMessage());
                 } catch (Exception e) {
                     return FormValidation.error(e.getMessage());

--- a/src/main/java/org/jfrog/hudson/pipeline/common/executors/GetJFrogPlatformInstancesExecutor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/executors/GetJFrogPlatformInstancesExecutor.java
@@ -48,7 +48,7 @@ public class GetJFrogPlatformInstancesExecutor implements Executor {
         JFrogPlatformInstance JFrogPlatformInstance = jfrogInstancesFound.get(0);
         ArtifactoryServer artifactoryServer = new ArtifactoryServer(JFrogPlatformInstance.getArtifactoryServer(), build.getParent());
         this.JFrogPlatformInstance = new org.jfrog.hudson.pipeline.common.types.JFrogPlatformInstance(artifactoryServer, JFrogPlatformInstance.getUrl(), JFrogPlatformInstance.getId());
-        artifactoryServer.setJfrogPlatformInstance(this.JFrogPlatformInstance);
+        artifactoryServer.setPlatformUrl(this.JFrogPlatformInstance.getUrl());
     }
 
     public static class ServerNotFoundException extends RuntimeException {

--- a/src/main/java/org/jfrog/hudson/pipeline/common/executors/PublishBuildInfoExecutor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/executors/PublishBuildInfoExecutor.java
@@ -34,9 +34,8 @@ public class PublishBuildInfoExecutor implements Executor {
         buildInfo.filterVariables();
         buildInfo.appendVcs(Utils.extractVcs(ws, new JenkinsBuildInfoLog(listener)));
         org.jfrog.hudson.ArtifactoryServer server = Utils.prepareArtifactoryServer(null, pipelineServer);
-        String platformUrl = pipelineServer.getJfrogPlatformInstance() != null ? pipelineServer.getJfrogPlatformInstance().getUrl() : null;
         try (ArtifactoryManager artifactoryManager = this.createArtifactoryManager(server, build, listener)) {
-            buildInfo.createDeployer(build, listener, new ArtifactoryConfigurator(server), artifactoryManager, platformUrl).deploy();
+            buildInfo.createDeployer(build, listener, new ArtifactoryConfigurator(server), artifactoryManager, pipelineServer.getPlatformUrl()).deploy();
         }
     }
 

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/ArtifactoryServer.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/ArtifactoryServer.java
@@ -39,6 +39,7 @@ public class ArtifactoryServer implements Serializable {
 
     private String serverName;
     private String url;
+    private String platformUrl;
     private String username;
     private String password;
     private String credentialsId;
@@ -47,7 +48,6 @@ public class ArtifactoryServer implements Serializable {
     private boolean usesCredentialsId;
     private final Connection connection = new Connection();
     private int deploymentThreads;
-    private JFrogPlatformInstance jfrogPlatformInstance;
 
     public ArtifactoryServer() {
     }
@@ -382,11 +382,11 @@ public class ArtifactoryServer implements Serializable {
         this.deploymentThreads = deploymentThreads;
     }
 
-    public JFrogPlatformInstance getJfrogPlatformInstance() {
-        return jfrogPlatformInstance;
+    public String getPlatformUrl() {
+        return platformUrl;
     }
 
-    public void setJfrogPlatformInstance(JFrogPlatformInstance jfrogPlatformInstance) {
-        this.jfrogPlatformInstance = jfrogPlatformInstance;
+    public void setPlatformUrl(String platformUrl) {
+        this.platformUrl = platformUrl;
     }
 }


### PR DESCRIPTION
…the build

Test connection fails for missing Artifactory URL

- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----
