### PR TITLE
Remove dependency on `run-condition`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,11 +162,6 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>run-condition</artifactId>
-            <version>1.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>mailer</artifactId>
             <version>1.24</version>
         </dependency>


### PR DESCRIPTION
I see no reason why this plugin needs to depend on [`run-condition`](https://plugins.jenkins.io/run-condition/). This plugin does not import any classes from `run-condition`, and the tests pass without `run-condition`.