### PR TITLE
Bugfix - Artifactory servers are missing in Jenkins dropdown list block

### DIFF
--- a/src/main/resources/org/jfrog/hudson/ArtifactoryBuilder/global.jelly
+++ b/src/main/resources/org/jfrog/hudson/ArtifactoryBuilder/global.jelly
@@ -24,7 +24,7 @@
 
                 <r:blockWrapper style="width:100%">
                     <f:entry title="Instance ID" help="/plugin/artifactory/help/ArtifactoryBuilder/help-serverId.html">
-                        <f:textbox field="instanceId" value="${instance.id}" use="required"/>
+                        <f:textbox field="instanceId" value="${instance.instanceId}" use="required"/>
                     </f:entry>
 
                     <f:entry title="JFrog Platform URL" field="platformUrl"
@@ -35,7 +35,7 @@
                         <f:advanced>
                             <f:entry title="JFrog Artifactory URL"
                                      help="/plugin/artifactory/help/ArtifactoryBuilder/help-artifactory-url.html">
-                                <f:textbox field="artifactoryUrl" value="${instance.artifactoryServer.artifactoryUrl}"/>
+                                <f:textbox field="artifactoryUrl" value="${instance.artifactoryUrl}"/>
                             </f:entry>
                             <f:entry title="Connection timeout" field="instance.timeout"
                                      help="/plugin/artifactory/help/ArtifactoryBuilder/help-timeout.html">
@@ -73,14 +73,14 @@
                         <f:block>
                             <input type="hidden" name="stapler-class" value="org.jfrog.hudson.CredentialsConfig"/>
                             <r:blockWrapper style="width:100%"
-                                            id="deployerCredentialsId${instance.artifactoryServer.artifactoryUrl}">
+                                            id="deployerCredentialsId${instance.artifactoryUrl}">
                                 <f:entry title="${%Credentials}" name="credentialsId" field="credentialsId">
                                     <c:select default="${instance.deployerCredentialsConfig.credentialsId}"/>
                                 </f:entry>
                             </r:blockWrapper>
 
                             <r:blockWrapper style="width:100%"
-                                            id="legacyDeployerCredentials${instance.artifactoryServer.artifactoryUrl}">
+                                            id="legacyDeployerCredentials${instance.artifactoryUrl}">
                                 <f:entry title="Username"
                                          help="/plugin/artifactory/help/common/help-deployerUserName.html">
                                     <f:textbox name="username" field="username"
@@ -109,14 +109,14 @@
                                 <input type="hidden" name="stapler-class"
                                        value="org.jfrog.hudson.CredentialsConfig"/>
                                 <r:blockWrapper style="width:100%"
-                                                id="resolverCredentialsId${instance.artifactoryServer.artifactoryUrl}">
+                                                id="resolverCredentialsId${instance.artifactoryUrl}">
                                     <f:entry title="${%Credentials}" field="credentialsId">
                                         <c:select default="${instance.resolverCredentialsConfig.credentialsId}"/>
                                     </f:entry>
                                 </r:blockWrapper>
 
                                 <r:blockWrapper style="width:100%"
-                                                id="legacyResolverCredentials${instance.artifactoryServer.artifactoryUrl}">
+                                                id="legacyResolverCredentials${instance.artifactoryUrl}">
                                     <f:entry title="Username"
                                              help="/plugin/artifactory/help/ArtifactoryBuilder/help-resolverUserName.html">
                                         <f:textbox field="username"

--- a/src/main/resources/org/jfrog/hudson/ArtifactoryRedeployPublisher/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/ArtifactoryRedeployPublisher/config.jelly
@@ -2,20 +2,20 @@
     <j:set var="uniqueId" value="${h.generateId()}"/>
     <f:dropdownList name="deployerDetails" title="${%Artifactory server}">
         <j:forEach var="s" items="${descriptor.jfrogInstances}" varStatus="loop">
-            <f:dropdownListBlock value="${s.id}" title="${s.artifactoryServer.artifactoryUrl}" selected="${s.id==instance.artifactoryName}">
+            <f:dropdownListBlock value="${s.instanceId}" title="${s.artifactoryUrl}" selected="${s.instanceId==instance.artifactoryName}">
                 <f:nested>
-                    <input type="hidden" name="artifactoryName" value="${s.id}"/>
-                    <input type="hidden" name="artifactoryUrl" id="artifactoryUrlDeploy${s.artifactoryServer.artifactoryUrl}" value="${s.artifactoryServer.artifactoryUrl}"/>
+                    <input type="hidden" name="artifactoryName" value="${s.instanceId}"/>
+                    <input type="hidden" name="artifactoryUrl" id="artifactoryUrlDeploy${s.artifactoryUrl}" value="${s.artifactoryUrl}"/>
                     <input type="hidden" name="stapler-class" value="org.jfrog.hudson.ServerDetails"/>
 
-                    <r:dynamicRepos id="publishRepositoryKey-${s.artifactoryServer.artifactoryUrl}-${uniqueId}"
+                    <r:dynamicRepos id="publishRepositoryKey-${s.artifactoryUrl}-${uniqueId}"
                                     field="deployReleaseRepository"
                                     title="Target releases repository"
                                     repositoryConf="${instance.deployerDetails.deployReleaseRepository}"
                                     repositories="${instance.releaseRepositoryList}"
                                     helpUrl="/plugin/artifactory/help/common/help-deployReleases.html"/>
 
-                    <r:dynamicRepos id="publishSnapshotsRepositoryKeys-${s.artifactoryServer.artifactoryUrl}-${uniqueId}"
+                    <r:dynamicRepos id="publishSnapshotsRepositoryKeys-${s.artifactoryUrl}-${uniqueId}"
                                     title="Target snapshot repository"
                                     field="deploySnapshotRepository"
                                     repositoryConf="${instance.deployerDetails.deploySnapshotRepository}"
@@ -24,10 +24,10 @@
 
                     <f:entry title="${%Custom staging configuration}"
                              help="/plugin/artifactory/help/release/common/help-stagingPlugin.html">
-                        <select class="setting-input" name="userPluginKey" id="customStagingConfiguration-${s.artifactoryServer.artifactoryUrl}-${uniqueId}"
+                        <select class="setting-input" name="userPluginKey" id="customStagingConfiguration-${s.artifactoryUrl}-${uniqueId}"
                                 onchange="setStagingParamsSelectedValue(this)">
                             <j:choose>
-                                <j:when test="${s.id==instance.artifactoryName}">
+                                <j:when test="${s.instanceId==instance.artifactoryName}">
                                     <j:choose>
                                         <f:option selected="${instance.deployerDetails.stagingPlugin.pluginName}"
                                                   value="${instance.deployerDetails.stagingPlugin.pluginName}">
@@ -39,7 +39,7 @@
                         </select>
                         <div id="stagingParamsDiv-${uniqueId}">
                             <j:choose>
-                                <j:when test="${s.id==instance.artifactoryName}">
+                                <j:when test="${s.instanceId==instance.artifactoryName}">
                                     <j:choose>
                                         <j:when test="${instance.deployerDetails.stagingPlugin != null}">
                                             <j:choose>
@@ -62,7 +62,7 @@
                     </script>
                     <r:repos bind="bindToDescriptor"
                              jsFunction="artifactoryRedeployPublisher"
-                             repoUrl="artifactoryUrlDeploy${s.artifactoryServer.artifactoryUrl}"
+                             repoUrl="artifactoryUrlDeploy${s.artifactoryUrl}"
                              credentialsDescriber="overridingDeployerCredentials-${uniqueId}"/>
                 </f:nested>
             </f:dropdownListBlock>

--- a/src/main/resources/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator/config.jelly
@@ -17,13 +17,13 @@
                     <r:blockWrapper style="width:100%" id="artifactory-deployer-spec-dd-${uniqueId}">
                         <f:dropdownList name="specsDeployerDetails" title="${%Artifactory upload server}">
                             <j:forEach var="s" items="${descriptor.jfrogInstances}" varStatus="loop">
-                                <f:dropdownListBlock value="${s.id}" title="${s.artifactoryServer.artifactoryUrl}"
-                                                     selected="${s.id==instance.specsDeployerDetails.artifactoryName}">
+                                <f:dropdownListBlock value="${s.instanceId}" title="${s.instanceId} ${s.artifactoryUrl}"
+                                                     selected="${s.instanceId==instance.specsDeployerDetails.artifactoryName}">
                                     <f:nested>
-                                        <input type="hidden" name="artifactoryName" value="${s.id}"/>
+                                        <input type="hidden" name="artifactoryName" value="${s.instanceId}"/>
                                         <input type="hidden" name="artifactoryUrl"
-                                               id="artifactoryUrlDeploy${s.artifactoryServer.artifactoryUrl}"
-                                               value="${s.artifactoryServer.artifactoryUrl}"/>
+                                               id="artifactoryUrlDeploy${s.artifactoryUrl}"
+                                               value="${s.artifactoryUrl}"/>
                                         <input type="hidden" name="stapler-class"
                                                value="org.jfrog.hudson.ServerDetails"/>
                                     </f:nested>
@@ -142,13 +142,13 @@
                         <r:blockWrapper style="width:100%" id="artifactory-resolver-spec-dd-${uniqueId}">
                             <f:dropdownList name="specsResolverDetails" title="${%Artifactory download server}">
                                 <j:forEach var="s" items="${descriptor.jfrogInstances}" varStatus="loop">
-                                    <f:dropdownListBlock value="${s.id}" title="${s.artifactoryServer.artifactoryUrl}"
-                                                         selected="${s.id==instance.specsResolverDetails.artifactoryName}">
+                                    <f:dropdownListBlock value="${s.instanceId}" title="${s.instanceId} ${s.artifactoryUrl}"
+                                                         selected="${s.instanceId==instance.specsResolverDetails.artifactoryName}">
                                         <f:nested>
                                             <input type="hidden" name="artifactoryName" value="${s.id}"/>
                                             <input type="hidden" name="artifactoryUrl"
-                                                   id="artifactoryUrlResolve${s.artifactoryServer.artifactoryUrl}"
-                                                   value="${s.artifactoryServer.artifactoryUrl}"/>
+                                                   id="artifactoryUrlResolve${s.artifactoryUrl}"
+                                                   value="${s.artifactoryUrl}"/>
                                             <input type="hidden" name="stapler-class"
                                                    value="org.jfrog.hudson.ServerDetails"/>
 

--- a/src/main/resources/org/jfrog/hudson/gradle/ArtifactoryGradleConfigurator/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/gradle/ArtifactoryGradleConfigurator/config.jelly
@@ -6,15 +6,15 @@
         <f:section title="Deployment Details">
             <f:dropdownList name="deployerDetails" title="${%Artifactory deployment server}">
                 <j:forEach var="s" items="${descriptor.jfrogInstances}" varStatus="loop">
-                    <f:dropdownListBlock value="${s.artifactoryServer.serverId}" title="${s.artifactoryServer.artifactoryUrl}"
-                                         selected="${s.id==instance.artifactoryName}">
+                    <f:dropdownListBlock value="${s.instanceId}" title="${s.instanceId} ${s.artifactoryUrl}"
+                                         selected="${s.instanceId==instance.artifactoryName}">
                         <f:nested>
-                            <input type="hidden" name="artifactoryName" value="${s.id}"/>
-                            <input type="hidden" name="artifactoryUrl" id="artifactoryUrlDeploy${s.artifactoryServer.artifactoryUrl}"
-                                   value="${s.artifactoryServer.artifactoryUrl}"/>
+                            <input type="hidden" name="artifactoryName" value="${s.instanceId}"/>
+                            <input type="hidden" name="artifactoryUrl" id="artifactoryUrlDeploy${s.artifactoryUrl}"
+                                   value="${s.artifactoryUrl}"/>
                             <input type="hidden" name="stapler-class" value="org.jfrog.hudson.ServerDetails"/>
 
-                            <r:dynamicRepos id="gradlePublishRepositoryKeys-${s.artifactoryServer.artifactoryUrl}-${uniqueId}"
+                            <r:dynamicRepos id="gradlePublishRepositoryKeys-${s.artifactoryUrl}-${uniqueId}"
                                             title="Publishing repository"
                                             field="deployReleaseRepository"
                                             repositories="${instance.releaseRepositories}"
@@ -23,10 +23,10 @@
                             <f:entry title="${%Custom staging configuration}"
                                      help="/plugin/artifactory/help/release/common/help-stagingPlugin.html">
                                 <select class="setting-input" name="userPluginKey"
-                                        id="gradleCustomStagingConfiguration-${s.artifactoryServer.artifactoryUrl}-${uniqueId}"
+                                        id="gradleCustomStagingConfiguration-${s.artifactoryUrl}-${uniqueId}"
                                         onchange="setStagingParamsSelectedValue(this)">
                                     <j:choose>
-                                        <j:when test="${s.serverId==instance.artifactoryName}">
+                                        <j:when test="${s.instanceId==instance.artifactoryName}">
                                             <j:choose>
                                                 <f:option
                                                         selected="${instance.deployerDetails.stagingPlugin.pluginName}"
@@ -39,7 +39,7 @@
                                 </select>
                                 <div id="stagingParamsDiv-${uniqueId}">
                                     <j:choose>
-                                        <j:when test="${s.id==instance.artifactoryName}">
+                                        <j:when test="${s.instanceId==instance.artifactoryName}">
                                             <j:choose>
                                                 <j:when test="${instance.deployerDetails.stagingPlugin.paramsString != ''}">
                                                     <input class='setting-input' name='userPluginParams'
@@ -58,7 +58,7 @@
                             </script>
                             <r:repos bind="bindToDescriptor"
                                      jsFunction="artifactoryGradleConfigurator"
-                                     repoUrl="artifactoryUrlDeploy${s.artifactoryServer.artifactoryUrl}"
+                                     repoUrl="artifactoryUrlDeploy${s.artifactoryUrl}"
                                      credentialsDescriber="overridingDeployerCredentials-gradle-${uniqueId}"/>
 
                         </f:nested>
@@ -74,14 +74,14 @@
         <f:section title="Resolution Details">
             <f:dropdownList name="resolverDetails" title="${%Artifactory resolve server}">
                 <j:forEach var="s" items="${descriptor.jfrogInstances}" varStatus="loop">
-                    <f:dropdownListBlock value="${s.id}" title="${s.artifactoryServer.artifactoryUrl}"
-                                         selected="${s.id==instance.resolverDetails.artifactoryName}">
+                    <f:dropdownListBlock value="${s.instanceId}" title="${s.instanceId} ${s.artifactoryUrl}"
+                                         selected="${s.instanceId==instance.resolverDetails.artifactoryName}">
                         <f:nested>
-                            <input type="hidden" name="artifactoryName" value="${s.id}"/>
-                            <input type="hidden" name="artifactoryUrl" id="artifactoryUrlResolver${s.artifactoryServer.artifactoryUrl}"
-                                   value="${s.artifactoryServer.artifactoryUrl}"/>
+                            <input type="hidden" name="artifactoryName" value="${s.instanceId}"/>
+                            <input type="hidden" name="artifactoryUrl" id="artifactoryUrlResolver${s.artifactoryUrl}"
+                                   value="${s.artifactoryUrl}"/>
                             <input type="hidden" name="stapler-class" value="org.jfrog.hudson.ServerDetails"/>
-                            <r:dynamicRepos id="gradleResolutionRepositoryKeys-${s.artifactoryServer.artifactoryUrl}-${uniqueId}"
+                            <r:dynamicRepos id="gradleResolutionRepositoryKeys-${s.artifactoryUrl}-${uniqueId}"
                                             title="Resolution repository"
                                             field="resolveReleaseRepository"
                                             repositories="${instance.virtualRepositories}"
@@ -93,7 +93,7 @@
                             </script>
                             <r:repos bind="bindToDescriptorResolver"
                                      jsFunction="artifactoryGradleConfigurationResolve"
-                                     repoUrl="artifactoryUrlResolver${s.artifactoryServer.artifactoryUrl}"
+                                     repoUrl="artifactoryUrlResolver${s.artifactoryUrl}"
                                      credentialsDescriber="overridingResolverCredentials-gradle-${uniqueId}"/>
 
                         </f:nested>

--- a/src/main/resources/org/jfrog/hudson/ivy/ArtifactoryIvyConfigurator/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/ivy/ArtifactoryIvyConfigurator/config.jelly
@@ -6,13 +6,13 @@
         <j:set var="uniqueId" value="${h.generateId()}"/>
         <f:dropdownList name="deployerDetails" title="${%Artifactory server}">
             <j:forEach var="s" items="${descriptor.jfrogInstances}" varStatus="loop">
-                <f:dropdownListBlock value="${s.id}" title="${s.artifactoryServer.artifactoryUrl}" selected="${s.id==instance.artifactoryName}">
+                <f:dropdownListBlock value="${s.instanceId}" title="${s.instanceId} ${s.artifactoryUrl}" selected="${s.instanceId==instance.artifactoryName}">
                     <f:nested>
-                        <input type="hidden" name="artifactoryName" value="${s.id}"/>
-                        <input type="hidden" name="artifactoryUrl" id="artifactoryUrlDeploy${s.artifactoryServer.artifactoryUrl}" value="${s.artifactoryServer.artifactoryUrl}"/>
+                        <input type="hidden" name="artifactoryName" value="${s.instanceId}"/>
+                        <input type="hidden" name="artifactoryUrl" id="artifactoryUrlDeploy${s.artifactoryUrl}" value="${s.artifactoryUrl}"/>
                         <input type="hidden" name="stapler-class" value="org.jfrog.hudson.ServerDetails"/>
 
-                        <r:dynamicRepos id="publishRepositoryKey-${s.artifactoryServer.artifactoryUrl}-${uniqueId}"
+                        <r:dynamicRepos id="publishRepositoryKey-${s.artifactoryUrl}-${uniqueId}"
                                         title="Target Repository"
                                         field="deployReleaseRepository"
                                         repositoryConf="${instance.deployerDetails.deployReleaseRepository}"
@@ -25,7 +25,7 @@
                         </script>
                         <r:repos bind="ivyDeployBind"
                                  jsFunction="artifactoryIvyConfigurator"
-                                 repoUrl="artifactoryUrlDeploy${s.artifactoryServer.artifactoryUrl}"
+                                 repoUrl="artifactoryUrlDeploy${s.artifactoryUrl}"
                                  credentialsDescriber="overridingDeployerCredentials-ivy-project-${uniqueId}"/>
                     </f:nested>
                 </f:dropdownListBlock>

--- a/src/main/resources/org/jfrog/hudson/ivy/ArtifactoryIvyFreeStyleConfigurator/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/ivy/ArtifactoryIvyFreeStyleConfigurator/config.jelly
@@ -6,12 +6,12 @@
         <j:set var="uniqueId" value="${h.generateId()}"/>
         <f:dropdownList name="deployerDetails" title="${%Artifactory server}">
             <j:forEach var="s" items="${descriptor.jfrogInstances}" varStatus="loop">
-                <f:dropdownListBlock value="${s.id}" title="${s.artifactoryServer.artifactoryUrl}" selected="${s.id==instance.artifactoryName}">
+                <f:dropdownListBlock value="${s.instanceId}" title="${s.instanceId} ${s.artifactoryUrl}" selected="${s.instanceId==instance.artifactoryName}">
                     <f:nested>
-                        <input type="hidden" name="artifactoryName" value="${s.id}"/>
-                        <input type="hidden" name="artifactoryUrl" id="artifactoryUrlDeploy${s.artifactoryServer.artifactoryUrl}" value="${s.artifactoryServer.artifactoryUrl}"/>
+                        <input type="hidden" name="artifactoryName" value="${s.instanceId}"/>
+                        <input type="hidden" name="artifactoryUrl" id="artifactoryUrlDeploy${s.artifactoryUrl}" value="${s.artifactoryUrl}"/>
                         <input type="hidden" name="stapler-class" value="org.jfrog.hudson.ServerDetails"/>
-                        <r:dynamicRepos id="ivyFreeRepositoryKeys-${s.artifactoryServer.artifactoryUrl}-${uniqueId}"
+                        <r:dynamicRepos id="ivyFreeRepositoryKeys-${s.artifactoryUrl}-${uniqueId}"
                                         title="Publishing repository"
                                         field="deployReleaseRepository"
                                         repositoryConf="${instance.deployerDetails.deployReleaseRepository}"
@@ -23,7 +23,7 @@
                         </script>
                         <r:repos bind="ivyFreeDeployBind"
                                  jsFunction="artifactoryIvyFreeStyleConfigurator"
-                                 repoUrl="artifactoryUrlDeploy${s.artifactoryServer.artifactoryUrl}"
+                                 repoUrl="artifactoryUrlDeploy${s.artifactoryUrl}"
                                  credentialsDescriber="overridingDeployerCredentials-ivy-${uniqueId}"/>
                     </f:nested>
                 </f:dropdownListBlock>

--- a/src/main/resources/org/jfrog/hudson/maven3/ArtifactoryMaven3Configurator/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/maven3/ArtifactoryMaven3Configurator/config.jelly
@@ -22,19 +22,19 @@
         <j:set var="uniqueId" value="${h.generateId()}"/>
         <f:dropdownList name="deployerDetails" title="${%Artifactory server}">
             <j:forEach var="s" items="${descriptor.jfrogInstances}" varStatus="loop">
-                <f:dropdownListBlock value="${s.id}" title="${s.artifactoryServer.artifactoryUrl}" selected="${s.id==instance.artifactoryName}">
+                <f:dropdownListBlock value="${s.instanceId}" title="${s.instanceId} ${s.artifactoryUrl}" selected="${s.instanceId==instance.artifactoryName}">
                     <f:nested>
-                        <input type="hidden" name="artifactoryName" value="${s.id}"/>
-                        <input type="hidden" name="artifactoryUrl" id="artifactoryUrlDeploy${s.artifactoryServer.artifactoryUrl}" value="${s.artifactoryServer.artifactoryUrl}"/>
+                        <input type="hidden" name="artifactoryName" value="${s.instanceId}"/>
+                        <input type="hidden" name="artifactoryUrl" id="artifactoryUrlDeploy${s.artifactoryUrl}" value="${s.artifactoryUrl}"/>
                         <input type="hidden" name="stapler-class" value="org.jfrog.hudson.ServerDetails"/>
-                        <r:dynamicRepos id="maven3RepositoryKeys-${s.artifactoryServer.artifactoryUrl}-${uniqueId}"
+                        <r:dynamicRepos id="maven3RepositoryKeys-${s.artifactoryUrl}-${uniqueId}"
                                         title="Target releases repository"
                                         field="deployReleaseRepository"
                                         repositoryConf="${instance.deployerDetails.deployReleaseRepository}"
                                         repositories="${instance.releaseRepositoryList}"
                                         helpUrl="/plugin/artifactory/help/common/help-deployReleases.html"/>
 
-                        <r:dynamicRepos id="maven3SnapshotsRepositoryKeys-${s.artifactoryServer.artifactoryUrl}-${uniqueId}"
+                        <r:dynamicRepos id="maven3SnapshotsRepositoryKeys-${s.artifactoryUrl}-${uniqueId}"
                                         title="Target snapshots repository"
                                         field="deploySnapshotRepository"
                                         repositoryConf="${instance.deployerDetails.deploySnapshotRepository}"
@@ -47,7 +47,7 @@
                         </script>
                         <r:repos bind="maven3DeployBind"
                                  jsFunction="artifactoryMaven3Configurator"
-                                 repoUrl="artifactoryUrlDeploy${s.artifactoryServer.artifactoryUrl}"
+                                 repoUrl="artifactoryUrlDeploy${s.artifactoryUrl}"
                                  credentialsDescriber="overridingDeployerCredentials-maven3-${uniqueId}"/>
                     </f:nested>
                 </f:dropdownListBlock>
@@ -69,28 +69,28 @@
 
                     <f:dropdownList name="resolverDetails" title="${%Artifactory server}">
                         <j:forEach var="s" items="${descriptor.jfrogInstances}" varStatus="loop">
-                            <f:dropdownListBlock value="${s.id}" title="${s.id} (${s.artifactoryServer.artifactoryUrl})"
-                                                 selected="${s.id==instance.resolverDetails.artifactoryName}">
+                            <f:dropdownListBlock value="${s.instanceId}" title="${s.instanceId} ${s.artifactoryUrl}"
+                                                 selected="${s.instanceId==instance.resolverDetails.artifactoryName}">
 
                                 <f:nested>
-                                    <input type="hidden" name="artifactoryName" value="${s.id}"/>
-                                    <input type="hidden" name="artifactoryUrl" id="artifactoryUrlResolve${s.artifactoryServer.artifactoryUrl}"
-                                           value="${s.artifactoryServer.artifactoryUrl}"/>
+                                    <input type="hidden" name="artifactoryName" value="${s.instanceId}"/>
+                                    <input type="hidden" name="artifactoryUrl" id="artifactoryUrlResolve${s.artifactoryUrl}"
+                                           value="${s.artifactoryUrl}"/>
                                     <input type="hidden" name="stapler-class" value="org.jfrog.hudson.ServerDetails"/>
                                     <input type="hidden" name="downloadReleaseRepositoryDisplayName"
-                                           id="downloadReleaseRepositoryDisplayName-maven3-${s.artifactoryServer.artifactoryUrl}"
+                                           id="downloadReleaseRepositoryDisplayName-maven3-${s.artifactoryUrl}"
                                            value="${instance.resolverDetails.downloadReleaseRepositoryDisplayName}"/>
                                     <input type="hidden" name="downloadSnapshotRepositoryDisplayName"
-                                           id="downloadSnapshotRepositoryDisplayName-maven3-${s.artifactoryServer.artifactoryUrl}"
+                                           id="downloadSnapshotRepositoryDisplayName-maven3-${s.artifactoryUrl}"
                                            value="${instance.resolverDetails.downloadSnapshotRepositoryDisplayName}"/>
 
-                                    <r:dynamicRepos id="maven3NativeReleaseRepositoryKeys-${s.artifactoryServer.artifactoryUrl}-${uniqueId}"
+                                    <r:dynamicRepos id="maven3NativeReleaseRepositoryKeys-${s.artifactoryUrl}-${uniqueId}"
                                                     title="Resolution releases repository"
                                                     field="resolveReleaseRepository"
                                                     repositoryConf="${instance.resolverDetails.resolveReleaseRepository}"
                                                     repositories="${instance.resolveReleaseRepositoryList}"/>
 
-                                    <r:dynamicRepos id="maven3NativeSnapshotRepositoryKeys-${s.artifactoryServer.artifactoryUrl}-${uniqueId}"
+                                    <r:dynamicRepos id="maven3NativeSnapshotRepositoryKeys-${s.artifactoryUrl}-${uniqueId}"
                                                     title="Resolution snapshots repository"
                                                     field="resolveSnapshotRepository"
                                                     repositoryConf="${instance.resolverDetails.resolveSnapshotRepository}"
@@ -101,7 +101,7 @@
                                     </script>
                                     <r:repos bind="maven3ResolveBind"
                                              jsFunction="artifactoryMaven3NativeConfigurator"
-                                             repoUrl="artifactoryUrlResolve${s.artifactoryServer.artifactoryUrl}"
+                                             repoUrl="artifactoryUrlResolve${s.artifactoryUrl}"
                                              credentialsDescriber="overridingResolverCredentials-maven3-${uniqueId}"/>
                                 </f:nested>
                             </f:dropdownListBlock>

--- a/src/main/resources/org/jfrog/hudson/maven3/ArtifactoryMaven3NativeConfigurator/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/maven3/ArtifactoryMaven3NativeConfigurator/config.jelly
@@ -2,18 +2,18 @@
     <j:set var="uniqueId" value="${h.generateId()}"/>
     <f:dropdownList name="resolverDetails" title="${%Artifactory server}">
         <j:forEach var="s" items="${descriptor.jfrogInstances}" varStatus="loop">
-            <f:dropdownListBlock value="${s.id}" title="${s.artifactoryServer.artifactoryUrl}" selected="${s.id==instance.artifactoryName}">
+            <f:dropdownListBlock value="${s.instanceId}" title="${s.instanceId} ${s.artifactoryUrl}" selected="${s.instanceId==instance.artifactoryName}">
                 <f:nested>
-                    <input type="hidden" name="artifactoryName" value="${s.id}"/>
-                    <input type="hidden" name="artifactoryUrl" id="artifactoryUrlResolver${s.artifactoryServer.artifactoryUrl}" value="${s.artifactoryServer.artifactoryUrl}"/>
+                    <input type="hidden" name="artifactoryName" value="${s.instanceId}"/>
+                    <input type="hidden" name="artifactoryUrl" id="artifactoryUrlResolver${s.artifactoryUrl}" value="${s.artifactoryUrl}"/>
                     <input type="hidden" name="stapler-class" value="org.jfrog.hudson.ServerDetails"/>
-                    <r:dynamicRepos id="maven3NativeReleaseRepositoryKeys-${s.artifactoryServer.artifactoryUrl}-${uniqueId}"
+                    <r:dynamicRepos id="maven3NativeReleaseRepositoryKeys-${s.artifactoryUrl}-${uniqueId}"
                                     title="Resolution releases repository"
                                     field="resolveReleaseRepository"
                                     repositories="${instance.virtualRepositoryList}"
                                     repositoryConf="${instance.resolverDetails.resolveReleaseRepository}"/>
 
-                    <r:dynamicRepos id="maven3NativeSnapshotRepositoryKeys-${s.artifactoryServer.artifactoryUrl}-${uniqueId}"
+                    <r:dynamicRepos id="maven3NativeSnapshotRepositoryKeys-${s.artifactoryUrl}-${uniqueId}"
                                     title="Resolution snapshots repository"
                                     field="resolveSnapshotRepository"
                                     repositories="${instance.virtualRepositoryList}"
@@ -24,7 +24,7 @@
                     </script>
                     <r:repos bind="maven3NativeResolveBind"
                              jsFunction="artifactoryMaven3NativeConfigurator"
-                             repoUrl="artifactoryUrlResolver${s.artifactoryServer.artifactoryUrl}"
+                             repoUrl="artifactoryUrlResolver${s.artifactoryUrl}"
                              credentialsDescriber="overridingResolverCredentials-${uniqueId}"/>
                 </f:nested>
             </f:dropdownListBlock>

--- a/src/main/resources/org/jfrog/hudson/trigger/ArtifactoryTrigger/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/trigger/ArtifactoryTrigger/config.jelly
@@ -1,10 +1,10 @@
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:dropdownList name="details" title="${%Artifactory server}">
         <j:forEach var="s" items="${instance.jfrogInstances ?: descriptor.jfrogInstances}" varStatus="loop">
-            <f:dropdownListBlock value="${s.id}" title="${s.id} (${s.artifactoryServer.artifactoryUrl})"
-                                 selected="${s.id==instance.selectedServerId}">
+            <f:dropdownListBlock value="${s.instanceId}" title="${s.instanceId} ${s.artifactoryUrl}"
+                                 selected="${s.instanceId==instance.selectedServerId}">
                 <f:nested>
-                    <input type="hidden" name="artifactoryName" value="${s.id}"/>
+                    <input type="hidden" name="artifactoryName" value="${s.instanceId}"/>
                     <input type="hidden" name="stapler-class" value="org.jfrog.hudson.ServerDetails"/>
                 </f:nested>
             </f:dropdownListBlock>


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----
Artifactory servers are missing in Jenkins dropdown list block E.G.:
![Screen Shot 2021-05-27 at 10 26 32](https://user-images.githubusercontent.com/9606235/119783818-47b11b00-bed6-11eb-972c-1688d9e59c84.png)
