### PR TITLE
Stop persisting deprecated `artifactoryServers` on serialization

### DIFF
--- a/src/main/java/org/jfrog/hudson/ArtifactoryBuilder.java
+++ b/src/main/java/org/jfrog/hudson/ArtifactoryBuilder.java
@@ -83,7 +83,7 @@ public class ArtifactoryBuilder extends GlobalConfiguration {
          * @deprecated: Use org.jfrog.hudson.ArtifactoryBuilder.DescriptorImpl#getJFrogInstances()
          */
         @Deprecated
-        private List<ArtifactoryServer> artifactoryServers;
+        private transient List<ArtifactoryServer> artifactoryServers;
         private JFrogPipelinesServer jfrogPipelinesServer = new JFrogPipelinesServer();
 
         public DescriptorImpl() {


### PR DESCRIPTION
Amends #455, which broke JCasC export. Fixes this regression by marking the deprecated `artifactoryServers` field with `transient`, which causes XStream not to serialize the (already migrated!) field as described in [the Jenkins developer documentation](https://wiki.jenkins.io/display/JENKINS/Hint+on+retaining+backward+compatibility#Hintonretainingbackwardcompatibility-Scenario:Renameafield).

(Note that the common convention in Jenkins plugins is to perform such migration logic in an XStream `readResolve()` method, as described in the above developer documentation, but the JFrog Artifactory plugin does this in a dedicated `ArtifactoryBuilderConverter` class.)