### PR TITLE
Fix: Issue faulty URLs returned by BuildInfoResultAction

### DIFF
--- a/src/main/java/org/jfrog/hudson/BuildInfoResultAction.java
+++ b/src/main/java/org/jfrog/hudson/BuildInfoResultAction.java
@@ -95,7 +95,7 @@ public class BuildInfoResultAction implements BuildBadgeAction {
     }
 
     private PublishedBuildDetails createBuildInfoIdentifier(String artifactoryUrl, String buildName, String buildNumber, String platformUrl, String startedBuildTimestamp, String project) {
-        return new PublishedBuildDetails(artifactoryUrl, Util.rawEncode(buildName), Util.rawEncode(buildNumber), platformUrl, startedBuildTimestamp, project);
+        return new PublishedBuildDetails(artifactoryUrl, buildName, buildNumber, platformUrl, startedBuildTimestamp, project);
     }
 
     private PublishedBuildDetails createBuildInfoIdentifier(String artifactoryUrl, Run build, Build buildInfo, String platformUrl) {


### PR DESCRIPTION
This commit solves:
  https://github.com/jfrog/jenkins-artifactory-plugin/issues/454

As per @jonsten's suggestion, we stop escaping URLs when stored in the
BuildInfoResultAction, but instead _only_ when returned.

To ensure that old BuildInfos are handled correctly, a readResolve()
detects the string "%20%3A%3A%20", which indicates an already
escaped URL (while it is possible to create a Jenkins job name
that includes this String, it should in practice never happen).

- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests. * 
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----

* Note: All tests passes. I have not added a new test for the serialization issue. Not sure writing serialization test for this is worth it, but I'll be happy too if a maintainer deems it necessary. 