### PR TITLE
Artifactory Build Info URL is broken when using multibranch

### DIFF
--- a/src/main/java/org/jfrog/hudson/BuildInfoResultAction.java
+++ b/src/main/java/org/jfrog/hudson/BuildInfoResultAction.java
@@ -95,7 +95,7 @@ public class BuildInfoResultAction implements BuildBadgeAction {
     }
 
     private PublishedBuildDetails createBuildInfoIdentifier(String artifactoryUrl, String buildName, String buildNumber, String platformUrl, String startedBuildTimestamp, String project) {
-        return new PublishedBuildDetails(artifactoryUrl, Util.rawEncode(buildName), Util.rawEncode(buildNumber), platformUrl, startedBuildTimestamp, project);
+        return new PublishedBuildDetails(artifactoryUrl, buildName, buildNumber, platformUrl, startedBuildTimestamp, project);
     }
 
     private PublishedBuildDetails createBuildInfoIdentifier(String artifactoryUrl, Run build, Build buildInfo, String platformUrl) {


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----
BuildInfo's URL וndergoes an encoding process twice while using the multi-branch pipeline. As a result, the BuildInfo's link gets corrupted.

The root cause of the issue is found in createBuildInfoIdentifier function which encodes the build name/number but later on, createBuildInfoUrl encodes it a second time.
Solves: https://github.com/jfrog/jenkins-artifactory-plugin/issues/454 & https://github.com/jfrog/jenkins-artifactory-plugin/issues/483