### PR TITLE
Bugfix - Old jobs' BuildInfo link is broken with special characters

### DIFF
--- a/src/main/java/org/jfrog/hudson/BuildInfoResultAction.java
+++ b/src/main/java/org/jfrog/hudson/BuildInfoResultAction.java
@@ -16,11 +16,11 @@
 
 package org.jfrog.hudson;
 
-import hudson.Util;
 import hudson.model.BuildBadgeAction;
 import hudson.model.Run;
 import org.apache.commons.lang.StringUtils;
 import org.jfrog.build.api.Build;
+import org.jfrog.build.extractor.clientConfiguration.client.JFrogService;
 import org.jfrog.hudson.util.BuildUniqueIdentifierHelper;
 
 import java.text.ParseException;
@@ -95,7 +95,7 @@ public class BuildInfoResultAction implements BuildBadgeAction {
     }
 
     private PublishedBuildDetails createBuildInfoIdentifier(String artifactoryUrl, String buildName, String buildNumber, String platformUrl, String startedBuildTimestamp, String project) {
-        return new PublishedBuildDetails(artifactoryUrl, buildName, buildNumber, platformUrl, startedBuildTimestamp, project);
+        return new PublishedBuildDetails(artifactoryUrl, JFrogService.encodeUrl(buildName), JFrogService.encodeUrl(buildNumber), platformUrl, startedBuildTimestamp, project);
     }
 
     private PublishedBuildDetails createBuildInfoIdentifier(String artifactoryUrl, Run build, Build buildInfo, String platformUrl) {
@@ -115,7 +115,7 @@ public class BuildInfoResultAction implements BuildBadgeAction {
     }
 
     private String generateUrl(String artifactoryUrl, Run build, String buildName) {
-        return createBuildInfoUrl(artifactoryUrl, buildName, BuildUniqueIdentifierHelper.getBuildNumber(build));
+        return createBuildInfoUrl(artifactoryUrl, buildName, BuildUniqueIdentifierHelper.getBuildNumber(build), true);
     }
 
     /**

--- a/src/main/java/org/jfrog/hudson/PublishedBuildDetails.java
+++ b/src/main/java/org/jfrog/hudson/PublishedBuildDetails.java
@@ -35,9 +35,10 @@ public class PublishedBuildDetails implements Serializable {
 
     public String getBuildInfoUrl() throws ParseException {
         if (StringUtils.isNotBlank(platformUrl) && StringUtils.isNotBlank(startedTimeStamp)) {
-            return createBuildInfoUrl(platformUrl, buildName, buildNumber, startedTimeStamp, project);
+            // Encode already happened in BuildInfoResultAction#createBuildInfoIdentifier.
+            return createBuildInfoUrl(platformUrl, buildName, buildNumber, startedTimeStamp, project, false);
         }
-        return createBuildInfoUrl(this.artifactoryUrl, this.buildName, this.buildNumber);
+        return createBuildInfoUrl(this.artifactoryUrl, this.buildName, this.buildNumber, false);
     }
 
     public String getDisplayName() {


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----
Fixes: https://github.com/jfrog/jenkins-artifactory-plugin/issues/483#issuecomment-873937075
This [fix](https://github.com/jfrog/jenkins-artifactory-plugin/pull/516) currently solves new builds' URL that is made with version 3.12.1.
Old builds' URL is still not valid. This commit fixes this by encoding the old builds once as well as the new builds

Related: https://github.com/jfrog/build-info/pull/526