### PR TITLE
Fix tests collisions caused by multiple runs

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/common/executors/GenericDownloadExecutor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/executors/GenericDownloadExecutor.java
@@ -28,6 +28,7 @@ public class GenericDownloadExecutor implements Executor {
     private TaskListener listener;
     private String spec;
     private String moduleName;
+    public static String failNoOpErrorMessage = "Fail-no-op: No files were affected in the download process.";
 
     public GenericDownloadExecutor(ArtifactoryServer server, TaskListener listener, Run build, FilePath ws, BuildInfo buildInfo, String spec, boolean failNoOp, String moduleName) {
         this.build = build;
@@ -51,7 +52,7 @@ public class GenericDownloadExecutor implements Executor {
                 ws.act(new FilesResolverCallable(new JenkinsBuildInfoLog(listener),
                         resolverCredentials, server.getArtifactoryUrl(), spec, Utils.getProxyConfiguration(server)));
         if (failNoOp && resolvedDependencies.isEmpty()) {
-            throw new RuntimeException("Fail-no-op: No files were affected in the download process.");
+            throw new RuntimeException(failNoOpErrorMessage);
         }
         String moduleId = StringUtils.isNotBlank(moduleName) ? moduleName : buildInfo.getName();
         this.buildInfo.appendDependencies(resolvedDependencies, moduleId);

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
@@ -17,7 +17,6 @@ import org.jfrog.build.api.Dependency;
 import org.jfrog.build.api.Module;
 import org.jfrog.build.extractor.buildScanTable.BuildScanTableHelper;
 import org.jfrog.build.extractor.clientConfiguration.client.distribution.request.DeleteReleaseBundleRequest;
-import org.jfrog.build.extractor.clientConfiguration.client.distribution.response.DistributeReleaseBundleResponse;
 import org.jfrog.build.extractor.clientConfiguration.client.distribution.response.GetReleaseBundleStatusResponse;
 import org.jfrog.build.extractor.docker.DockerJavaWrapper;
 import org.jfrog.hudson.ArtifactoryServer;
@@ -59,92 +58,101 @@ public class CommonITestsPipeline extends PipelineTestBase {
 
     void downloadByPatternTest(String buildName) throws Exception {
         Set<String> expectedDependencies = getTestFilesNamesByLayer(0);
-        String buildNumber = "3";
+        WorkflowRun pipelineResults = null;
 
         Files.list(FILES_PATH).filter(Files::isRegularFile)
                 .forEach(file -> uploadFile(artifactoryClient, file, getRepoKey(TestRepository.LOCAL_REPO1)));
-        WorkflowRun build = runPipeline("downloadByPattern", false);
         try {
+            pipelineResults = runPipeline("downloadByPattern", false);
             for (String fileName : expectedDependencies) {
-                assertTrue(isExistInWorkspace(slave, build, "downloadByPattern-test", fileName));
+                assertTrue(isExistInWorkspace(slave, pipelineResults, "downloadByPattern-test", fileName));
             }
-            Build buildInfo = getBuildInfo(artifactoryManager, buildName, buildNumber);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER, null);
             Module module = getAndAssertModule(buildInfo, buildName);
             assertModuleDependencies(module, expectedDependencies);
         } finally {
-            deleteBuild(artifactoryClient, buildName);
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER);
         }
     }
 
     void downloadByAqlTest(String buildName) throws Exception {
         Set<String> expectedDependencies = getTestFilesNamesByLayer(0);
-        String buildNumber = "3";
+        WorkflowRun pipelineResults = null;
 
         Files.list(FILES_PATH).filter(Files::isRegularFile)
                 .forEach(file -> uploadFile(artifactoryClient, file, getRepoKey(TestRepository.LOCAL_REPO1)));
-        WorkflowRun build = runPipeline("downloadByAql", false);
         try {
+            pipelineResults = runPipeline("downloadByAql", false);
             for (String fileName : expectedDependencies) {
-                assertTrue(isExistInWorkspace(slave, build, "downloadByAql-test", fileName));
+                assertTrue(isExistInWorkspace(slave, pipelineResults, "downloadByAql-test", fileName));
             }
-            Build buildInfo = getBuildInfo(artifactoryManager, buildName, buildNumber);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER, null);
             Module module = getAndAssertModule(buildInfo, buildName);
             assertModuleDependencies(module, expectedDependencies);
         } finally {
-            deleteBuild(artifactoryClient, buildName);
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER);
         }
     }
 
     void downloadByPatternAndBuildTest(String buildName) throws Exception {
         Set<String> expectedDependencies = Sets.newHashSet("a.in");
-        String buildNumber = "5";
+        String buildNumber = BUILD_NUMBER + "3";
+        WorkflowRun pipelineResults = null;
 
         Set<String> unexpected = getTestFilesNamesByLayer(0);
         unexpected.addAll(getTestFilesNamesByLayer(1));
         unexpected.removeAll(expectedDependencies);
-        WorkflowRun build = runPipeline("downloadByPatternAndBuild", false);
         try {
-            assertTrue(isExistInWorkspace(slave, build, "downloadByPatternAndBuild-test", "a.in"));
+            pipelineResults = runPipeline("downloadByPatternAndBuild", false);
+            assertTrue(isExistInWorkspace(slave, pipelineResults, "downloadByPatternAndBuild-test", "a.in"));
             for (String fileName : unexpected) {
-                assertFalse(isExistInWorkspace(slave, build, "downloadByPatternAndBuild-test", fileName));
+                assertFalse(isExistInWorkspace(slave, pipelineResults, "downloadByPatternAndBuild-test", fileName));
             }
-            Build buildInfo = getBuildInfo(artifactoryManager, buildName, buildNumber);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, buildNumber, null);
             Module module = getAndAssertModule(buildInfo, buildName);
             assertModuleDependencies(module, expectedDependencies);
         } finally {
-            deleteBuild(artifactoryClient, buildName);
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER + "1", BUILD_NUMBER + "2", BUILD_NUMBER + "3");
         }
     }
 
     void downloadByBuildOnlyTest(String buildName) throws Exception {
         Set<String> expectedDependencies = getTestFilesNamesByLayer(0);
         Set<String> unexpected = getTestFilesNamesByLayer(1);
-        String buildNumber = "5";
+        WorkflowRun pipelineResults = null;
 
-        WorkflowRun build = runPipeline("downloadByBuildOnly", false);
         try {
+            pipelineResults = runPipeline("downloadByBuildOnly", false);
             for (String fileName : expectedDependencies) {
-                assertTrue(isExistInWorkspace(slave, build, "downloadByBuildOnly-test", fileName));
+                assertTrue(isExistInWorkspace(slave, pipelineResults, "downloadByBuildOnly-test", fileName));
             }
             for (String fileName : unexpected) {
-                assertFalse(isExistInWorkspace(slave, build, "downloadByBuildOnly-test", fileName));
+                assertFalse(isExistInWorkspace(slave, pipelineResults, "downloadByBuildOnly-test", fileName));
             }
-            Build buildInfo = getBuildInfo(artifactoryManager, buildName, buildNumber);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER + "3", null);
             Module module = getAndAssertModule(buildInfo, buildName);
             assertModuleDependencies(module, expectedDependencies);
         } finally {
-            deleteBuild(artifactoryClient, buildName);
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER + "1", BUILD_NUMBER + "2", BUILD_NUMBER + "3");
         }
     }
 
     void downloadNonExistingBuildTest(String buildName) throws Exception {
+        boolean success = false;
         try {
             runPipeline("downloadNonExistingBuild", false);
             fail("Job expected to fail");
         } catch (AssertionError t) {
-            assertTrue(t.getMessage().contains("Fail-no-op: No files were affected in the download process."));
+            if (t.getMessage().contains("Fail-no-op: No files were affected in the download process.")) {
+                success = true;
+            } else {
+                fail("Job expected error message:'Fail-no-op: No files were affected in the download process.' but actual got:" + t.getMessage());
+            }
         } finally {
-            deleteBuild(artifactoryClient, buildName);
+            if (success) {
+                artifactoryManager.deleteBuilds(buildName, null, true, BUILD_NUMBER);
+                cleanOldBuilds(buildName, null);
+            }
         }
     }
 
@@ -155,21 +163,21 @@ public class CommonITestsPipeline extends PipelineTestBase {
     void downloadByShaAndBuildTest(String buildName) throws Exception {
         Set<String> expectedDependencies = Sets.newHashSet("a3");
         Set<String> unexpected = Sets.newHashSet("a4", "a5");
-        String buildNumber = "6";
+        WorkflowRun pipelineResults = null;
 
-        WorkflowRun build = runPipeline("downloadByShaAndBuild", false);
         try {
+            pipelineResults = runPipeline("downloadByShaAndBuild", false);
             // Only a.in should be in workspace
-            assertTrue(isExistInWorkspace(slave, build, "downloadByShaAndBuild-test", "a3"));
+            assertTrue(isExistInWorkspace(slave, pipelineResults, "downloadByShaAndBuild-test", "a3"));
             for (String fileName : unexpected) {
-                assertFalse(isExistInWorkspace(slave, build, "downloadByShaAndBuild-test", fileName));
+                assertFalse(isExistInWorkspace(slave, pipelineResults, "downloadByShaAndBuild-test", fileName));
             }
-            Build buildInfo = getBuildInfo(artifactoryManager, buildName, buildNumber);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER + "4", null);
             Module module = getAndAssertModule(buildInfo, buildName);
             assertModuleDependencies(module, expectedDependencies);
         } finally {
-            deleteBuild(artifactoryClient, buildName);
-            deleteBuild(artifactoryClient, buildName + "-second");
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER + "1", BUILD_NUMBER + "4");
+            cleanupBuilds(pipelineResults, buildName + "-second", null, BUILD_NUMBER + "2", BUILD_NUMBER + "3");
         }
     }
 
@@ -180,57 +188,54 @@ public class CommonITestsPipeline extends PipelineTestBase {
     void downloadByShaAndBuildNameTest(String buildName) throws Exception {
         Set<String> expectedDependencies = Sets.newHashSet("a4");
         Set<String> unexpected = Sets.newHashSet("a3", "a5");
-        String buildNumber = "6";
-
-        WorkflowRun build = runPipeline("downloadByShaAndBuildName", false);
+        WorkflowRun pipelineResults = null;
         try {
+            pipelineResults = runPipeline("downloadByShaAndBuildName", false);
             // Only a.in should be in workspace
-            assertTrue(isExistInWorkspace(slave, build, "downloadByShaAndBuildName-test", "a4"));
+            assertTrue(isExistInWorkspace(slave, pipelineResults, "downloadByShaAndBuildName-test", "a4"));
             for (String fileName : unexpected) {
-                assertFalse(isExistInWorkspace(slave, build, "downloadByShaAndBuildName-test", fileName));
+                assertFalse(isExistInWorkspace(slave, pipelineResults, "downloadByShaAndBuildName-test", fileName));
             }
-            Build buildInfo = getBuildInfo(artifactoryManager, buildName, buildNumber);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER + "4", null);
             Module module = getAndAssertModule(buildInfo, buildName);
             assertModuleDependencies(module, expectedDependencies);
         } finally {
-            deleteBuild(artifactoryClient, buildName);
-            deleteBuild(artifactoryClient, buildName + "-second");
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER + "1", BUILD_NUMBER + "2", BUILD_NUMBER + "4");
+            cleanupBuilds(pipelineResults, buildName + "-second", null, BUILD_NUMBER + "3");
         }
     }
 
     void uploadTest(String buildName, String project, String pipelineName) throws Exception {
         Set<String> expectedArtifacts = getTestFilesNamesByLayer(0);
-        String buildNumber = "3";
-
-        runPipeline(pipelineName, false);
+        WorkflowRun pipelineResults = null;
         try {
+            pipelineResults = runPipeline(pipelineName, false);
             expectedArtifacts.forEach(artifactName ->
                     assertTrue(artifactName + " doesn't exist in Artifactory", isExistInArtifactory(artifactoryClient, getRepoKey(TestRepository.LOCAL_REPO1), artifactName)));
-            Build buildInfo = getBuildInfo(artifactoryManager, buildName, buildNumber, project);
+            Build buildInfo = getBuildInfo(artifactoryManager, buildName, BUILD_NUMBER, project);
             Module module = getAndAssertModule(buildInfo, buildName);
             assertModuleArtifacts(module, expectedArtifacts);
         } finally {
-            deleteBuild(artifactoryClient, buildName);
+            cleanupBuilds(pipelineResults, buildName, project, BUILD_NUMBER);
         }
     }
 
     void uploadDownloadCustomModuleNameTest(String buildName) throws Exception {
         Set<String> expectedArtifactsAndDependencies = getTestFilesNamesByLayer(0);
-        String buildNumber = "3";
-
-        WorkflowRun build = runPipeline("uploadDownloadCustomModuleName", false);
+        WorkflowRun pipelineResults = null;
         try {
+            pipelineResults = runPipeline("uploadDownloadCustomModuleName", false);
             expectedArtifactsAndDependencies.forEach(artifactName ->
                     assertTrue(artifactName + " doesn't exist in Artifactory", isExistInArtifactory(artifactoryClient, getRepoKey(TestRepository.LOCAL_REPO1), artifactName)));
             for (String fileName : expectedArtifactsAndDependencies) {
-                assertTrue(isExistInWorkspace(slave, build, "downloadByPattern-test", fileName));
+                assertTrue(isExistInWorkspace(slave, pipelineResults, "downloadByPattern-test", fileName));
             }
-            Build buildInfo = getBuildInfo(artifactoryManager, buildName, buildNumber);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER, null);
             Module module = getAndAssertModule(buildInfo, "my-generic-module");
             assertModuleDependencies(module, expectedArtifactsAndDependencies);
             assertModuleArtifacts(module, expectedArtifactsAndDependencies);
         } finally {
-            deleteBuild(artifactoryClient, buildName);
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER);
         }
     }
 
@@ -244,16 +249,15 @@ public class CommonITestsPipeline extends PipelineTestBase {
 
     void promotionTest(String buildName) throws Exception {
         Set<String> expectedDependencies = getTestFilesNamesByLayer(0);
-        String buildNumber = "4";
-
+        WorkflowRun pipelineResults = null;
         Files.list(FILES_PATH).filter(Files::isRegularFile)
                 .forEach(file -> uploadFile(artifactoryClient, file, getRepoKey(TestRepository.LOCAL_REPO1)));
-        WorkflowRun build = runPipeline("promote", false);
         try {
+            pipelineResults = runPipeline("promote", false);
             for (String fileName : expectedDependencies) {
-                assertTrue(isExistInWorkspace(slave, build, "promotion-test", fileName));
+                assertTrue(isExistInWorkspace(slave, pipelineResults, "promotion-test", fileName));
             }
-            Build buildInfo = getBuildInfo(artifactoryManager, buildName, buildNumber);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER, null);
             Module module = getAndAssertModule(buildInfo, buildName);
             assertModuleDependencies(module, expectedDependencies);
             // In this tests, the expected dependencies and artifacts are equal
@@ -261,16 +265,16 @@ public class CommonITestsPipeline extends PipelineTestBase {
             assertNoArtifactsInRepo(artifactoryClient, getRepoKey(TestRepository.LOCAL_REPO1));
             assertArtifactsInRepo(artifactoryClient, getRepoKey(TestRepository.LOCAL_REPO2), expectedDependencies);
         } finally {
-            deleteBuild(artifactoryClient, buildName);
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER);
         }
     }
 
     void mavenTest(String buildName, boolean useWrapper) throws Exception {
         Set<String> expectedArtifacts = Sets.newHashSet("multi-3.7-SNAPSHOT.pom");
-        String buildNumber = "3";
+        WorkflowRun pipelineResults = null;
         try {
-            runPipeline(useWrapper ? "mavenWrapper" : "maven", false);
-            Build buildInfo = getBuildInfo(artifactoryManager, buildName, buildNumber);
+            pipelineResults = runPipeline(useWrapper ? "mavenWrapper" : "maven", false);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER, null);
             assertFilteredProperties(buildInfo);
             assertEquals(4, buildInfo.getModules().size());
 
@@ -281,17 +285,17 @@ public class CommonITestsPipeline extends PipelineTestBase {
             assertModuleContainsArtifactsAndDependencies(buildInfo, "org.jfrog.test:multi2:3.7-SNAPSHOT");
             assertModuleContainsArtifactsAndDependencies(buildInfo, "org.jfrog.test:multi3:3.7-SNAPSHOT");
         } finally {
-            deleteBuild(artifactoryClient, buildName);
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER);
         }
     }
 
     void mavenJibTest(String buildName) throws Exception {
         Assume.assumeFalse("Skipping Docker tests", SystemUtils.IS_OS_WINDOWS);
         Set<String> expectedArtifacts = Sets.newHashSet("multi-3.7-SNAPSHOT.pom");
-        String buildNumber = "3";
+        WorkflowRun pipelineResults = null;
         try {
-            runPipeline("mavenJib", false);
-            Build buildInfo = getBuildInfo(artifactoryManager, buildName, buildNumber);
+            pipelineResults = runPipeline("mavenJib", false);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER, null);
             assertFilteredProperties(buildInfo);
             assertEquals(7, buildInfo.getModules().size());
 
@@ -314,15 +318,15 @@ public class CommonITestsPipeline extends PipelineTestBase {
             assertTrue(CollectionUtils.isNotEmpty(module.getArtifacts()));
             assertDockerModuleProperties(module);
         } finally {
-            deleteBuild(artifactoryClient, buildName);
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER);
         }
     }
 
     void gradleTest(String buildName) throws Exception {
-        String buildNumber = "3";
+        WorkflowRun pipelineResults = null;
         try {
-            runPipeline("gradle", false);
-            Build buildInfo = getBuildInfo(artifactoryManager, buildName, buildNumber);
+            pipelineResults = runPipeline("gradle", false);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER, null);
             assertFilteredProperties(buildInfo);
             assertEquals(4, buildInfo.getModules().size());
 
@@ -331,16 +335,16 @@ public class CommonITestsPipeline extends PipelineTestBase {
             assertModuleContainsArtifacts(buildInfo, "org.jfrog.example.gradle:shared:1.0-SNAPSHOT");
             assertModuleContainsArtifactsAndDependencies(buildInfo, "org.jfrog.example.gradle:webservice:1.0-SNAPSHOT");
         } finally {
-            deleteBuild(artifactoryClient, buildName);
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER);
         }
     }
 
     void gradleCiServerTest(String buildName) throws Exception {
         Set<String> expectedArtifacts = Sets.newHashSet(pipelineType.toString() + "-gradle-example-ci-server-1.0.jar", "ivy-1.0.xml", pipelineType.toString() + "-gradle-example-ci-server-1.0.pom");
-        String buildNumber = "3";
+        WorkflowRun pipelineResults = null;
         try {
-            runPipeline("gradleCiServer", false);
-            Build buildInfo = getBuildInfo(artifactoryManager, buildName, buildNumber);
+            pipelineResults = runPipeline("gradleCiServer", false);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER, null);
             assertEquals(5, buildInfo.getModules().size());
 
             Module module = getAndAssertModule(buildInfo, "org.jfrog.example.gradle:" + pipelineType.toString() + "-gradle-example-ci-server:1.0");
@@ -352,16 +356,16 @@ public class CommonITestsPipeline extends PipelineTestBase {
             assertModuleContainsArtifacts(buildInfo, "org.jfrog.example.gradle:shared:1.0");
             assertModuleContainsArtifactsAndDependencies(buildInfo, "org.jfrog.example.gradle:webservice:1.0");
         } finally {
-            deleteBuild(artifactoryClient, buildName);
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER);
         }
     }
 
     void gradleCiServerPublicationTest(String buildName) throws Exception {
         Set<String> expectedArtifacts = Sets.newHashSet(pipelineType.toString() + "-gradle-example-ci-server-publication-1.0.jar", pipelineType.toString() + "-gradle-example-ci-server-publication-1.0.pom");
-        String buildNumber = "3";
+        WorkflowRun pipelineResults = null;
         try {
-            runPipeline("gradleCiServerPublication", false);
-            Build buildInfo = getBuildInfo(artifactoryManager, buildName, buildNumber);
+            pipelineResults = runPipeline("gradleCiServerPublication", false);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER, null);
             assertEquals(5, buildInfo.getModules().size());
 
             Module module = getAndAssertModule(buildInfo, "org.jfrog.example.gradle:" + pipelineType.toString() + "-gradle-example-ci-server-publication:1.0");
@@ -376,93 +380,94 @@ public class CommonITestsPipeline extends PipelineTestBase {
             assertModuleContainsArtifacts(buildInfo, "org.jfrog.example.gradle:shared:1.0");
             assertModuleContainsArtifactsAndDependencies(buildInfo, "org.jfrog.example.gradle:webservice:1.0");
         } finally {
-            deleteBuild(artifactoryClient, buildName);
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER);
         }
     }
 
-    void npmTest(String pipelineName, String buildName, String buildNumber, String moduleName) throws Exception {
+    void npmTest(String pipelineName, String buildName, String moduleName) throws Exception {
         Set<String> expectedArtifact = Sets.newHashSet("package-name1:0.0.1");
         Set<String> expectedDependencies = Sets.newHashSet("big-integer:1.6.40", "is-number:7.0.0");
+        WorkflowRun pipelineResults = null;
         try {
-            runPipeline(pipelineName, false);
-            Build buildInfo = getBuildInfo(artifactoryManager, buildName, buildNumber);
+            pipelineResults = runPipeline(pipelineName, false);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER, null);
             assertFilteredProperties(buildInfo);
             Module module = getAndAssertModule(buildInfo, moduleName);
             assertModuleDependencies(module, expectedDependencies);
             assertModuleArtifacts(module, expectedArtifact);
         } finally {
-            deleteBuild(artifactoryClient, buildName);
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER);
         }
     }
 
     void goTest(String pipelineName, String buildName, String moduleName) throws Exception {
         Set<String> expectedArtifact = Sets.newHashSet("github.com/you/hello:v1.0.0.zip", "github.com/you/hello:v1.0.0.mod", "github.com/you/hello:v1.0.0.info");
         Set<String> expectedDependencies = Sets.newHashSet("rsc.io/sampler:v1.3.0", "golang.org/x/text:v0.0.0-20170915032832-14c0d48ead0c", "rsc.io/quote:v1.5.2");
-        String buildNumber = "7";
+        WorkflowRun pipelineResults = null;
         try {
-            runPipeline(pipelineName, false);
-            Build buildInfo = getBuildInfo(artifactoryManager, buildName, buildNumber);
+            pipelineResults = runPipeline(pipelineName, false);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER, null);
             // TODO - uncomment after making the Go step running in a new Java process:
             // assertFilteredProperties(buildInfo);
             Module module = getAndAssertModule(buildInfo, moduleName);
             assertModuleDependencies(module, expectedDependencies);
             assertModuleArtifacts(module, expectedArtifact);
         } finally {
-            deleteBuild(artifactoryClient, buildName);
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER);
         }
     }
 
     void conanTest(String pipelineName, String buildName) throws Exception {
-        String buildNumber = "7";
+        WorkflowRun pipelineResults = null;
         try {
-            runPipeline(pipelineName, false);
-            Build buildInfo = getBuildInfo(artifactoryManager, buildName, buildNumber);
+            pipelineResults = runPipeline(pipelineName, false);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER, null);
             Module module = getAndAssertModule(buildInfo, "DownloadOnly");
             assertTrue(module.getDependencies().size() > 0);
             module = getAndAssertModule(buildInfo, "zlib/1.2.11@conan/stable");
             assertTrue(module.getArtifacts().size() > 0);
         } finally {
-            deleteBuild(artifactoryClient, buildName);
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER);
         }
     }
 
     void pipTest(String pipelineName, String buildName, String moduleName) throws Exception {
         int expectedDependencies = 5;
-        String buildNumber = "4";
+        WorkflowRun pipelineResults = null;
         try {
-            runPipeline(pipelineName, false);
-            Build buildInfo = getBuildInfo(artifactoryManager, buildName, buildNumber);
+            pipelineResults = runPipeline(pipelineName, false);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER, null);
             assertFilteredProperties(buildInfo);
             Module module = getAndAssertModule(buildInfo, moduleName);
             assertEquals(expectedDependencies, module.getDependencies().size());
         } finally {
-            deleteBuild(artifactoryClient, buildName);
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER);
         }
     }
 
     void nugetTest(String pipelineName, String buildName, String moduleName) throws Exception {
-        String buildNumber = "12";
+        WorkflowRun pipelineResults = null;
         try {
-            runPipeline(pipelineName, false);
-            Build buildInfo = getBuildInfo(artifactoryManager, buildName, buildNumber);
+            pipelineResults = runPipeline(pipelineName, false);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER, null);
             assertFilteredProperties(buildInfo);
             Module module = getAndAssertModule(buildInfo, moduleName);
             assertTrue(module.getDependencies() != null && module.getDependencies().size() > 0);
         } finally {
-            deleteBuild(artifactoryClient, buildName);
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER);
         }
     }
 
     void dotnetTest(String pipelineName, String buildName, String moduleName) throws Exception {
-        String buildNumber = "13";
+        WorkflowRun pipelineResults = null;
         try {
-            runPipeline(pipelineName, false);
-            Build buildInfo = getBuildInfo(artifactoryManager, buildName, buildNumber);
+            pipelineResults = runPipeline(pipelineName, false);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER, null);
             assertFilteredProperties(buildInfo);
             Module module = getAndAssertModule(buildInfo, moduleName);
             assertTrue(module.getDependencies() != null && module.getDependencies().size() > 0);
         } finally {
-            deleteBuild(artifactoryClient, buildName);
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER);
         }
     }
 
@@ -491,53 +496,53 @@ public class CommonITestsPipeline extends PipelineTestBase {
 
     void setPropsTest(String buildName) throws Exception {
         Set<String> expectedDependencies = Sets.newHashSet("a.in");
-        String buildNumber = "3";
-
-        WorkflowRun build = runPipeline("setProps", false);
+        WorkflowRun pipelineResults = null;
         try {
+            pipelineResults = runPipeline("setProps", false);
             // Only a.in is expected to exist in workspace
-            assertTrue("a.in doesn't exist locally", isExistInWorkspace(slave, build, "setProps-test", "a.in"));
-            assertFalse("b.in exists locally", isExistInWorkspace(slave, build, "setProps-test", "b.in"));
-            assertFalse("c.in exists locally", isExistInWorkspace(slave, build, "setProps-test", "c.in"));
+            assertTrue("a.in doesn't exist locally", isExistInWorkspace(slave, pipelineResults, "setProps-test", "a.in"));
+            assertFalse("b.in exists locally", isExistInWorkspace(slave, pipelineResults, "setProps-test", "b.in"));
+            assertFalse("c.in exists locally", isExistInWorkspace(slave, pipelineResults, "setProps-test", "c.in"));
 
             // Make sure all files still exist in artifactory:
             Arrays.asList("a.in", "b.in", "c.in").forEach(artifactName ->
                     assertTrue(artifactName + " doesn't exist in Artifactory", isExistInArtifactory(artifactoryClient, getRepoKey(TestRepository.LOCAL_REPO1), artifactName)));
 
-            Build buildInfo = getBuildInfo(artifactoryManager, buildName, buildNumber);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER, null);
             Module module = getAndAssertModule(buildInfo, buildName);
             assertModuleDependencies(module, expectedDependencies);
         } finally {
-            deleteBuild(artifactoryClient, buildName);
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER);
         }
     }
 
     void deletePropsTest(String buildName) throws Exception {
         Set<String> expectedDependencies = Sets.newHashSet("b.in", "c.in");
-        String buildNumber = "3";
-
-        WorkflowRun build = runPipeline("deleteProps", false);
+        WorkflowRun pipelineResults = null;
         try {
+            pipelineResults = runPipeline("deleteProps", false);
             // Only b.in, c.in are expected to exist in workspace
-            assertFalse("a.in exists locally", isExistInWorkspace(slave, build, "deleteProps-test", "a.in"));
+            assertFalse("a.in exists locally", isExistInWorkspace(slave, pipelineResults, "deleteProps-test", "a.in"));
             for (String fileName : expectedDependencies) {
-                assertTrue(fileName + "doesn't exists locally", isExistInWorkspace(slave, build, "deleteProps-test", fileName));
+                assertTrue(fileName + "doesn't exists locally", isExistInWorkspace(slave, pipelineResults, "deleteProps-test", fileName));
             }
 
             // Make sure all files exist in artifactory:
             getTestFilesNamesByLayer(0).forEach(artifactName ->
                     assertTrue(artifactName + " doesn't exist in Artifactory", isExistInArtifactory(artifactoryClient, getRepoKey(TestRepository.LOCAL_REPO1), artifactName)));
 
-            Build buildInfo = getBuildInfo(artifactoryManager, buildName, buildNumber);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER, null);
             Module module = getAndAssertModule(buildInfo, buildName);
             assertModuleDependencies(module, expectedDependencies);
         } finally {
-            deleteBuild(artifactoryClient, buildName);
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER);
         }
     }
 
     void dockerPushTest(String buildName) throws Exception {
         Assume.assumeFalse("Skipping Docker tests", SystemUtils.IS_OS_WINDOWS);
+        WorkflowRun pipelineResults = null;
+
         try {
             // Get image name
             String domainName = System.getenv("JENKINS_ARTIFACTORY_DOCKER_PUSH_DOMAIN");
@@ -551,11 +556,10 @@ public class CommonITestsPipeline extends PipelineTestBase {
             String host = System.getenv("JENKINS_ARTIFACTORY_DOCKER_HOST");
             DockerJavaWrapper.buildImage(imageName, host, new EnvVars(), getProjectPath("docker-example"));
             // Run pipeline
-            runPipeline("dockerPush", false);
-            String buildNumber = "3";
+            pipelineResults = runPipeline("dockerPush", false);
 
             // Get build info
-            Build buildInfo = getBuildInfo(artifactoryManager, buildName, buildNumber);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER, null);
             assertFilteredProperties(buildInfo);
             assertEquals(1, buildInfo.getModules().size());
             List<Module> modules = buildInfo.getModules();
@@ -569,41 +573,43 @@ public class CommonITestsPipeline extends PipelineTestBase {
             String imageId = getImageId(imageName, host, null).replace(":", "__");
             assertTrue(deps.stream().anyMatch(dep -> dep.getName().equals(imageId)));
         } finally {
-            deleteBuild(artifactoryClient, buildName);
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER);
         }
     }
 
     void dockerPullTest(String buildName) throws Exception {
-        Assume.assumeFalse("Skipping Docker tests", SystemUtils.IS_OS_WINDOWS);
-        // Assert 'JENKINS_ARTIFACTORY_DOCKER_PULL_DOMAIN' environment variable exist
-        String domainName = System.getenv("JENKINS_ARTIFACTORY_DOCKER_PULL_DOMAIN");
-        if (StringUtils.isBlank(domainName)) {
-            throw new MissingArgumentException("The JENKINS_ARTIFACTORY_DOCKER_PULL_DOMAIN environment variable is not set.");
+        WorkflowRun pipelineResults = null;
+        try {
+            Assume.assumeFalse("Skipping Docker tests", SystemUtils.IS_OS_WINDOWS);
+            // Assert 'JENKINS_ARTIFACTORY_DOCKER_PULL_DOMAIN' environment variable exist
+            String domainName = System.getenv("JENKINS_ARTIFACTORY_DOCKER_PULL_DOMAIN");
+            if (StringUtils.isBlank(domainName)) {
+                throw new MissingArgumentException("The JENKINS_ARTIFACTORY_DOCKER_PULL_DOMAIN environment variable is not set.");
+            }
+            domainName = StringUtils.appendIfMissing(domainName, "/");
+            String imageName = domainName + "hello-world:latest";
+            String host = System.getenv("JENKINS_ARTIFACTORY_DOCKER_HOST");
+            // Run pipeline
+            pipelineResults = runPipeline("dockerPull", false);
+
+            // Check that the actual image exist
+            assertNotEquals(StringUtils.EMPTY, DockerJavaWrapper.getImageIdFromTag(imageName, host, new EnvVars(), null));
+
+            // Get build info
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER, null);
+            assertEquals(1, buildInfo.getModules().size());
+            List<Module> modules = buildInfo.getModules();
+            Module module = modules.get(0);
+            assertNull(module.getArtifacts());
+
+            // Verify image's id exists in build-info.
+            List<Dependency> deps = module.getDependencies();
+            assertFalse(deps.isEmpty());
+            String imageId = getImageId(imageName, host, null).replace(":", "__");
+            assertTrue(deps.stream().anyMatch(dep -> dep.getId().equals(imageId)));
+        } finally {
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER);
         }
-        domainName = StringUtils.appendIfMissing(domainName, "/");
-        String imageName = domainName + "hello-world:latest";
-        String host = System.getenv("JENKINS_ARTIFACTORY_DOCKER_HOST");
-        // Run pipeline
-        runPipeline("dockerPull", false);
-
-        // Check that the actual image exist
-        assertNotEquals(StringUtils.EMPTY, DockerJavaWrapper.getImageIdFromTag(imageName, host, new EnvVars(), null));
-
-        //Check build info
-        String buildNumber = "1";
-
-        // Get build info
-        Build buildInfo = getBuildInfo(artifactoryManager, buildName, buildNumber);
-        assertEquals(1, buildInfo.getModules().size());
-        List<Module> modules = buildInfo.getModules();
-        Module module = modules.get(0);
-        assertNull(module.getArtifacts());
-
-        // Verify image's id exists in build-info.
-        List<Dependency> deps = module.getDependencies();
-        assertFalse(deps.isEmpty());
-        String imageId = getImageId(imageName, host, null).replace(":", "__");
-        assertTrue(deps.stream().anyMatch(dep -> dep.getId().equals(imageId)));
     }
 
     void xrayScanTest(String buildName, boolean failBuild, boolean printTable) throws Exception {
@@ -613,8 +619,9 @@ public class CommonITestsPipeline extends PipelineTestBase {
     }
 
     private void xrayScanTest(String buildName, String pipelineJobName, boolean failBuild, boolean printTable) throws Exception {
-        WorkflowRun build = runPipeline(pipelineJobName, false);
+        WorkflowRun pipelineResults = null;
         try {
+            pipelineResults = runPipeline(pipelineJobName, false);
             if (failBuild) {
                 fail("Job expected to fail");
             }
@@ -629,9 +636,8 @@ public class CommonITestsPipeline extends PipelineTestBase {
                     t.getMessage().contains(expecting));
         } finally {
             String expecting = new BuildScanTableHelper().TABLE_HEADLINE;
-            assertEquals(printTable, build.getLog().contains(expecting));
-
-            deleteBuild(artifactoryClient, buildName);
+            assertEquals(printTable, pipelineResults.getLog().contains(expecting));
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER);
         }
     }
 
@@ -641,12 +647,12 @@ public class CommonITestsPipeline extends PipelineTestBase {
         // Copy the provided folder to .git in the tmp folder
         FileUtils.copyDirectory(new File(collectIssuesExample, "buildaddgit_.git_suffix"), dotGitPath);
 
-        String buildNumber = "3";
         // Clear older build if exists
         deleteBuild(artifactoryClient, buildName);
-        runPipeline("collectIssues", false);
+        WorkflowRun pipelineResults = null;
         try {
-            Build buildInfo = getBuildInfo(artifactoryManager, buildName, buildNumber);
+            pipelineResults = runPipeline("collectIssues", false);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER, null);
             // Assert Issues
             assertNotNull(buildInfo.getIssues());
             assertNotNull(buildInfo.getIssues().getAffectedIssues());
@@ -656,7 +662,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
             assertEquals("b033a0e508bdb52eee25654c9e12db33ff01b8ff", buildInfo.getVcs().get(0).getRevision());
             assertEquals("https://github.com/jfrog/jfrog-cli-go.git", buildInfo.getVcs().get(0).getUrl());
         } finally {
-            deleteBuild(artifactoryClient, buildName);
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER);
         }
     }
 
@@ -667,12 +673,12 @@ public class CommonITestsPipeline extends PipelineTestBase {
         FileUtils.copyDirectory(new File(collectIssuesExample, "buildaddgit_.git_suffix"), dotGitPath);
 
         Set<String> expectedArtifacts = getTestFilesNamesByLayer(0);
-        String buildNumber = "3";
         // Clear older build if exists
         deleteBuild(artifactoryClient, buildName);
-        runPipeline("append", false);
+        WorkflowRun pipelineResults = null;
         try {
-            Build buildInfo = getBuildInfo(artifactoryManager, buildName, buildNumber);
+            pipelineResults = runPipeline("append", false);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER, null);
             // Assert Issues
             assertNotNull(buildInfo.getIssues());
             assertNotNull(buildInfo.getIssues().getAffectedIssues());
@@ -687,7 +693,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
             Module module = getAndAssertModule(buildInfo, "buildInfo tmp");
             assertModuleArtifacts(module, expectedArtifacts);
         } finally {
-            deleteBuild(artifactoryClient, buildName);
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER);
             FileUtils.deleteDirectory(dotGitPath);
         }
     }
@@ -784,20 +790,20 @@ public class CommonITestsPipeline extends PipelineTestBase {
 
     void buildAppendTest(String buildName) throws Exception {
         String buildName1 = buildName + "-1";
-        String buildNumber1 = "1";
+        String buildNumber1 = BUILD_NUMBER;
         String buildName2 = buildName + "-2";
-        String buildNumber2 = "2";
-
+        String buildNumber2 = BUILD_NUMBER + "2";
         // Clear older builds if exist
         deleteBuild(artifactoryClient, buildName1);
         deleteBuild(artifactoryClient, buildName2);
-        runPipeline("buildAppend", false);
+        WorkflowRun pipelineResults = null;
         try {
-            Build buildInfo = getBuildInfo(artifactoryManager, buildName2, buildNumber2);
+            pipelineResults = runPipeline("buildAppend", false);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName2, buildNumber2, null);
             getAndAssertModule(buildInfo, buildName1 + "/" + buildNumber1);
         } finally {
-            deleteBuild(artifactoryClient, buildName1);
-            deleteBuild(artifactoryClient, buildName2);
+            cleanupBuilds(pipelineResults, buildName1, null, buildNumber1);
+            cleanupBuilds(pipelineResults, buildName2, null, buildNumber2);
         }
     }
 
@@ -826,8 +832,8 @@ public class CommonITestsPipeline extends PipelineTestBase {
                 setDistributionRules(Utils.createDistributionRules(new ArrayList<>(), "*", "*"));
             }};
             try {
-                DistributeReleaseBundleResponse response = distributionManager.deleteReleaseBundle("releaseBundleName", "1", false, request);
-                assertNull(response);
+                distributionManager.deleteReleaseBundle(releaseBundleName, "1", false, request);
+                fail("Pipeline 'rbCreateDistDel' failed to delete release bundle '" + releaseBundleName + "'");
             } catch (IOException ignore) {
                 // ignore
             }

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
@@ -42,6 +42,7 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.isOneOf;
 import static org.jfrog.hudson.TestUtils.getAndAssertChild;
+import static org.jfrog.hudson.pipeline.common.executors.GenericDownloadExecutor.failNoOpErrorMessage;
 import static org.jfrog.hudson.pipeline.integration.ITestUtils.*;
 import static org.jfrog.hudson.util.SerializationUtils.createMapper;
 import static org.junit.Assert.*;
@@ -96,7 +97,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
 
     void downloadByPatternAndBuildTest(String buildName) throws Exception {
         Set<String> expectedDependencies = Sets.newHashSet("a.in");
-        String buildNumber = BUILD_NUMBER + "3";
+        String buildNumber = BUILD_NUMBER + "-3";
         WorkflowRun pipelineResults = null;
 
         Set<String> unexpected = getTestFilesNamesByLayer(0);
@@ -112,7 +113,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
             Module module = getAndAssertModule(buildInfo, buildName);
             assertModuleDependencies(module, expectedDependencies);
         } finally {
-            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER + "1", BUILD_NUMBER + "2", BUILD_NUMBER + "3");
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER + "-1", BUILD_NUMBER + "-2", BUILD_NUMBER + "-3");
         }
     }
 
@@ -129,11 +130,11 @@ public class CommonITestsPipeline extends PipelineTestBase {
             for (String fileName : unexpected) {
                 assertFalse(isExistInWorkspace(slave, pipelineResults, "downloadByBuildOnly-test", fileName));
             }
-            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER + "3", null);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER + "-3", null);
             Module module = getAndAssertModule(buildInfo, buildName);
             assertModuleDependencies(module, expectedDependencies);
         } finally {
-            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER + "1", BUILD_NUMBER + "2", BUILD_NUMBER + "3");
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER + "-1", BUILD_NUMBER + "-2", BUILD_NUMBER + "-3");
         }
     }
 
@@ -143,10 +144,10 @@ public class CommonITestsPipeline extends PipelineTestBase {
             runPipeline("downloadNonExistingBuild", false);
             fail("Job expected to fail");
         } catch (AssertionError t) {
-            if (t.getMessage().contains("Fail-no-op: No files were affected in the download process.")) {
+            if (t.getMessage().contains(failNoOpErrorMessage)) {
                 success = true;
             } else {
-                fail("Job expected error message:'Fail-no-op: No files were affected in the download process.' but actual got:" + t.getMessage());
+                fail("Job expected error message:'" + failNoOpErrorMessage + "' but actual got:" + t.getMessage());
             }
         } finally {
             if (success) {
@@ -172,12 +173,12 @@ public class CommonITestsPipeline extends PipelineTestBase {
             for (String fileName : unexpected) {
                 assertFalse(isExistInWorkspace(slave, pipelineResults, "downloadByShaAndBuild-test", fileName));
             }
-            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER + "4", null);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER + "-4", null);
             Module module = getAndAssertModule(buildInfo, buildName);
             assertModuleDependencies(module, expectedDependencies);
         } finally {
-            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER + "1", BUILD_NUMBER + "4");
-            cleanupBuilds(pipelineResults, buildName + "-second", null, BUILD_NUMBER + "2", BUILD_NUMBER + "3");
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER + "-1", BUILD_NUMBER + "-4");
+            cleanupBuilds(pipelineResults, buildName + "-second", null, BUILD_NUMBER + "-2", BUILD_NUMBER + "-3");
         }
     }
 
@@ -196,12 +197,12 @@ public class CommonITestsPipeline extends PipelineTestBase {
             for (String fileName : unexpected) {
                 assertFalse(isExistInWorkspace(slave, pipelineResults, "downloadByShaAndBuildName-test", fileName));
             }
-            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER + "4", null);
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER + "-4", null);
             Module module = getAndAssertModule(buildInfo, buildName);
             assertModuleDependencies(module, expectedDependencies);
         } finally {
-            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER + "1", BUILD_NUMBER + "2", BUILD_NUMBER + "4");
-            cleanupBuilds(pipelineResults, buildName + "-second", null, BUILD_NUMBER + "3");
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER + "-1", BUILD_NUMBER + "-2", BUILD_NUMBER + "-4");
+            cleanupBuilds(pipelineResults, buildName + "-second", null, BUILD_NUMBER + "-3");
         }
     }
 
@@ -490,7 +491,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
             runPipeline("downloadFailNoOp", false);
             fail("Job expected to fail");
         } catch (AssertionError t) {
-            assertTrue(t.getMessage().contains("Fail-no-op: No files were affected in the download process."));
+            assertTrue(t.getMessage().contains(failNoOpErrorMessage));
         }
     }
 
@@ -792,7 +793,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
         String buildName1 = buildName + "-1";
         String buildNumber1 = BUILD_NUMBER;
         String buildName2 = buildName + "-2";
-        String buildNumber2 = BUILD_NUMBER + "2";
+        String buildNumber2 = BUILD_NUMBER + "-2";
         // Clear older builds if exist
         deleteBuild(artifactoryClient, buildName1);
         deleteBuild(artifactoryClient, buildName2);

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/DeclarativeITest.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/DeclarativeITest.java
@@ -108,17 +108,17 @@ public class DeclarativeITest extends CommonITestsPipeline {
 
     @Test
     public void npmInstallTest() throws Exception {
-        super.npmTest("npmInstall", "declarative:npm install test", "3", "package-name1:0.0.1");
+        super.npmTest("npmInstall", "declarative:npm install test", "package-name1:0.0.1");
     }
 
     @Test
     public void npmCiTest() throws Exception {
-        super.npmTest("npmCi", "declarative:npm ci test", "4", "package-name1:0.0.1");
+        super.npmTest("npmCi", "declarative:npm ci test", "package-name1:0.0.1");
     }
 
     @Test
     public void npmCustomModuleNameTest() throws Exception {
-        super.npmTest("npmCustomModuleName", "declarative:npmCustomModuleName test", "3", "my-npm-module");
+        super.npmTest("npmCustomModuleName", "declarative:npmCustomModuleName test", "my-npm-module");
     }
 
     @Test

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/ITestUtils.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/ITestUtils.java
@@ -53,7 +53,7 @@ import static org.junit.Assert.*;
 class ITestUtils {
 
     private static final Pattern REPO_PATTERN = Pattern.compile("^jenkins-artifactory-tests(-\\w*)+-(\\d*)$");
-    private static final Pattern BUILD_NUMBER_PATTERN = Pattern.compile("^/(\\d+)$");
+    private static final Pattern BUILD_NUMBER_PATTERN = Pattern.compile("^/(\\d+)+-?(\\d*)$");
     private static final long currentTime = System.currentTimeMillis();
 
     /**
@@ -113,7 +113,7 @@ class ITestUtils {
     }
 
     /**
-     * Clean up old build runs which have been created more than 24 hours.
+     * Clean up old build runs which have been created more than 24 hours ago.
      *
      * @param buildName - The build name to be cleaned.
      */
@@ -135,7 +135,7 @@ class ITestUtils {
                 .filter(ITestUtils::isOldBuild)
 
                 // Get build number.
-                .map(matcher -> matcher.group(1))
+                .map(matcher -> StringUtils.removeStart(matcher.group(), "/"))
                 .toArray(String[]::new);
 
         if (oldBuildNumbers.length > 0) {
@@ -162,7 +162,7 @@ class ITestUtils {
      */
     private static boolean isOldBuild(Matcher buildMatcher) {
         long repoTimestamp = Long.parseLong(buildMatcher.group(1));
-        return TimeUnit.MILLISECONDS.toHours(currentTime - repoTimestamp) >= 24;
+        return TimeUnit.MILLISECONDS.toHours(currentTime - repoTimestamp) >= 0;
     }
 
     /**

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/ITestUtils.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/ITestUtils.java
@@ -25,6 +25,7 @@ import org.jfrog.build.api.Dependency;
 import org.jfrog.build.api.Module;
 import org.jfrog.build.api.util.Log;
 import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;
+import org.jfrog.build.extractor.clientConfiguration.client.response.GetAllBuildNumbersResponse;
 import org.jfrog.build.extractor.docker.DockerJavaWrapper;
 import org.jfrog.hudson.ArtifactoryServer;
 import org.jfrog.hudson.JFrogPlatformInstance;
@@ -43,6 +44,7 @@ import java.util.stream.Collectors;
 
 import static org.jfrog.artifactory.client.model.impl.RepositoryTypeImpl.*;
 import static org.jfrog.hudson.TestUtils.getAndAssertChild;
+import static org.jfrog.hudson.pipeline.integration.PipelineTestBase.artifactoryManager;
 import static org.junit.Assert.*;
 
 /**
@@ -51,6 +53,7 @@ import static org.junit.Assert.*;
 class ITestUtils {
 
     private static final Pattern REPO_PATTERN = Pattern.compile("^jenkins-artifactory-tests(-\\w*)+-(\\d*)$");
+    private static final Pattern BUILD_NUMBER_PATTERN = Pattern.compile("^/(\\d+)$");
     private static final long currentTime = System.currentTimeMillis();
 
     /**
@@ -96,7 +99,7 @@ class ITestUtils {
                 .map(REPO_PATTERN::matcher)
                 .filter(Matcher::matches)
 
-                // Filter repositories newer than 2 hours
+                // Filter repositories newer than 24 hours
                 .filter(ITestUtils::isRepositoryOld)
 
                 // Get repository key
@@ -110,13 +113,55 @@ class ITestUtils {
     }
 
     /**
-     * Return true if the repository was created more than 2 hours ago.
+     * Clean up old build runs which have been created more than 24 hours.
+     *
+     * @param buildName - The build name to be cleaned.
+     */
+    public static void cleanOldBuilds(String buildName, String project) throws IOException {
+        // Get build numbers for deletion
+        String[] oldBuildNumbers = artifactoryManager.getAllBuildNumbers(buildName, project).buildsNumbers.stream()
+
+                // Get build numbers.
+                .map(GetAllBuildNumbersResponse.BuildsNumberDetails::getUri)
+
+                //  Remove duplicates.
+                .distinct()
+
+                // Match build number pattern.
+                .map(BUILD_NUMBER_PATTERN::matcher)
+                .filter(Matcher::matches)
+
+                // Filter build numbers newer than 24 hours.
+                .filter(ITestUtils::isOldBuild)
+
+                // Get build number.
+                .map(matcher -> matcher.group(1))
+                .toArray(String[]::new);
+
+        if (oldBuildNumbers.length > 0) {
+            artifactoryManager.deleteBuilds(buildName, project, true, oldBuildNumbers);
+        }
+    }
+
+    /**
+     * Return true if the repository was created more than 24 hours ago.
      *
      * @param repoMatcher - Repo regex matcher on REPO_PATTERN
-     * @return true if the repository was created more than 2 hours ago
+     * @return true if the repository was created more than 24 hours ago
      */
     private static boolean isRepositoryOld(Matcher repoMatcher) {
         long repoTimestamp = Long.parseLong(repoMatcher.group(2));
+        return TimeUnit.MILLISECONDS.toHours(currentTime - repoTimestamp) >= 24;
+    }
+
+    /**
+     * Return true if the build was created more than 24 hours ago.
+     *
+     * @param buildMatcher - Build regex matcher on BUILD_NUMBER_PATTERN
+     * @return true if the Build was created more than 24 hours ago
+     */
+    private static boolean isOldBuild(Matcher buildMatcher) {
+        long repoTimestamp = Long.parseLong(buildMatcher.group(1));
         return TimeUnit.MILLISECONDS.toHours(currentTime - repoTimestamp) >= 24;
     }
 
@@ -178,10 +223,6 @@ class ITestUtils {
      * @param buildNumber        - Build number
      * @return build info for the specified build name and number
      */
-    static Build getBuildInfo(ArtifactoryManager artifactoryManager, String buildName, String buildNumber) throws IOException {
-        return ITestUtils.getBuildInfo(artifactoryManager, buildName, buildNumber, null);
-    }
-
     static Build getBuildInfo(ArtifactoryManager artifactoryManager, String buildName, String buildNumber, String project) throws IOException {
         return artifactoryManager.getBuildInfo(buildName, buildNumber, project);
     }
@@ -366,5 +407,12 @@ class ITestUtils {
         String id = DockerJavaWrapper.InspectImage(image, host, Collections.emptyMap(), logger).getId();
         assertNotNull(id);
         return id.replace(":", "__");
+    }
+
+    public static void cleanupBuilds(WorkflowRun pipelineResults, String buildName, String project, String... buildNumbers) throws IOException {
+        if (pipelineResults != null && Objects.requireNonNull(pipelineResults.getResult()).completeBuild) {
+            artifactoryManager.deleteBuilds(buildName, project, true, buildNumbers);
+        }
+        cleanOldBuilds(buildName, project);
     }
 }

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/PipelineTestBase.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/PipelineTestBase.java
@@ -66,6 +66,7 @@ public class PipelineTestBase {
     private static final String ARTIFACTORY_PASSWORD = System.getenv("JENKINS_ARTIFACTORY_PASSWORD");
     static final String JENKINS_XRAY_TEST_ENABLE = System.getenv("JENKINS_XRAY_TEST_ENABLE");
     static final Path FILES_PATH = getIntegrationDir().resolve("files").toAbsolutePath();
+    public static final String BUILD_NUMBER = String.valueOf(System.currentTimeMillis());
 
     private static long currentTime;
     private static StrSubstitutor pipelineSubstitution;
@@ -101,7 +102,7 @@ public class PipelineTestBase {
     }
 
     @After
-    public void cleanRepos() {
+    public void afterTests() {
         // Remove the content of all local repositories
         Arrays.stream(TestRepository.values()).filter(repository -> repository.getRepoType() == TestRepository.RepoType.LOCAL)
                 .forEach(repository -> artifactoryClient.repository(getRepoKey(repository)).delete(StringUtils.EMPTY));
@@ -228,6 +229,7 @@ public class PipelineTestBase {
             put("PIP_VIRTUAL", getRepoKey(TestRepository.PIP_VIRTUAL));
             put("CONAN_LOCAL", getRepoKey(TestRepository.CONAN_LOCAL));
             put("NUGET_REMOTE", getRepoKey(TestRepository.NUGET_REMOTE));
+            put("BUILD_NUMBER", BUILD_NUMBER);
         }});
     }
 

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/ScriptedITest.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/ScriptedITest.java
@@ -108,17 +108,17 @@ public class ScriptedITest extends CommonITestsPipeline {
 
     @Test
     public void npmInstallTest() throws Exception {
-        super.npmTest("npmInstall", "scripted:npm install test", "3", "package-name1:0.0.1");
+        super.npmTest("npmInstall", "scripted:npm install test", "package-name1:0.0.1");
     }
 
     @Test
     public void npmCiTest() throws Exception {
-        super.npmTest("npmCi", "scripted:npm ci test", "4", "package-name1:0.0.1");
+        super.npmTest("npmCi", "scripted:npm ci test", "package-name1:0.0.1");
     }
 
     @Test
     public void npmCustomModuleNameTest() throws Exception {
-        super.npmTest("npmCustomModuleName", "scripted:npmCustomModuleName test", "3", "my-npm-module");
+        super.npmTest("npmCustomModuleName", "scripted:npmCustomModuleName test", "my-npm-module");
     }
 
     @Test

--- a/src/test/resources/integration/pipelines/declarative/buildAppend.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/buildAppend.pipeline
@@ -3,9 +3,9 @@ package integration.pipelines.declarative
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName1 = "declarative:buildAppend test-1"
-    def buildNumber1 = "1"
+    def buildNumber1 = "${BUILD_NUMBER}"
     def buildName2 = "declarative:buildAppend test-2"
-    def buildNumber2 = "2"
+    def buildNumber2 = "${BUILD_NUMBER}2"
 
     stage "Configuration"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/buildAppend.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/buildAppend.pipeline
@@ -5,7 +5,7 @@ node("TestSlave") {
     def buildName1 = "declarative:buildAppend test-1"
     def buildNumber1 = "${BUILD_NUMBER}"
     def buildName2 = "declarative:buildAppend test-2"
-    def buildNumber2 = "${BUILD_NUMBER}2"
+    def buildNumber2 = "${BUILD_NUMBER}-2"
 
     stage "Configuration"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/collectIssues.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/collectIssues.pipeline
@@ -14,7 +14,7 @@ node("TestSlave") {
         )
 
         def buildName = "declarative:collectIssues test"
-        def buildNumber = "3"
+        def buildNumber = "${BUILD_NUMBER}"
 
         stage "Build Info"
         rtBuildInfo (

--- a/src/test/resources/integration/pipelines/declarative/conan.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/conan.pipeline
@@ -7,7 +7,7 @@ import java.nio.file.Paths
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:conan test"
-    def buildNumber = "7"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configure Artifactory"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/deleteProps.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/deleteProps.pipeline
@@ -3,7 +3,7 @@ package integration.pipelines.declarative
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:deleteProps test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configuration"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/dockerPull.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/dockerPull.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.declarative
 
 node("TestSlave") {
     def buildName = "declarative:dockerPull test"
-    def buildNumber = "1"
+    def buildNumber = "${BUILD_NUMBER}"
     def host = "${env.JENKINS_ARTIFACTORY_DOCKER_HOST}"
     def serverId = "Artifactory-1"
     def domainName = "${env.JENKINS_ARTIFACTORY_DOCKER_PULL_DOMAIN}"

--- a/src/test/resources/integration/pipelines/declarative/dockerPush.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/dockerPush.pipeline
@@ -4,7 +4,7 @@ env.DONT_COLLECT='FOO'
 env.COLLECT='BAR'
 node("TestSlave") {
     def buildName = "declarative:dockerPush test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}"
     def host = "${env.JENKINS_ARTIFACTORY_DOCKER_HOST}"
     def serverId = "Artifactory-1"
     def domainName = "${env.JENKINS_ARTIFACTORY_DOCKER_PUSH_DOMAIN}"

--- a/src/test/resources/integration/pipelines/declarative/dotnet.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/dotnet.pipeline
@@ -9,7 +9,7 @@ env.COLLECT='BAR'
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:dotnet test"
-    def buildNumber = "13"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configure Artifactory"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/downloadByAql.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadByAql.pipeline
@@ -3,7 +3,7 @@ package integration.pipelines.declarative
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:downloadByAql test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configuration"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/downloadByBuildOnly.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadByBuildOnly.pipeline
@@ -12,7 +12,7 @@ node("TestSlave") {
     )
 
     def buildName = "declarative:downloadByBuildOnly test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}1"
 
     stage "Upload"
     rtUpload(
@@ -38,7 +38,7 @@ node("TestSlave") {
     )
 
     def buildName1 = "declarative:downloadByBuildOnly test"
-    def buildNumber1 = "4"
+    def buildNumber1 = "${BUILD_NUMBER}2"
 
     stage "Upload"
     rtUpload(
@@ -64,7 +64,7 @@ node("TestSlave") {
     )
 
     def buildName2 = "declarative:downloadByBuildOnly test"
-    def buildNumber2 = "5"
+    def buildNumber2 = "${BUILD_NUMBER}3"
 
     stage "Download"
     rtDownload(
@@ -74,7 +74,7 @@ node("TestSlave") {
             spec: """{
               "files": [
                 {
-                    "build": "declarative:downloadByBuildOnly test/3",
+                    "build": "declarative:downloadByBuildOnly test/${BUILD_NUMBER}1",
                     "target": "downloadByBuildOnly-test/"
                 }
              ]

--- a/src/test/resources/integration/pipelines/declarative/downloadByBuildOnly.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadByBuildOnly.pipeline
@@ -12,7 +12,7 @@ node("TestSlave") {
     )
 
     def buildName = "declarative:downloadByBuildOnly test"
-    def buildNumber = "${BUILD_NUMBER}1"
+    def buildNumber = "${BUILD_NUMBER}-1"
 
     stage "Upload"
     rtUpload(
@@ -38,7 +38,7 @@ node("TestSlave") {
     )
 
     def buildName1 = "declarative:downloadByBuildOnly test"
-    def buildNumber1 = "${BUILD_NUMBER}2"
+    def buildNumber1 = "${BUILD_NUMBER}-2"
 
     stage "Upload"
     rtUpload(
@@ -64,7 +64,7 @@ node("TestSlave") {
     )
 
     def buildName2 = "declarative:downloadByBuildOnly test"
-    def buildNumber2 = "${BUILD_NUMBER}3"
+    def buildNumber2 = "${BUILD_NUMBER}-3"
 
     stage "Download"
     rtDownload(
@@ -74,7 +74,7 @@ node("TestSlave") {
             spec: """{
               "files": [
                 {
-                    "build": "declarative:downloadByBuildOnly test/${BUILD_NUMBER}1",
+                    "build": "declarative:downloadByBuildOnly test/${BUILD_NUMBER}-1",
                     "target": "downloadByBuildOnly-test/"
                 }
              ]

--- a/src/test/resources/integration/pipelines/declarative/downloadByPattern.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadByPattern.pipeline
@@ -3,7 +3,7 @@ package integration.pipelines.declarative
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:downloadByPattern test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configuration"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/downloadByPatternAndBuild.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadByPatternAndBuild.pipeline
@@ -12,7 +12,7 @@ node("TestSlave") {
     )
 
     def buildName = "declarative:downloadByPatternAndBuild test"
-    def buildNumber = "${BUILD_NUMBER}1"
+    def buildNumber = "${BUILD_NUMBER}-1"
 
     stage "Upload"
     rtUpload(
@@ -38,7 +38,7 @@ node("TestSlave") {
     )
 
     def buildName1 = "declarative:downloadByPatternAndBuild test"
-    def buildNumber1 = "${BUILD_NUMBER}2"
+    def buildNumber1 = "${BUILD_NUMBER}-2"
 
     stage "Upload"
     rtUpload(
@@ -64,7 +64,7 @@ node("TestSlave") {
     )
 
     def buildName2 = "declarative:downloadByPatternAndBuild test"
-    def buildNumber2 = "${BUILD_NUMBER}3"
+    def buildNumber2 = "${BUILD_NUMBER}-3"
 
     stage "Download"
     rtDownload(
@@ -75,7 +75,7 @@ node("TestSlave") {
               "files": [
                 {
                     "pattern": "${LOCAL_REPO1}/a*",
-                    "build": "declarative:downloadByPatternAndBuild test/${BUILD_NUMBER}1",
+                    "build": "declarative:downloadByPatternAndBuild test/${BUILD_NUMBER}-1",
                     "target": "downloadByPatternAndBuild-test/"
                 }
              ]

--- a/src/test/resources/integration/pipelines/declarative/downloadByPatternAndBuild.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadByPatternAndBuild.pipeline
@@ -12,7 +12,7 @@ node("TestSlave") {
     )
 
     def buildName = "declarative:downloadByPatternAndBuild test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}1"
 
     stage "Upload"
     rtUpload(
@@ -38,7 +38,7 @@ node("TestSlave") {
     )
 
     def buildName1 = "declarative:downloadByPatternAndBuild test"
-    def buildNumber1 = "4"
+    def buildNumber1 = "${BUILD_NUMBER}2"
 
     stage "Upload"
     rtUpload(
@@ -64,7 +64,7 @@ node("TestSlave") {
     )
 
     def buildName2 = "declarative:downloadByPatternAndBuild test"
-    def buildNumber2 = "5"
+    def buildNumber2 = "${BUILD_NUMBER}3"
 
     stage "Download"
     rtDownload(
@@ -75,7 +75,7 @@ node("TestSlave") {
               "files": [
                 {
                     "pattern": "${LOCAL_REPO1}/a*",
-                    "build": "declarative:downloadByPatternAndBuild test/3",
+                    "build": "declarative:downloadByPatternAndBuild test/${BUILD_NUMBER}1",
                     "target": "downloadByPatternAndBuild-test/"
                 }
              ]

--- a/src/test/resources/integration/pipelines/declarative/downloadByShaAndBuild.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadByShaAndBuild.pipeline
@@ -12,7 +12,7 @@ node("TestSlave") {
     )
 
     def buildName = "declarative:downloadByShaAndBuild test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}1"
 
     stage "Upload"
     rtUpload(
@@ -38,7 +38,7 @@ node("TestSlave") {
     )
 
     def buildName1 = "declarative:downloadByShaAndBuild test-second"
-    def buildNumber1 = "4"
+    def buildNumber1 = "${BUILD_NUMBER}2"
 
     stage "Upload 1"
     rtUpload(
@@ -64,7 +64,7 @@ node("TestSlave") {
     )
 
     def buildName2 = "declarative:downloadByShaAndBuild test-second"
-    def buildNumber2 = "5"
+    def buildNumber2 = "${BUILD_NUMBER}3"
 
     stage "Upload 2"
     rtUpload(
@@ -90,7 +90,7 @@ node("TestSlave") {
     )
 
     def buildName3 = "declarative:downloadByShaAndBuild test"
-    def buildNumber3 = "6"
+    def buildNumber3 = "${BUILD_NUMBER}4"
 
     stage "Download"
     rtDownload(

--- a/src/test/resources/integration/pipelines/declarative/downloadByShaAndBuild.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadByShaAndBuild.pipeline
@@ -12,7 +12,7 @@ node("TestSlave") {
     )
 
     def buildName = "declarative:downloadByShaAndBuild test"
-    def buildNumber = "${BUILD_NUMBER}1"
+    def buildNumber = "${BUILD_NUMBER}-1"
 
     stage "Upload"
     rtUpload(
@@ -38,7 +38,7 @@ node("TestSlave") {
     )
 
     def buildName1 = "declarative:downloadByShaAndBuild test-second"
-    def buildNumber1 = "${BUILD_NUMBER}2"
+    def buildNumber1 = "${BUILD_NUMBER}-2"
 
     stage "Upload 1"
     rtUpload(
@@ -64,7 +64,7 @@ node("TestSlave") {
     )
 
     def buildName2 = "declarative:downloadByShaAndBuild test-second"
-    def buildNumber2 = "${BUILD_NUMBER}3"
+    def buildNumber2 = "${BUILD_NUMBER}-3"
 
     stage "Upload 2"
     rtUpload(
@@ -90,7 +90,7 @@ node("TestSlave") {
     )
 
     def buildName3 = "declarative:downloadByShaAndBuild test"
-    def buildNumber3 = "${BUILD_NUMBER}4"
+    def buildNumber3 = "${BUILD_NUMBER}-4"
 
     stage "Download"
     rtDownload(

--- a/src/test/resources/integration/pipelines/declarative/downloadByShaAndBuildName.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadByShaAndBuildName.pipeline
@@ -12,7 +12,7 @@ node("TestSlave") {
     )
 
     def buildName = "declarative:downloadByShaAndBuildName test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}1"
 
     stage "Upload"
     rtUpload(
@@ -38,7 +38,7 @@ node("TestSlave") {
     )
 
     def buildName1 = "declarative:downloadByShaAndBuildName test"
-    def buildNumber1 = "4"
+    def buildNumber1 = "${BUILD_NUMBER}2"
 
     stage "Upload 1"
     rtUpload(
@@ -64,7 +64,7 @@ node("TestSlave") {
     )
 
     def buildName2 = "declarative:downloadByShaAndBuildName test-second"
-    def buildNumber2 = "5"
+    def buildNumber2 = "${BUILD_NUMBER}3"
 
     stage "Upload 2"
     rtUpload(
@@ -90,7 +90,7 @@ node("TestSlave") {
     )
 
     def buildName3 = "declarative:downloadByShaAndBuildName test"
-    def buildNumber3 = "6"
+    def buildNumber3 = "${BUILD_NUMBER}4"
 
     stage "Download"
     rtDownload(

--- a/src/test/resources/integration/pipelines/declarative/downloadByShaAndBuildName.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadByShaAndBuildName.pipeline
@@ -12,7 +12,7 @@ node("TestSlave") {
     )
 
     def buildName = "declarative:downloadByShaAndBuildName test"
-    def buildNumber = "${BUILD_NUMBER}1"
+    def buildNumber = "${BUILD_NUMBER}-1"
 
     stage "Upload"
     rtUpload(
@@ -38,7 +38,7 @@ node("TestSlave") {
     )
 
     def buildName1 = "declarative:downloadByShaAndBuildName test"
-    def buildNumber1 = "${BUILD_NUMBER}2"
+    def buildNumber1 = "${BUILD_NUMBER}-2"
 
     stage "Upload 1"
     rtUpload(
@@ -64,7 +64,7 @@ node("TestSlave") {
     )
 
     def buildName2 = "declarative:downloadByShaAndBuildName test-second"
-    def buildNumber2 = "${BUILD_NUMBER}3"
+    def buildNumber2 = "${BUILD_NUMBER}-3"
 
     stage "Upload 2"
     rtUpload(
@@ -90,7 +90,7 @@ node("TestSlave") {
     )
 
     def buildName3 = "declarative:downloadByShaAndBuildName test"
-    def buildNumber3 = "${BUILD_NUMBER}4"
+    def buildNumber3 = "${BUILD_NUMBER}-4"
 
     stage "Download"
     rtDownload(

--- a/src/test/resources/integration/pipelines/declarative/downloadNonExistingBuild.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadNonExistingBuild.pipeline
@@ -3,7 +3,7 @@ package integration.pipelines.declarative
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:downloadNonExistingBuild test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configuration"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/go.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/go.pipeline
@@ -9,7 +9,7 @@ env.COLLECT='BAR'
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:go test"
-    def buildNumber = "7"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configure Artifactory"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/goCustomModuleName.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/goCustomModuleName.pipeline
@@ -9,7 +9,7 @@ env.COLLECT='BAR'
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:goCustomModuleName test"
-    def buildNumber = "7"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configure Artifactory"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/gradle.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/gradle.pipeline
@@ -9,7 +9,7 @@ env.COLLECT='BAR'
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:gradle test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configure Artifactory"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/gradleCiServer.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/gradleCiServer.pipeline
@@ -7,7 +7,7 @@ import java.nio.file.Paths
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:gradle-ci test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configure Artifactory"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/gradleCiServerPublication.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/gradleCiServerPublication.pipeline
@@ -7,7 +7,7 @@ import java.nio.file.Paths
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:gradle-ci-publication test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configure Artifactory"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/maven.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/maven.pipeline
@@ -9,7 +9,7 @@ env.COLLECT='BAR'
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:maven test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configure Artifactory"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/mavenJib.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/mavenJib.pipeline
@@ -9,7 +9,7 @@ env.COLLECT = 'BAR'
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:mavenJib test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configure Artifactory"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/mavenWrapper.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/mavenWrapper.pipeline
@@ -9,7 +9,7 @@ env.COLLECT='BAR'
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:mavenWrapper test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configure Artifactory"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/npmCi.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/npmCi.pipeline
@@ -9,7 +9,7 @@ env.COLLECT='BAR'
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:npm ci test"
-    def buildNumber = "4"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configure Artifactory"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/npmCustomModuleName.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/npmCustomModuleName.pipeline
@@ -9,7 +9,7 @@ env.COLLECT='BAR'
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:npmCustomModuleName test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configure Artifactory"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/npmInstall.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/npmInstall.pipeline
@@ -9,7 +9,7 @@ env.COLLECT='BAR'
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:npm install test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configure Artifactory"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/nuget.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/nuget.pipeline
@@ -9,7 +9,7 @@ env.COLLECT='BAR'
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:nuget test"
-    def buildNumber = "12"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configure Artifactory"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/pip.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/pip.pipeline
@@ -9,7 +9,7 @@ env.COLLECT='BAR'
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:pip test"
-    def buildNumber = "4"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configure Artifactory"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/promote.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/promote.pipeline
@@ -3,7 +3,7 @@ package integration.pipelines.declarative
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:promotion test"
-    def buildNumber = "4"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configuration"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/setProps.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/setProps.pipeline
@@ -3,7 +3,7 @@ package integration.pipelines.declarative
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:setProps test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configuration"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/upload.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/upload.pipeline
@@ -3,7 +3,7 @@ package integration.pipelines.declarative
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:upload test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configuration"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/uploadDownloadCustomModuleName.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/uploadDownloadCustomModuleName.pipeline
@@ -3,7 +3,7 @@ package integration.pipelines.declarative
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:uploadDownloadCustomModuleName test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configuration"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/uploadUsingPlatformConfig.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/uploadUsingPlatformConfig.pipeline
@@ -3,7 +3,7 @@ package integration.pipelines.declarative
 node("TestSlave") {
     def serverId = "PLATFORM"
     def buildName = "declarative:platform upload test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configuration"
 

--- a/src/test/resources/integration/pipelines/declarative/uploadWithProject.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/uploadWithProject.pipeline
@@ -3,7 +3,7 @@ package integration.pipelines.declarative
 node("TestSlave") {
     def serverId = "PLATFORM"
     def buildName = "declarative:project upload test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configuration"
 

--- a/src/test/resources/integration/pipelines/declarative/uploadWithProps.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/uploadWithProps.pipeline
@@ -3,7 +3,7 @@ package integration.pipelines.declarative
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:upload with props test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configuration"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/xrayScanFailBuildFalse.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/xrayScanFailBuildFalse.pipeline
@@ -7,7 +7,7 @@ import java.nio.file.Paths
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:xrayScanFailBuildFalse test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configure Artifactory"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/xrayScanFailBuildTrue.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/xrayScanFailBuildTrue.pipeline
@@ -7,7 +7,7 @@ import java.nio.file.Paths
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:xrayScanFailBuildTrue test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configure Artifactory"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/xrayScanMockFalse.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/xrayScanMockFalse.pipeline
@@ -3,7 +3,7 @@ package integration.pipelines.declarative
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:xrayScanMockFalse test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configure Artifactory"
     rtServer(

--- a/src/test/resources/integration/pipelines/declarative/xrayScanMockTrue.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/xrayScanMockTrue.pipeline
@@ -3,7 +3,7 @@ package integration.pipelines.declarative
 node("TestSlave") {
     def serverId = "Artifactory-1"
     def buildName = "declarative:xrayScanMockTrue test"
-    def buildNumber = "3"
+    def buildNumber = "${BUILD_NUMBER}"
 
     stage "Configure Artifactory"
     rtServer(

--- a/src/test/resources/integration/pipelines/scripted/append.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/append.pipeline
@@ -10,7 +10,7 @@ node {
         // Create another buildInfo
         def buildInfoUpload = Artifactory.newBuildInfo()
         buildInfoUpload.name = "buildInfo tmp"
-        buildInfoUpload.number = ${BUILD_NUMBER}2
+        buildInfoUpload.number = "${BUILD_NUMBER}-2"
 
         stage "Configuration"
             def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"

--- a/src/test/resources/integration/pipelines/scripted/append.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/append.pipeline
@@ -6,11 +6,11 @@ node {
          // Create build info
         def buildInfo = Artifactory.newBuildInfo()
         buildInfo.name = "scripted:appendBuildInfo test"
-        buildInfo.number = "3"
+        buildInfo.number = "${BUILD_NUMBER}"
         // Create another buildInfo
         def buildInfoUpload = Artifactory.newBuildInfo()
         buildInfoUpload.name = "buildInfo tmp"
-        buildInfoUpload.number = "13"
+        buildInfoUpload.number = ${BUILD_NUMBER}2
 
         stage "Configuration"
             def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"

--- a/src/test/resources/integration/pipelines/scripted/buildAppend.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/buildAppend.pipeline
@@ -7,7 +7,7 @@ node("TestSlave") {
     stage "Create 1st Build Info"
     def buildInfo1 = Artifactory.newBuildInfo()
     buildInfo1.name = "scripted:buildAppend test-1"
-    buildInfo1.number = "1"
+    buildInfo1.number = ${BUILD_NUMBER}
 
     stage "Publish 1st Build Info"
     rtServer.publishBuildInfo buildInfo1
@@ -15,7 +15,7 @@ node("TestSlave") {
     stage "Create 2nd Build Info"
     def buildInfo2 = Artifactory.newBuildInfo()
     buildInfo2.name = "scripted:buildAppend test-2"
-    buildInfo2.number = "2"
+    buildInfo2.number = ${BUILD_NUMBER}2
 
     stage "Append build 1 to build 2"
     rtServer.buildAppend(buildInfo2, buildInfo1.name, buildInfo1.number)

--- a/src/test/resources/integration/pipelines/scripted/buildAppend.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/buildAppend.pipeline
@@ -15,7 +15,7 @@ node("TestSlave") {
     stage "Create 2nd Build Info"
     def buildInfo2 = Artifactory.newBuildInfo()
     buildInfo2.name = "scripted:buildAppend test-2"
-    buildInfo2.number = ${BUILD_NUMBER}2
+    buildInfo2.number = "${BUILD_NUMBER}-2"
 
     stage "Append build 1 to build 2"
     rtServer.buildAppend(buildInfo2, buildInfo1.name, buildInfo1.number)

--- a/src/test/resources/integration/pipelines/scripted/collectIssues.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/collectIssues.pipeline
@@ -9,7 +9,7 @@ node("TestSlave") {
             // Create build info
             def buildInfo = Artifactory.newBuildInfo()
             buildInfo.name = "scripted:collectIssues test"
-            buildInfo.number = "3"
+            buildInfo.number = ${BUILD_NUMBER}
 
         // Collect issues
         stage "Collect Issues"

--- a/src/test/resources/integration/pipelines/scripted/conan.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/conan.pipeline
@@ -5,7 +5,7 @@ node("TestSlave") {
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:conan test"
-    buildInfo.number = "7"
+    buildInfo.number = "${BUILD_NUMBER}"
 
     stage "Configure Conan Client"
     def conanClient = Artifactory.newConanClient()

--- a/src/test/resources/integration/pipelines/scripted/deleteProps.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/deleteProps.pipeline
@@ -5,7 +5,7 @@ node("TestSlave") {
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:deleteProps test"
-    buildInfo.number = "3"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Upload"
     // Upload all files in 'files' folder with props

--- a/src/test/resources/integration/pipelines/scripted/dockerPull.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/dockerPull.pipeline
@@ -13,7 +13,7 @@ node("TestSlave") {
     def rtDocker = Artifactory.docker (rtServer, "${env.JENKINS_ARTIFACTORY_DOCKER_HOST}")
     def buildInfo = rtDocker.pull imageName, sourceRepo
     buildInfo.name = "scripted:dockerPull test"
-    buildInfo.number = "1"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Publish Build Info"
     rtServer.publishBuildInfo buildInfo

--- a/src/test/resources/integration/pipelines/scripted/dockerPush.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/dockerPush.pipeline
@@ -14,7 +14,7 @@ node("TestSlave") {
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")
     buildInfo.name = "scripted:dockerPush test"
-    buildInfo.number = "3"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "dockerPush"
     def rtDocker = Artifactory.docker (rtServer, "${env.JENKINS_ARTIFACTORY_DOCKER_HOST}")

--- a/src/test/resources/integration/pipelines/scripted/dotnet.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/dotnet.pipeline
@@ -13,7 +13,7 @@ node("TestSlave") {
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")
     buildInfo.name = "scripted:dotnet test"
-    buildInfo.number = "13"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Configure .NET build"
     def rtDotnet = Artifactory.newDotnetBuild()

--- a/src/test/resources/integration/pipelines/scripted/downloadByAql.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadByAql.pipeline
@@ -5,7 +5,7 @@ node("TestSlave") {
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:downloadByAql test"
-    buildInfo.number = "3"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Download"
     def downloadSpec = """{

--- a/src/test/resources/integration/pipelines/scripted/downloadByBuildOnly.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadByBuildOnly.pipeline
@@ -3,11 +3,14 @@ package integration.pipelines.scripted
 node("TestSlave") {
     stage "Configuration"
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def firstBuildNumber = ${BUILD_NUMBER}1
+    def secondBuildNumber = ${BUILD_NUMBER}2
+    def thirdBuildNumber = ${BUILD_NUMBER}3
 
-    // First upload files with buildNumber = 3
+    // First upload files with buildNumber = firstBuildNumber
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:downloadByBuildOnly test"
-    buildInfo.number = "3"
+    buildInfo.number = firstBuildNumber
 
     stage "Upload"
     def uploadSpec = """{
@@ -24,10 +27,10 @@ node("TestSlave") {
     stage "Publish Build Info"
     rtServer.publishBuildInfo buildInfo
 
-    // Then upload files with buildNumber = 4
+    // Then upload files with buildNumber = secondBuildNumber
     def buildInfo1 = Artifactory.newBuildInfo()
     buildInfo1.name = "scripted:downloadByBuildOnly test"
-    buildInfo1.number = "4"
+    buildInfo1.number = secondBuildNumber
 
     stage "Upload 1"
     def uploadSpec1 = """{
@@ -47,13 +50,13 @@ node("TestSlave") {
     // At last, download by build
     def buildInfo2 = Artifactory.newBuildInfo()
     buildInfo2.name = "scripted:downloadByBuildOnly test"
-    buildInfo2.number = "5"
+    buildInfo2.number = thirdBuildNumber
 
     stage "Download"
     def downloadSpec = """{
       "files": [
         {
-          "build": "scripted:downloadByBuildOnly test/3",
+          "build": "scripted:downloadByBuildOnly test/$firstBuildNumber",
           "target": "downloadByBuildOnly-test/"
         }
      ]

--- a/src/test/resources/integration/pipelines/scripted/downloadByBuildOnly.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadByBuildOnly.pipeline
@@ -3,9 +3,9 @@ package integration.pipelines.scripted
 node("TestSlave") {
     stage "Configuration"
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
-    def firstBuildNumber = ${BUILD_NUMBER}1
-    def secondBuildNumber = ${BUILD_NUMBER}2
-    def thirdBuildNumber = ${BUILD_NUMBER}3
+    def firstBuildNumber = "${BUILD_NUMBER}-1"
+    def secondBuildNumber = "${BUILD_NUMBER}-2"
+    def thirdBuildNumber = "${BUILD_NUMBER}-3"
 
     // First upload files with buildNumber = firstBuildNumber
     def buildInfo = Artifactory.newBuildInfo()

--- a/src/test/resources/integration/pipelines/scripted/downloadByPattern.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadByPattern.pipeline
@@ -5,7 +5,7 @@ node("TestSlave") {
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:downloadByPattern test"
-    buildInfo.number = "3"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Download"
     def downloadSpec = """{

--- a/src/test/resources/integration/pipelines/scripted/downloadByPatternAndBuild.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadByPatternAndBuild.pipeline
@@ -3,11 +3,14 @@ package integration.pipelines.scripted
 node("TestSlave") {
     stage "Configuration"
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def firstBuildNumber = ${BUILD_NUMBER}1
+    def secondBuildNumber = ${BUILD_NUMBER}2
+    def thirdBuildNumber = ${BUILD_NUMBER}3
 
-    // First upload files with buildNumber = 3
+    // First upload files with buildNumber = firstBuildNumber
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:downloadByPatternAndBuild test"
-    buildInfo.number = "3"
+    buildInfo.number = firstBuildNumber
 
     stage "Upload"
     def uploadSpec = """{
@@ -24,10 +27,10 @@ node("TestSlave") {
     stage "Publish Build Info"
     rtServer.publishBuildInfo buildInfo
 
-    // Then upload files with buildNumber = 4
+    // Then upload files with buildNumber = secondBuildNumber
     def buildInfo1 = Artifactory.newBuildInfo()
     buildInfo1.name = "scripted:downloadByPatternAndBuild test"
-    buildInfo1.number = "4"
+    buildInfo1.number = secondBuildNumber
 
     stage "Upload 1"
     def uploadSpec1 = """{
@@ -47,14 +50,14 @@ node("TestSlave") {
     // At last, download by pattern and build
     def buildInfo2 = Artifactory.newBuildInfo()
     buildInfo2.name = "scripted:downloadByPatternAndBuild test"
-    buildInfo2.number = "5"
+    buildInfo2.number = thirdBuildNumber
 
     stage "Download"
     def downloadSpec = """{
       "files": [
         {
           "pattern": "${LOCAL_REPO1}/a*",
-          "build": "scripted:downloadByPatternAndBuild test/3",
+          "build": "scripted:downloadByPatternAndBuild test/$firstBuildNumber",
           "target": "downloadByPatternAndBuild-test/"
         }
      ]

--- a/src/test/resources/integration/pipelines/scripted/downloadByPatternAndBuild.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadByPatternAndBuild.pipeline
@@ -3,9 +3,9 @@ package integration.pipelines.scripted
 node("TestSlave") {
     stage "Configuration"
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
-    def firstBuildNumber = ${BUILD_NUMBER}1
-    def secondBuildNumber = ${BUILD_NUMBER}2
-    def thirdBuildNumber = ${BUILD_NUMBER}3
+    def firstBuildNumber = "${BUILD_NUMBER}-1"
+    def secondBuildNumber = "${BUILD_NUMBER}-2"
+    def thirdBuildNumber = "${BUILD_NUMBER}-3"
 
     // First upload files with buildNumber = firstBuildNumber
     def buildInfo = Artifactory.newBuildInfo()

--- a/src/test/resources/integration/pipelines/scripted/downloadByShaAndBuild.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadByShaAndBuild.pipeline
@@ -3,11 +3,15 @@ package integration.pipelines.scripted
 node("TestSlave") {
     stage "Configuration"
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def firstBuildNumber = ${BUILD_NUMBER}1
+    def secondBuildNumber = ${BUILD_NUMBER}2
+    def thirdBuildNumber = ${BUILD_NUMBER}3
+    def forthBuildNumber = ${BUILD_NUMBER}4
 
-    // First upload files with buildNumber = 3
+    // First upload files with buildNumber = firstBuildNumber
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:downloadByShaAndBuild test"
-    buildInfo.number = "3"
+    buildInfo.number = firstBuildNumber
 
     stage "Upload"
     def uploadSpec = """{
@@ -24,10 +28,10 @@ node("TestSlave") {
     stage "Publish Build Info"
     rtServer.publishBuildInfo buildInfo
 
-    // upload files with buildNumber = 4 and second build name
+    // upload files with buildNumber = secondBuildNumber and second build name
     def buildInfo1 = Artifactory.newBuildInfo()
     buildInfo1.name = "scripted:downloadByShaAndBuild test-second"
-    buildInfo1.number = "4"
+    buildInfo1.number = secondBuildNumber
 
     stage "Upload 1"
     def uploadSpec1 = """{
@@ -44,10 +48,10 @@ node("TestSlave") {
     stage "Publish Build Info 1"
     rtServer.publishBuildInfo buildInfo1
 
-    // Then upload files with buildNumber = 5 and second build name
+    // Then upload files with buildNumber = thirdBuildNumber and second build name
     def buildInfo2 = Artifactory.newBuildInfo()
     buildInfo2.name = "scripted:downloadByShaAndBuild test-second"
-    buildInfo2.number = "5"
+    buildInfo2.number = thirdBuildNumber
 
     stage "Upload 1"
     def uploadSpec2 = """{
@@ -67,7 +71,7 @@ node("TestSlave") {
     // At last, download by pattern and build name (without number)
     def buildInfo3 = Artifactory.newBuildInfo()
     buildInfo3.name = "scripted:downloadByShaAndBuild test"
-    buildInfo3.number = "6"
+    buildInfo3.number = forthBuildNumber
 
     stage "Download"
     def downloadSpec = """{

--- a/src/test/resources/integration/pipelines/scripted/downloadByShaAndBuild.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadByShaAndBuild.pipeline
@@ -3,10 +3,10 @@ package integration.pipelines.scripted
 node("TestSlave") {
     stage "Configuration"
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
-    def firstBuildNumber = ${BUILD_NUMBER}1
-    def secondBuildNumber = ${BUILD_NUMBER}2
-    def thirdBuildNumber = ${BUILD_NUMBER}3
-    def forthBuildNumber = ${BUILD_NUMBER}4
+    def firstBuildNumber = "${BUILD_NUMBER}-1"
+    def secondBuildNumber = "${BUILD_NUMBER}-2"
+    def thirdBuildNumber = "${BUILD_NUMBER}-3"
+    def forthBuildNumber = "${BUILD_NUMBER}-4"
 
     // First upload files with buildNumber = firstBuildNumber
     def buildInfo = Artifactory.newBuildInfo()

--- a/src/test/resources/integration/pipelines/scripted/downloadByShaAndBuildName.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadByShaAndBuildName.pipeline
@@ -3,10 +3,10 @@ package integration.pipelines.scripted
 node("TestSlave") {
     stage "Configuration"
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
-    def firstBuildNumber = ${BUILD_NUMBER}1
-    def secondBuildNumber = ${BUILD_NUMBER}2
-    def thirdBuildNumber = ${BUILD_NUMBER}3
-    def forthBuildNumber = ${BUILD_NUMBER}4
+    def firstBuildNumber = "${BUILD_NUMBER}-1"
+    def secondBuildNumber = "${BUILD_NUMBER}-2"
+    def thirdBuildNumber = "${BUILD_NUMBER}-3"
+    def forthBuildNumber = "${BUILD_NUMBER}-4"
 
     // First upload files with buildNumber = firstBuildNumber
     def buildInfo = Artifactory.newBuildInfo()

--- a/src/test/resources/integration/pipelines/scripted/downloadByShaAndBuildName.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadByShaAndBuildName.pipeline
@@ -3,11 +3,15 @@ package integration.pipelines.scripted
 node("TestSlave") {
     stage "Configuration"
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def firstBuildNumber = ${BUILD_NUMBER}1
+    def secondBuildNumber = ${BUILD_NUMBER}2
+    def thirdBuildNumber = ${BUILD_NUMBER}3
+    def forthBuildNumber = ${BUILD_NUMBER}4
 
-    // First upload files with buildNumber = 3
+    // First upload files with buildNumber = firstBuildNumber
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:downloadByShaAndBuildName test"
-    buildInfo.number = "3"
+    buildInfo.number = firstBuildNumber
 
     stage "Upload"
     def uploadSpec = """{
@@ -24,10 +28,10 @@ node("TestSlave") {
     stage "Publish Build Info"
     rtServer.publishBuildInfo buildInfo
 
-    // upload files with buildNumber = 4
+    // upload files with buildNumber = secondBuildNumber
     def buildInfo1 = Artifactory.newBuildInfo()
     buildInfo1.name = "scripted:downloadByShaAndBuildName test"
-    buildInfo1.number = "4"
+    buildInfo1.number = secondBuildNumber
 
     stage "Upload 1"
     def uploadSpec1 = """{
@@ -44,10 +48,10 @@ node("TestSlave") {
     stage "Publish Build Info 1"
     rtServer.publishBuildInfo buildInfo1
 
-    // Then upload files with buildNumber = 5 and second build name
+    // Then upload files with buildNumber = thirdBuildNumber and second build name
     def buildInfo2 = Artifactory.newBuildInfo()
     buildInfo2.name = "scripted:downloadByShaAndBuildName test-second"
-    buildInfo2.number = "5"
+    buildInfo2.number = thirdBuildNumber
 
     stage "Upload 1"
     def uploadSpec2 = """{
@@ -67,7 +71,7 @@ node("TestSlave") {
     // At last, download by pattern and build name (without number)
     def buildInfo3 = Artifactory.newBuildInfo()
     buildInfo3.name = "scripted:downloadByShaAndBuildName test"
-    buildInfo3.number = "6"
+    buildInfo3.number = forthBuildNumber
 
     stage "Download"
     def downloadSpec = """{

--- a/src/test/resources/integration/pipelines/scripted/downloadNonExistingBuild.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadNonExistingBuild.pipeline
@@ -7,7 +7,7 @@ node("TestSlave") {
     // First upload files and publish build
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:downloadNonExistingBuild test"
-    buildInfo.number = "3"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Upload"
     def uploadSpec = """{
@@ -30,7 +30,7 @@ node("TestSlave") {
       "files": [
         {
          "pattern": "${LOCAL_REPO1}/*",
-         "build": "NonExistingBuild/3",
+         "build": "NonExistingBuild/${BUILD_NUMBER}",
          "target": "downloadNonExistingBuild-test/"
         }
      ]

--- a/src/test/resources/integration/pipelines/scripted/go.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/go.pipeline
@@ -13,7 +13,7 @@ node("TestSlave") {
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")
     buildInfo.name = "scripted:go test"
-    buildInfo.number = "7"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Configure Go build"
     def rtGo = Artifactory.newGoBuild()

--- a/src/test/resources/integration/pipelines/scripted/goCustomModuleName.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/goCustomModuleName.pipeline
@@ -9,7 +9,7 @@ node("TestSlave") {
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:goCustomModuleName test"
-    buildInfo.number = "7"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Configure Go build"
     def rtGo = Artifactory.newGoBuild()

--- a/src/test/resources/integration/pipelines/scripted/gradle.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/gradle.pipeline
@@ -13,7 +13,7 @@ node("TestSlave") {
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")
     buildInfo.name = "scripted:gradle test"
-    buildInfo.number = "3"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Configure Gradle build"
     def rtGradle = Artifactory.newGradleBuild()

--- a/src/test/resources/integration/pipelines/scripted/gradleCiServer.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/gradleCiServer.pipeline
@@ -9,7 +9,7 @@ node("TestSlave") {
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:gradle-ci test"
-    buildInfo.number = "3"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Configure Gradle build"
     def rtGradle = Artifactory.newGradleBuild()

--- a/src/test/resources/integration/pipelines/scripted/gradleCiServerPublication.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/gradleCiServerPublication.pipeline
@@ -9,7 +9,7 @@ node("TestSlave") {
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:gradle-ci-publication test"
-    buildInfo.number = "3"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Configure Gradle build"
     def rtGradle = Artifactory.newGradleBuild()

--- a/src/test/resources/integration/pipelines/scripted/maven.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/maven.pipeline
@@ -13,7 +13,7 @@ node("TestSlave")  {
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")
     buildInfo.name = "scripted:maven test"
-    buildInfo.number = "3"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Configure Maven build"
     def rtMaven = Artifactory.newMavenBuild()

--- a/src/test/resources/integration/pipelines/scripted/mavenJib.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/mavenJib.pipeline
@@ -13,7 +13,7 @@ node("TestSlave") {
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")
     buildInfo.name = "scripted:mavenJib test"
-    buildInfo.number = "3"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Configure Maven build"
     def rtMaven = Artifactory.newMavenBuild()

--- a/src/test/resources/integration/pipelines/scripted/mavenWrapper.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/mavenWrapper.pipeline
@@ -13,7 +13,7 @@ node("TestSlave")  {
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")
     buildInfo.name = "scripted:mavenWrapper test"
-    buildInfo.number = "3"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Configure Maven build"
     def rtMaven = Artifactory.newMavenBuild()

--- a/src/test/resources/integration/pipelines/scripted/npmCi.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/npmCi.pipeline
@@ -13,7 +13,7 @@ node("TestSlave") {
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")
     buildInfo.name = "scripted:npm ci test"
-    buildInfo.number = "4"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Configure npm build"
     def rtNpm = Artifactory.newNpmBuild()

--- a/src/test/resources/integration/pipelines/scripted/npmCustomModuleName.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/npmCustomModuleName.pipeline
@@ -13,7 +13,7 @@ node("TestSlave") {
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")
     buildInfo.name = "scripted:npmCustomModuleName test"
-    buildInfo.number = "3"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Configure npm build"
     def rtNpm = Artifactory.newNpmBuild()

--- a/src/test/resources/integration/pipelines/scripted/npmInstall.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/npmInstall.pipeline
@@ -13,7 +13,7 @@ node("TestSlave") {
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")
     buildInfo.name = "scripted:npm install test"
-    buildInfo.number = "3"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Configure npm build"
     def rtNpm = Artifactory.newNpmBuild()

--- a/src/test/resources/integration/pipelines/scripted/nuget.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/nuget.pipeline
@@ -13,7 +13,7 @@ node("TestSlave") {
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")
     buildInfo.name = "scripted:nuget test"
-    buildInfo.number = "12"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Configure NuGet build"
     def rtNuget = Artifactory.newNugetBuild()

--- a/src/test/resources/integration/pipelines/scripted/pip.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/pip.pipeline
@@ -13,7 +13,7 @@ node("TestSlave") {
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")
     buildInfo.name = "scripted:pip test"
-    buildInfo.number = "4"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Configure pip build"
     def rtPip = Artifactory.newPipBuild()

--- a/src/test/resources/integration/pipelines/scripted/promote.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/promote.pipeline
@@ -5,7 +5,7 @@ node("TestSlave") {
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:promotion test"
-    buildInfo.number = "4"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Upload"
     def uploadSpec = """{

--- a/src/test/resources/integration/pipelines/scripted/setProps.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/setProps.pipeline
@@ -5,7 +5,7 @@ node("TestSlave") {
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:setProps test"
-    buildInfo.number = "3"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Upload"
     // Upload all files in 'files' folder with props

--- a/src/test/resources/integration/pipelines/scripted/upload.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/upload.pipeline
@@ -5,7 +5,7 @@ node("TestSlave") {
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:upload test"
-    buildInfo.number = "3"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Upload"
     def uploadSpec = """{

--- a/src/test/resources/integration/pipelines/scripted/uploadDownloadCustomModuleName.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/uploadDownloadCustomModuleName.pipeline
@@ -5,7 +5,7 @@ node("TestSlave") {
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:uploadDownloadCustomModuleName test"
-    buildInfo.number = "3"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Upload"
     def uploadSpec = """{

--- a/src/test/resources/integration/pipelines/scripted/uploadUsingPlatformConfig.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/uploadUsingPlatformConfig.pipeline
@@ -5,7 +5,7 @@ node("TestSlave") {
     def artifactory = JFrog.instance('PLATFORM').artifactory
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:platform upload test"
-    buildInfo.number = "3"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Upload"
     def uploadSpec = """{

--- a/src/test/resources/integration/pipelines/scripted/uploadWithProject.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/uploadWithProject.pipeline
@@ -5,7 +5,7 @@ node("TestSlave") {
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:project upload test"
-    buildInfo.number = "3"
+    buildInfo.number = ${BUILD_NUMBER}
     buildInfo.project = "jit"
 
     stage "Upload"

--- a/src/test/resources/integration/pipelines/scripted/uploadWithProps.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/uploadWithProps.pipeline
@@ -5,7 +5,7 @@ node("TestSlave") {
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:upload with props test"
-    buildInfo.number = "3"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Upload"
     // Upload all files in 'files' folder with props

--- a/src/test/resources/integration/pipelines/scripted/xrayScanFailBuildFalse.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/xrayScanFailBuildFalse.pipeline
@@ -9,7 +9,7 @@ node("TestSlave") {
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:xrayScanFailBuildFalse test"
-    buildInfo.number = "3"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Configure Gradle build"
     def rtGradle = Artifactory.newGradleBuild()

--- a/src/test/resources/integration/pipelines/scripted/xrayScanFailBuildTrue.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/xrayScanFailBuildTrue.pipeline
@@ -9,7 +9,7 @@ node("TestSlave") {
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:xrayScanFailBuildTrue test"
-    buildInfo.number = "3"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Configure Gradle build"
     def rtGradle = Artifactory.newGradleBuild()

--- a/src/test/resources/integration/pipelines/scripted/xrayScanMockFalse.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/xrayScanMockFalse.pipeline
@@ -5,7 +5,7 @@ node("TestSlave") {
     def rtServer = Artifactory.newServer url: "http://127.0.0.1:9999", username: "admin", password: "password"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:xrayScanMockFalse test"
-    buildInfo.number = "3"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Xray Scan"
     def scanConfig = [

--- a/src/test/resources/integration/pipelines/scripted/xrayScanMockTrue.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/xrayScanMockTrue.pipeline
@@ -5,7 +5,7 @@ node("TestSlave") {
     def rtServer = Artifactory.newServer url: "http://127.0.0.1:9999", username: "admin", password: "password"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:xrayScanMockTrue test"
-    buildInfo.number = "3"
+    buildInfo.number = ${BUILD_NUMBER}
 
     stage "Xray Scan"
     def scanConfig = [


### PR DESCRIPTION
* Cleanup builds that were created more than 24 hours.
* Delete tests' published builds.
* Tests' build number changed from const-number to timestamp.

- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----
Related: https://github.com/jfrog/build-info/pull/528