### PR TITLE
Bugfix - exception raised when multibranch plugin is not installed

### DIFF
--- a/src/main/java/org/jfrog/hudson/trigger/ArtifactoryMultibranchTrigger.java
+++ b/src/main/java/org/jfrog/hudson/trigger/ArtifactoryMultibranchTrigger.java
@@ -76,7 +76,12 @@ public class ArtifactoryMultibranchTrigger extends BaseTrigger<MultiBranchProjec
 
         @Override
         public boolean isApplicable(Item item) {
-            return item instanceof MultiBranchProject;
+            try {
+                return item instanceof MultiBranchProject;
+            } catch (NoClassDefFoundError ignore) {
+                // workflow-multibranch plugin is not installed
+                return false;
+            }
         }
 
         public List<JFrogPlatformInstance> getJfrogInstances() {

--- a/src/main/java/org/jfrog/hudson/trigger/ArtifactoryTrigger.java
+++ b/src/main/java/org/jfrog/hudson/trigger/ArtifactoryTrigger.java
@@ -45,7 +45,15 @@ public class ArtifactoryTrigger extends BaseTrigger<BuildableItem> {
 
         @Override
         public boolean isApplicable(Item item) {
-            return item instanceof BuildableItem && !(item instanceof MultiBranchProject);
+            if (!(item instanceof BuildableItem)) {
+                return false;
+            }
+            try {
+                return !(item instanceof MultiBranchProject);
+            } catch (NoClassDefFoundError ignore) {
+                // workflow-multibranch plugin is not installed
+                return true;
+            }
         }
 
         public List<JFrogPlatformInstance> getJfrogInstances() {


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----

If the multibranch-workflow plugin doesn't installed, an attempt to configuring a pipeline may throw a NoClassFoundException:
```
Caused by: java.lang.NoClassDefFoundError: jenkins/branch/MultiBranchProject
        at org.jfrog.hudson.trigger.ArtifactoryTrigger$DescriptorImpl.isApplicable(ArtifactoryTrigger.java:48)
        at hudson.triggers.Trigger.for_(Trigger.java:335)
```