### PR TITLE
Fix rbCreateUpdateSign test

### DIFF
--- a/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
@@ -818,7 +818,11 @@ public class CommonITestsPipeline extends PipelineTestBase {
         // Make sure release bundle updated
         assertEquals("Update a release bundle", status.getDescription());
         // Make sure release bundle is signed
-        assertThat(status.getState(), isOneOf(GetReleaseBundleStatusResponse.DistributionState.SIGNED, GetReleaseBundleStatusResponse.DistributionState.READY_FOR_DISTRIBUTION));
+        assertThat(status.getState(), isOneOf(
+                GetReleaseBundleStatusResponse.DistributionState.SIGNED,
+                GetReleaseBundleStatusResponse.DistributionState.STORED,
+                GetReleaseBundleStatusResponse.DistributionState.READY_FOR_DISTRIBUTION)
+        );
     }
 
     void rbCreateDistDel(String releaseBundleName) throws Exception {


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----

The test should allow STORED status, since this status is also signed. 