### PR TITLE
Bugfix - autofill JFrog servers get trigger for the wrong server-id

### DIFF
--- a/src/main/java/org/jfrog/hudson/ArtifactoryBuilder.java
+++ b/src/main/java/org/jfrog/hudson/ArtifactoryBuilder.java
@@ -420,6 +420,9 @@ public class ArtifactoryBuilder extends GlobalConfiguration {
                 if (!preSavedInstance.isPresent()) {
                     continue;
                 }
+                if (!isPlatformUrlChangedSinceLastSave(preSavedInstance.get(), newInstance)) {
+                    continue;
+                }
                 // Check if Artifactory URL has a different prefix than platform URL.
                 if (!StringUtils.startsWithIgnoreCase(newInstance.getArtifactoryUrl(), newInstance.getUrl())) {
                     // Check if the new Artifactory URL has changed since last time by comparing the URLs.
@@ -460,6 +463,10 @@ public class ArtifactoryBuilder extends GlobalConfiguration {
 
         private boolean isArtifactoryUrlChangedSinceLastSave(JFrogPlatformInstance oldInstance, JFrogPlatformInstance newInstance) {
             return !oldInstance.getArtifactory().getArtifactoryUrl().equals(newInstance.getArtifactory().getArtifactoryUrl());
+        }
+
+        private boolean isPlatformUrlChangedSinceLastSave(JFrogPlatformInstance oldInstance, JFrogPlatformInstance newInstance) {
+            return !oldInstance.getUrl().equals(newInstance.getUrl());
         }
 
         private boolean isDistributionUrlChangedSinceLastSave(JFrogPlatformInstance oldInstance, JFrogPlatformInstance newInstance) {

--- a/src/main/java/org/jfrog/hudson/ArtifactoryBuilder.java
+++ b/src/main/java/org/jfrog/hudson/ArtifactoryBuilder.java
@@ -467,7 +467,7 @@ public class ArtifactoryBuilder extends GlobalConfiguration {
 
         private boolean isPlatformUrlChangedSinceLastSave(JFrogPlatformInstance oldInstance, JFrogPlatformInstance newInstance) {
             String oldUrl = oldInstance.getUrl();
-            if(StringUtils.isEmpty(oldUrl)){
+            if (StringUtils.isEmpty(oldUrl)) {
                 return StringUtils.isNotEmpty(newInstance.getUrl());
             }
             return !oldInstance.getUrl().equals(newInstance.getUrl());

--- a/src/main/java/org/jfrog/hudson/ArtifactoryBuilder.java
+++ b/src/main/java/org/jfrog/hudson/ArtifactoryBuilder.java
@@ -466,6 +466,10 @@ public class ArtifactoryBuilder extends GlobalConfiguration {
         }
 
         private boolean isPlatformUrlChangedSinceLastSave(JFrogPlatformInstance oldInstance, JFrogPlatformInstance newInstance) {
+            String oldUrl = oldInstance.getUrl();
+            if(StringUtils.isEmpty(oldUrl)){
+                return StringUtils.isNotEmpty(newInstance.getUrl());
+            }
             return !oldInstance.getUrl().equals(newInstance.getUrl());
         }
 

--- a/src/test/java/org/jfrog/hudson/ArtifactoryBuilderTest.java
+++ b/src/test/java/org/jfrog/hudson/ArtifactoryBuilderTest.java
@@ -5,6 +5,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
@@ -54,5 +55,35 @@ public class ArtifactoryBuilderTest {
         assertEquals("www.new333.jfrog.platform.com", newJfrogPlatformInstance.getPlatformUrl());
         assertEquals("www.new444.jfrog.platform.com/artifactory", newJfrogPlatformInstance.getArtifactoryUrl());
         assertEquals("www.new555.jfrog.platform.com/distribution", newJfrogPlatformInstance.getDistributionUrl());
+    }
+
+    @Test
+    public void testMultipleAutoFillPlatformServers() {
+        // Init tests
+        ArtifactoryBuilder.DescriptorImpl testBuilder = ExtensionList.lookupSingleton(ArtifactoryBuilder.DescriptorImpl.class);
+        JFrogPlatformInstance firstJfrogPlatformInstance = new JFrogPlatformInstance("testInstance1", "www.jfrog.platform.com1", "abc", "abc", null, null, 0, false, 0, 0);
+        JFrogPlatformInstance secondJfrogPlatformInstance = new JFrogPlatformInstance("testInstance2", "www.jfrog.platform.com2", "def", "def", null, null, 0, false, 0, 0);
+        JFrogPlatformInstance thirdJfrogPlatformInstance = new JFrogPlatformInstance("testInstance3", "www.jfrog.platform.com3", "jkl", "jkl", null, null, 0, false, 0, 0);
+        testBuilder.setJfrogInstances(Arrays.asList(firstJfrogPlatformInstance, secondJfrogPlatformInstance, thirdJfrogPlatformInstance));
+
+        // Check auto fill on instance id only for changing platform url,
+        JFrogPlatformInstance newSecondJfrogPlatformInstance = new JFrogPlatformInstance("testInstance2", "www.jfrog.platform.com2", "ghi", "ghi", null, null, 0, false, 0, 0);
+        JFrogPlatformInstance newthirdJfrogPlatformInstance = new JFrogPlatformInstance("testInstance3", "www.jfrog.platform.com33", "jkl", "jkl", null, null, 0, false, 0, 0);
+        testBuilder.autoFillPlatformServers(Arrays.asList(firstJfrogPlatformInstance, newSecondJfrogPlatformInstance, newthirdJfrogPlatformInstance));
+        assertEquals("www.jfrog.platform.com1", firstJfrogPlatformInstance.getPlatformUrl());
+        assertEquals("abc", firstJfrogPlatformInstance.getArtifactoryUrl());
+        assertEquals("abc", firstJfrogPlatformInstance.getDistributionUrl());
+
+        assertEquals("www.jfrog.platform.com2", secondJfrogPlatformInstance.getPlatformUrl());
+        assertEquals("def", secondJfrogPlatformInstance.getArtifactoryUrl());
+        assertEquals("def", secondJfrogPlatformInstance.getDistributionUrl());
+
+        assertEquals("www.jfrog.platform.com2", newSecondJfrogPlatformInstance.getPlatformUrl());
+        assertEquals("ghi", newSecondJfrogPlatformInstance.getArtifactoryUrl());
+        assertEquals("ghi", newSecondJfrogPlatformInstance.getDistributionUrl());
+
+        assertEquals("www.jfrog.platform.com33", newthirdJfrogPlatformInstance.getPlatformUrl());
+        assertEquals("www.jfrog.platform.com33/artifactory", newthirdJfrogPlatformInstance.getArtifactoryUrl());
+        assertEquals("www.jfrog.platform.com33/distribution", newthirdJfrogPlatformInstance.getDistributionUrl());
     }
 }

--- a/src/test/java/org/jfrog/hudson/ArtifactoryBuilderTest.java
+++ b/src/test/java/org/jfrog/hudson/ArtifactoryBuilderTest.java
@@ -68,8 +68,8 @@ public class ArtifactoryBuilderTest {
 
         // Check auto fill on instance id only for changing platform url,
         JFrogPlatformInstance newSecondJfrogPlatformInstance = new JFrogPlatformInstance("testInstance2", "www.jfrog.platform.com2", "ghi", "ghi", null, null, 0, false, 0, 0);
-        JFrogPlatformInstance newthirdJfrogPlatformInstance = new JFrogPlatformInstance("testInstance3", "www.jfrog.platform.com33", "jkl", "jkl", null, null, 0, false, 0, 0);
-        testBuilder.autoFillPlatformServers(Arrays.asList(firstJfrogPlatformInstance, newSecondJfrogPlatformInstance, newthirdJfrogPlatformInstance));
+        JFrogPlatformInstance newThirdJfrogPlatformInstance = new JFrogPlatformInstance("testInstance3", "www.jfrog.platform.com33", "jkl", "jkl", null, null, 0, false, 0, 0);
+        testBuilder.autoFillPlatformServers(Arrays.asList(firstJfrogPlatformInstance, newSecondJfrogPlatformInstance, newThirdJfrogPlatformInstance));
         assertEquals("www.jfrog.platform.com1", firstJfrogPlatformInstance.getPlatformUrl());
         assertEquals("abc", firstJfrogPlatformInstance.getArtifactoryUrl());
         assertEquals("abc", firstJfrogPlatformInstance.getDistributionUrl());
@@ -82,8 +82,8 @@ public class ArtifactoryBuilderTest {
         assertEquals("ghi", newSecondJfrogPlatformInstance.getArtifactoryUrl());
         assertEquals("ghi", newSecondJfrogPlatformInstance.getDistributionUrl());
 
-        assertEquals("www.jfrog.platform.com33", newthirdJfrogPlatformInstance.getPlatformUrl());
-        assertEquals("www.jfrog.platform.com33/artifactory", newthirdJfrogPlatformInstance.getArtifactoryUrl());
-        assertEquals("www.jfrog.platform.com33/distribution", newthirdJfrogPlatformInstance.getDistributionUrl());
+        assertEquals("www.jfrog.platform.com33", newThirdJfrogPlatformInstance.getPlatformUrl());
+        assertEquals("www.jfrog.platform.com33/artifactory", newThirdJfrogPlatformInstance.getArtifactoryUrl());
+        assertEquals("www.jfrog.platform.com33/distribution", newThirdJfrogPlatformInstance.getDistributionUrl());
     }
 }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----
If multiple JFrog instances are configured, and only the first JFrog instance in the instance list gets updated (deleting the wrong Artifactory URL and leaving it blank), it will automatically correct all the other JFrog instances.

Related issue: https://github.com/jfrog/jenkins-artifactory-plugin/issues/532#issuecomment-884289750