### PR TITLE
Add projects and retention tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ To run unit tests execute the following command:
 Before running the integration tests, set the following environment variables.
 
 *JENKINS_PLATFORM_URL*<br>
-*JENKINS_ARTIFACTORY_USERNAME*<br>
-*JENKINS_PLATFORM_ACCESS_TOKEN*<br>
+*JENKINS_PLATFORM_USERNAME*<br>
+*JENKINS_PLATFORM_ADMIN_TOKEN*<br>
 *JENKINS_ARTIFACTORY_DOCKER_PUSH_DOMAIN* (For example, server-docker-local.jfrog.io)<br>
 *JENKINS_ARTIFACTORY_DOCKER_PULL_DOMAIN* (For example, server-docker-remote.jfrog.io)<br>
 *JENKINS_ARTIFACTORY_DOCKER_PUSH_REPO* (For example, docker-local)<br>

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Before running the integration tests, set the following environment variables.
 
 *JENKINS_PLATFORM_URL*<br>
 *JENKINS_ARTIFACTORY_USERNAME*<br>
-*JENKINS_ARTIFACTORY_PASSWORD*<br>
+*JENKINS_PLATFORM_ACCESS_TOKEN*<br>
 *JENKINS_ARTIFACTORY_DOCKER_PUSH_DOMAIN* (For example, server-docker-local.jfrog.io)<br>
 *JENKINS_ARTIFACTORY_DOCKER_PULL_DOMAIN* (For example, server-docker-remote.jfrog.io)<br>
 *JENKINS_ARTIFACTORY_DOCKER_PUSH_REPO* (For example, docker-local)<br>

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ To run unit tests execute the following command:
 ### Integration tests
 #### Running integration tests
 Before running the integration tests, set the following environment variables.
+See [here](https://www.jfrog.com/confluence/display/JFROG/Access+Tokens#AccessTokens-GeneratingAdminTokens) how to generate a Platform Admin Token.
 
 *JENKINS_PLATFORM_URL*<br>
 *JENKINS_PLATFORM_USERNAME*<br>

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -14,7 +14,7 @@
 # = Override credentials in Appveyor in case of a fork =
 #   1. In the project at Appveyor - Go to settings -> Environment.
 #   2. Override 'JENKINS_PLATFORM_URL' and 'JENKINS_ARTIFACTORY_USERNAME'.
-#   3. Override 'JENKINS_ARTIFACTORY_PASSWORD' with variable encryption.
+#   3. Override 'JENKINS_PLATFORM_ACCESS_TOKEN'.
 
 stack: jdk 8, node 8, python 3.9
 skip_tags: true
@@ -34,8 +34,8 @@ environment:
 services:
   - docker
 before_test:
-  - cmd: "choco install maven --version 3.3.9.2 -i -s %JENKINS_PLATFORM_URL%/artifactory/api/nuget/choco -u %JENKINS_ARTIFACTORY_USERNAME% -p %JENKINS_ARTIFACTORY_PASSWORD%"
-  - cmd: "choco install gradle --version 6.5.1 -i -s %JENKINS_PLATFORM_URL%/artifactory/api/nuget/choco -u %JENKINS_ARTIFACTORY_USERNAME% -p %JENKINS_ARTIFACTORY_PASSWORD%"
+  - cmd: "choco install maven --version 3.3.9.2 -i -s %JENKINS_PLATFORM_URL%/artifactory/api/nuget/choco -u %JENKINS_ARTIFACTORY_USERNAME% -p %JENKINS_PLATFORM_ACCESS_TOKEN%"
+  - cmd: "choco install gradle --version 6.5.1 -i -s %JENKINS_PLATFORM_URL%/artifactory/api/nuget/choco -u %JENKINS_ARTIFACTORY_USERNAME% -p %JENKINS_PLATFORM_ACCESS_TOKEN%"
   - cmd: refreshenv
   - cmd: pip install conan -q
   - cmd: "C:\\Python37-x64\\python -m venv pip-venv"

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -13,8 +13,8 @@
 #
 # = Override credentials in Appveyor in case of a fork =
 #   1. In the project at Appveyor - Go to settings -> Environment.
-#   2. Override 'JENKINS_PLATFORM_URL' and 'JENKINS_ARTIFACTORY_USERNAME'.
-#   3. Override 'JENKINS_PLATFORM_ACCESS_TOKEN'.
+#   2. Override 'JENKINS_PLATFORM_URL' and 'JENKINS_PLATFORM_USERNAME'.
+#   3. Override 'JENKINS_PLATFORM_ADMIN_TOKEN'.
 
 stack: jdk 8, node 8, python 3.9
 skip_tags: true
@@ -34,8 +34,8 @@ environment:
 services:
   - docker
 before_test:
-  - cmd: "choco install maven --version 3.3.9.2 -i -s %JENKINS_PLATFORM_URL%/artifactory/api/nuget/choco -u %JENKINS_ARTIFACTORY_USERNAME% -p %JENKINS_PLATFORM_ACCESS_TOKEN%"
-  - cmd: "choco install gradle --version 6.5.1 -i -s %JENKINS_PLATFORM_URL%/artifactory/api/nuget/choco -u %JENKINS_ARTIFACTORY_USERNAME% -p %JENKINS_PLATFORM_ACCESS_TOKEN%"
+  - cmd: "choco install maven --version 3.3.9.2 -i -s %JENKINS_PLATFORM_URL%/artifactory/api/nuget/choco -u %JENKINS_PLATFORM_USERNAME% -p %JENKINS_PLATFORM_ADMIN_TOKEN%"
+  - cmd: "choco install gradle --version 6.5.1 -i -s %JENKINS_PLATFORM_URL%/artifactory/api/nuget/choco -u %JENKINS_PLATFORM_USERNAME% -p %JENKINS_PLATFORM_ADMIN_TOKEN%"
   - cmd: refreshenv
   - cmd: pip install conan -q
   - cmd: "C:\\Python37-x64\\python -m venv pip-venv"

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <!--Skip integration tests unless explicitly requested with -DskipITs=false-->
         <skipITs>true</skipITs>
 
-        <buildinfo.version>2.28.x-SNAPSHOT</buildinfo.version>
+        <buildinfo.version>2.29.x-SNAPSHOT</buildinfo.version>
         <buildinfo.gradle.version>4.24.x-SNAPSHOT</buildinfo.gradle.version>
     </properties>
 

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
@@ -850,4 +850,44 @@ public class CommonITestsPipeline extends PipelineTestBase {
             }
         }
     }
+
+    void buildInfoProjects(String buildName) throws Exception {
+        String buildName1 = buildName + "-1";
+        String buildNumber1 = BUILD_NUMBER;
+        String buildName2 = buildName + "-2";
+        String buildNumber2 = BUILD_NUMBER + "-2";
+        // Clear older builds if exist
+        deleteBuild(artifactoryClient, buildName1);
+        deleteBuild(artifactoryClient, buildName2);
+        try {
+            runPipeline("buildInfoProjects", false);
+            Build buildInfo1 = artifactoryManager.getBuildInfo(buildName1, buildNumber1, null);
+            Build buildInfo2 = artifactoryManager.getBuildInfo(buildName2, buildNumber2, PROJECT_KEY);
+            assertNotNull(buildInfo1);
+            assertNotNull(buildInfo2);
+        } finally {
+            artifactoryManager.deleteBuilds(buildName1, null, true, buildNumber1);
+            artifactoryManager.deleteBuilds(buildName2, PROJECT_KEY, true, buildNumber2);
+        }
+    }
+
+    void buildRetention(String buildName) throws Exception {
+        String buildNumber1 = BUILD_NUMBER;
+        String buildNumber2 = BUILD_NUMBER + "-2";
+        String buildNumber3 = BUILD_NUMBER + "-3";
+        // Clear older builds if exist
+        deleteBuild(artifactoryClient, buildName);
+        try {
+            runPipeline("buildRetention", false);
+            artifactoryManager.getBuildInfo(buildName, buildNumber2, null);
+            fail("expected build 2 not to exist");
+        } catch (IOException e) {
+            Build buildInfo1 = artifactoryManager.getBuildInfo(buildName, buildNumber1, null);
+            assertNotNull(buildInfo1);
+            Build buildInfo3 = artifactoryManager.getBuildInfo(buildName, buildNumber3, null);
+            assertNotNull(buildInfo3);
+        } finally {
+            deleteBuild(artifactoryClient, buildName);
+        }
+    }
 }

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/DeclarativeITest.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/DeclarativeITest.java
@@ -220,4 +220,14 @@ public class DeclarativeITest extends CommonITestsPipeline {
     public void rbCreateDistDel() throws Exception {
         super.rbCreateDistDel("declarative:createDistributeDelete");
     }
+
+    @Test
+    public void buildInfoProjects() throws Exception {
+        super.buildInfoProjects("declarative:buildInfoProjects");
+    }
+
+    @Test
+    public void buildRetention() throws Exception {
+        super.buildRetention("declarative:buildRetention");
+    }
 }

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/PipelineTestBase.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/PipelineTestBase.java
@@ -64,8 +64,8 @@ public class PipelineTestBase {
     private static final String ARTIFACTORY_URL = StringUtils.removeEnd(PLATFORM_URL, "/") + "/artifactory";
     private static final String DISTRIBUTION_URL = StringUtils.removeEnd(PLATFORM_URL, "/") + "/distribution";
     private static final String ACCESS_URL = StringUtils.removeEnd(PLATFORM_URL, "/") + "/access";
-    private static final String ARTIFACTORY_USERNAME = System.getenv("JENKINS_ARTIFACTORY_USERNAME");
-    private static final String ACCESS_TOKEN = System.getenv("JENKINS_PLATFORM_ACCESS_TOKEN");
+    private static final String ARTIFACTORY_USERNAME = System.getenv("JENKINS_PLATFORM_USERNAME");
+    private static final String ACCESS_TOKEN = System.getenv("JENKINS_PLATFORM_ADMIN_TOKEN");
     static final String JENKINS_XRAY_TEST_ENABLE = System.getenv("JENKINS_XRAY_TEST_ENABLE");
     static final Path FILES_PATH = getIntegrationDir().resolve("files").toAbsolutePath();
     public static final String BUILD_NUMBER = String.valueOf(System.currentTimeMillis());
@@ -330,10 +330,10 @@ public class PipelineTestBase {
             throw new IllegalArgumentException("JENKINS_PLATFORM_URL is not set");
         }
         if (StringUtils.isBlank(ARTIFACTORY_USERNAME)) {
-            throw new IllegalArgumentException("JENKINS_ARTIFACTORY_USERNAME is not set");
+            throw new IllegalArgumentException("JENKINS_PLATFORM_USERNAME is not set");
         }
         if (StringUtils.isBlank(ACCESS_TOKEN)) {
-            throw new IllegalArgumentException("JENKINS_PLATFORM_ACCESS_TOKEN is not set");
+            throw new IllegalArgumentException("JENKINS_PLATFORM_ADMIN_TOKEN is not set");
         }
     }
 

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/PipelineTestBase.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/PipelineTestBase.java
@@ -19,6 +19,7 @@ import org.jfrog.artifactory.client.ArtifactoryClientBuilder;
 import org.jfrog.artifactory.client.ArtifactoryRequest;
 import org.jfrog.artifactory.client.impl.ArtifactoryRequestImpl;
 import org.jfrog.build.api.util.NullLog;
+import org.jfrog.build.extractor.clientConfiguration.client.access.AccessManager;
 import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;
 import org.jfrog.build.extractor.clientConfiguration.client.distribution.DistributionManager;
 import org.jfrog.hudson.ArtifactoryBuilder;
@@ -62,16 +63,20 @@ public class PipelineTestBase {
     private static final String PLATFORM_URL = System.getenv("JENKINS_PLATFORM_URL");
     private static final String ARTIFACTORY_URL = StringUtils.removeEnd(PLATFORM_URL, "/") + "/artifactory";
     private static final String DISTRIBUTION_URL = StringUtils.removeEnd(PLATFORM_URL, "/") + "/distribution";
+    private static final String ACCESS_URL = StringUtils.removeEnd(PLATFORM_URL, "/") + "/access";
     private static final String ARTIFACTORY_USERNAME = System.getenv("JENKINS_ARTIFACTORY_USERNAME");
-    private static final String ARTIFACTORY_PASSWORD = System.getenv("JENKINS_ARTIFACTORY_PASSWORD");
+    private static final String ACCESS_TOKEN = System.getenv("JENKINS_PLATFORM_ACCESS_TOKEN");
     static final String JENKINS_XRAY_TEST_ENABLE = System.getenv("JENKINS_XRAY_TEST_ENABLE");
     static final Path FILES_PATH = getIntegrationDir().resolve("files").toAbsolutePath();
     public static final String BUILD_NUMBER = String.valueOf(System.currentTimeMillis());
+    public static final String PROJECT_KEY = "j" + StringUtils.right(String.valueOf(System.currentTimeMillis()), 5);
+    public static final String PROJECT_CONFIGURATION_FILE_NAME = "jenkins-artifactory-tests-project-conf";
 
     private static long currentTime;
     private static StrSubstitutor pipelineSubstitution;
     static ArtifactoryManager artifactoryManager;
     static DistributionManager distributionManager;
+    static AccessManager accessManager;
     static Artifactory artifactoryClient;
 
     private static final ClassLoader classLoader = PipelineTestBase.class.getClassLoader();
@@ -93,6 +98,7 @@ public class PipelineTestBase {
         createPipelineSubstitution();
         // Create repositories
         Arrays.stream(TestRepository.values()).forEach(PipelineTestBase::createRepo);
+        createProject();
     }
 
     @Before
@@ -112,12 +118,19 @@ public class PipelineTestBase {
     public static void tearDown() {
         // Remove repositories - need to remove virtual repositories first
         Stream.concat(
-                Arrays.stream(TestRepository.values()).filter(repository -> repository.getRepoType() == TestRepository.RepoType.VIRTUAL),
-                Arrays.stream(TestRepository.values()).filter(repository -> repository.getRepoType() != TestRepository.RepoType.VIRTUAL))
+                        Arrays.stream(TestRepository.values()).filter(repository -> repository.getRepoType() == TestRepository.RepoType.VIRTUAL),
+                        Arrays.stream(TestRepository.values()).filter(repository -> repository.getRepoType() != TestRepository.RepoType.VIRTUAL))
                 .forEach(repository -> artifactoryClient.repository(getRepoKey(repository)).delete());
+        // Remove project.
+        try {
+            accessManager.deleteProject(PROJECT_KEY);
+        } catch (Exception e) {
+            fail(ExceptionUtils.getRootCauseMessage(e));
+        }
         artifactoryManager.close();
         distributionManager.close();
         artifactoryClient.close();
+        accessManager.close();
     }
 
     /**
@@ -148,13 +161,7 @@ public class PipelineTestBase {
      */
     private static void createRepo(TestRepository repository) {
         try {
-            String repositorySettingsPath = Paths.get("integration", "settings", repository.getRepoName() + ".json").toString();
-            InputStream inputStream = classLoader.getResourceAsStream(repositorySettingsPath);
-            if (inputStream == null) {
-                throw new IOException(repositorySettingsPath + " not found");
-            }
-            String repositorySettings = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
-            repositorySettings = pipelineSubstitution.replace(repositorySettings);
+            String repositorySettings = readConfigurationWithSubstitution(repository.getRepoName());
             artifactoryClient.restCall(new ArtifactoryRequestImpl()
                     .method(ArtifactoryRequest.Method.PUT)
                     .requestType(ArtifactoryRequest.ContentType.JSON)
@@ -166,16 +173,49 @@ public class PipelineTestBase {
     }
 
     /**
+     * Read repository or project configuration and replace placeholders with their corresponding values.
+     *
+     * @param repoOrProject - Name of configuration in resources.
+     * @return The configuration after substitution.
+     */
+    private static String readConfigurationWithSubstitution(String repoOrProject) {
+        try {
+            String repositorySettingsPath = Paths.get("integration", "settings", repoOrProject + ".json").toString();
+            InputStream inputStream = classLoader.getResourceAsStream(repositorySettingsPath);
+            if (inputStream == null) {
+                throw new IOException(repositorySettingsPath + " not found");
+            }
+            String repositorySettings = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+            return pipelineSubstitution.replace(repositorySettings);
+        } catch (Exception e) {
+            fail(ExceptionUtils.getRootCauseMessage(e));
+        }
+        return null;
+    }
+
+    /**
+     * Creates a project in platform.
+     */
+    private static void createProject() {
+        try {
+            String projectConf = readConfigurationWithSubstitution(PROJECT_CONFIGURATION_FILE_NAME);
+            accessManager.createProject(projectConf);
+        } catch (Exception e) {
+            fail(ExceptionUtils.getRootCauseMessage(e));
+        }
+    }
+
+    /**
      * Creates build-info and Artifactory Java clients.
      */
     private static void createClients() {
-        artifactoryManager = new ArtifactoryManager(ARTIFACTORY_URL, ARTIFACTORY_USERNAME, ARTIFACTORY_PASSWORD, new NullLog());
-        distributionManager = new DistributionManager(DISTRIBUTION_URL, ARTIFACTORY_USERNAME, ARTIFACTORY_PASSWORD, new NullLog());
+        artifactoryManager = new ArtifactoryManager(ARTIFACTORY_URL, ACCESS_TOKEN, new NullLog());
+        distributionManager = new DistributionManager(DISTRIBUTION_URL, ACCESS_TOKEN, new NullLog());
         artifactoryClient = ArtifactoryClientBuilder.create()
                 .setUrl(ARTIFACTORY_URL)
-                .setUsername(ARTIFACTORY_USERNAME)
-                .setPassword(ARTIFACTORY_PASSWORD)
+                .setAccessToken(ACCESS_TOKEN)
                 .build();
+        accessManager = new AccessManager(ACCESS_URL, ACCESS_TOKEN, new NullLog());
     }
 
     /**
@@ -188,7 +228,7 @@ public class PipelineTestBase {
         JFrogPipelinesServer server = new JFrogPipelinesServer("http://127.0.0.1:1080", CredentialsConfig.EMPTY_CREDENTIALS_CONFIG, 300, false, 3);
         artifactoryBuilder.setJfrogPipelinesServer(server);
         CredentialsConfig cred = new CredentialsConfig("admin", "password", "cred1");
-        CredentialsConfig platformCred = new CredentialsConfig(ARTIFACTORY_USERNAME, ARTIFACTORY_PASSWORD, null);
+        CredentialsConfig platformCred = new CredentialsConfig(ARTIFACTORY_USERNAME, ACCESS_TOKEN, null);
         List<JFrogPlatformInstance> artifactoryServers = new ArrayList<JFrogPlatformInstance>() {{
             add(new JFrogPlatformInstance(new ArtifactoryServer("LOCAL", "http://127.0.0.1:8081/artifactory", cred, cred, 0, false, 3, null)));
             add(new JFrogPlatformInstance("PLATFORM", PLATFORM_URL, ARTIFACTORY_URL, DISTRIBUTION_URL, platformCred, platformCred, 0, false, 3, null));
@@ -230,6 +270,7 @@ public class PipelineTestBase {
             put("CONAN_LOCAL", getRepoKey(TestRepository.CONAN_LOCAL));
             put("NUGET_REMOTE", getRepoKey(TestRepository.NUGET_REMOTE));
             put("BUILD_NUMBER", BUILD_NUMBER);
+            put("PROJECT_KEY", PROJECT_KEY);
         }});
     }
 
@@ -282,7 +323,7 @@ public class PipelineTestBase {
     }
 
     /**
-     * Verify ARTIFACTORY_URL, ARTIFACTORY_USERNAME and ARTIFACTORY_PASSWORD
+     * Verify ARTIFACTORY_URL, ARTIFACTORY_USERNAME and ACCESS_TOKEN
      */
     private static void verifyEnvironment() {
         if (StringUtils.isBlank(PLATFORM_URL)) {
@@ -291,8 +332,8 @@ public class PipelineTestBase {
         if (StringUtils.isBlank(ARTIFACTORY_USERNAME)) {
             throw new IllegalArgumentException("JENKINS_ARTIFACTORY_USERNAME is not set");
         }
-        if (StringUtils.isBlank(ARTIFACTORY_PASSWORD)) {
-            throw new IllegalArgumentException("JENKINS_ARTIFACTORY_PASSWORD is not set");
+        if (StringUtils.isBlank(ACCESS_TOKEN)) {
+            throw new IllegalArgumentException("JENKINS_PLATFORM_ACCESS_TOKEN is not set");
         }
     }
 

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/ScriptedITest.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/ScriptedITest.java
@@ -215,4 +215,14 @@ public class ScriptedITest extends CommonITestsPipeline {
     public void rbCreateDistDel() throws Exception {
         super.rbCreateDistDel("scripted:createDistributeDelete");
     }
+
+    @Test
+    public void buildInfoProjects() throws Exception {
+        super.buildInfoProjects("scripted:buildInfoProjects");
+    }
+
+    @Test
+    public void buildRetention() throws Exception {
+        super.buildRetention("scripted:buildRetention");
+    }
 }

--- a/src/test/resources/integration/maven-jib-example/pom.xml
+++ b/src/test/resources/integration/maven-jib-example/pom.xml
@@ -77,15 +77,15 @@
                     <from>
                         <image>${env.JENKINS_ARTIFACTORY_DOCKER_PULL_DOMAIN}/adoptopenjdk:8-jdk-hotspot</image>
                         <auth>
-                            <username>${env.JENKINS_ARTIFACTORY_USERNAME}</username>
-                            <password>${env.JENKINS_PLATFORM_ACCESS_TOKEN}</password>
+                            <username>${env.JENKINS_PLATFORM_USERNAME}</username>
+                            <password>${env.JENKINS_PLATFORM_ADMIN_TOKEN}</password>
                         </auth>
                     </from>
                     <to>
                         <image>${env.JENKINS_ARTIFACTORY_DOCKER_PUSH_DOMAIN}/${project.artifactId}</image>
                         <auth>
-                            <username>${env.JENKINS_ARTIFACTORY_USERNAME}</username>
-                            <password>${env.JENKINS_PLATFORM_ACCESS_TOKEN}</password>
+                            <username>${env.JENKINS_PLATFORM_USERNAME}</username>
+                            <password>${env.JENKINS_PLATFORM_ADMIN_TOKEN}</password>
                         </auth>
                     </to>
                 </configuration>

--- a/src/test/resources/integration/maven-jib-example/pom.xml
+++ b/src/test/resources/integration/maven-jib-example/pom.xml
@@ -78,14 +78,14 @@
                         <image>${env.JENKINS_ARTIFACTORY_DOCKER_PULL_DOMAIN}/adoptopenjdk:8-jdk-hotspot</image>
                         <auth>
                             <username>${env.JENKINS_ARTIFACTORY_USERNAME}</username>
-                            <password>${env.JENKINS_ARTIFACTORY_PASSWORD}</password>
+                            <password>${env.JENKINS_PLATFORM_ACCESS_TOKEN}</password>
                         </auth>
                     </from>
                     <to>
                         <image>${env.JENKINS_ARTIFACTORY_DOCKER_PUSH_DOMAIN}/${project.artifactId}</image>
                         <auth>
                             <username>${env.JENKINS_ARTIFACTORY_USERNAME}</username>
-                            <password>${env.JENKINS_ARTIFACTORY_PASSWORD}</password>
+                            <password>${env.JENKINS_PLATFORM_ACCESS_TOKEN}</password>
                         </auth>
                     </to>
                 </configuration>

--- a/src/test/resources/integration/pipelines/declarative/buildAppend.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/buildAppend.pipeline
@@ -11,8 +11,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Create 1st Build Info"

--- a/src/test/resources/integration/pipelines/declarative/buildInfoProjects.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/buildInfoProjects.pipeline
@@ -11,8 +11,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Create 1st Build Info Without Project"

--- a/src/test/resources/integration/pipelines/declarative/buildInfoProjects.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/buildInfoProjects.pipeline
@@ -2,9 +2,9 @@ package integration.pipelines.declarative
 
 node("TestSlave") {
     def serverId = "Artifactory-1"
-    def buildName1 = "declarative:buildAppend test-1"
+    def buildName1 = "declarative:buildInfoProjects-1"
     def buildNumber1 = "${BUILD_NUMBER}"
-    def buildName2 = "declarative:buildAppend test-2"
+    def buildName2 = "declarative:buildInfoProjects-2"
     def buildNumber2 = "${BUILD_NUMBER}-2"
 
     stage "Configuration"
@@ -15,7 +15,7 @@ node("TestSlave") {
             password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
-    stage "Create 1st Build Info"
+    stage "Create 1st Build Info Without Project"
     rtBuildInfo(
             buildName: buildName1,
             buildNumber: buildNumber1
@@ -28,25 +28,18 @@ node("TestSlave") {
             buildNumber: buildNumber1
     )
 
-    stage "Create 2nd Build Info"
+    stage "Create 2nd Build Info With Project"
     rtBuildInfo(
             buildName: buildName2,
-            buildNumber: buildNumber2
-    )
-
-    stage "Append build 1 to build 2"
-    rtBuildAppend(
-            serverId: serverId,
-            buildName: buildName2,
             buildNumber: buildNumber2,
-            appendBuildName: buildName1,
-            appendBuildNumber: buildNumber1
+            project: "${PROJECT_KEY}"
     )
 
     stage "Publish 2nd Build Info"
     rtPublishBuildInfo(
             serverId: serverId,
             buildName: buildName2,
-            buildNumber: buildNumber2
+            buildNumber: buildNumber2,
+            project: "${PROJECT_KEY}"
     )
 }

--- a/src/test/resources/integration/pipelines/declarative/buildRetention.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/buildRetention.pipeline
@@ -2,10 +2,10 @@ package integration.pipelines.declarative
 
 node("TestSlave") {
     def serverId = "Artifactory-1"
-    def buildName1 = "declarative:buildAppend test-1"
+    def buildName = "declarative:buildRetention"
     def buildNumber1 = "${BUILD_NUMBER}"
-    def buildName2 = "declarative:buildAppend test-2"
     def buildNumber2 = "${BUILD_NUMBER}-2"
+    def buildNumber3 = "${BUILD_NUMBER}-3"
 
     stage "Configuration"
     rtServer(
@@ -17,36 +17,43 @@ node("TestSlave") {
 
     stage "Create 1st Build Info"
     rtBuildInfo(
-            buildName: buildName1,
+            buildName: buildName,
             buildNumber: buildNumber1
     )
 
     stage "Publish 1st Build Info"
     rtPublishBuildInfo(
             serverId: serverId,
-            buildName: buildName1,
+            buildName: buildName,
             buildNumber: buildNumber1
     )
 
     stage "Create 2nd Build Info"
     rtBuildInfo(
-            buildName: buildName2,
+            buildName: buildName,
             buildNumber: buildNumber2
-    )
-
-    stage "Append build 1 to build 2"
-    rtBuildAppend(
-            serverId: serverId,
-            buildName: buildName2,
-            buildNumber: buildNumber2,
-            appendBuildName: buildName1,
-            appendBuildNumber: buildNumber1
     )
 
     stage "Publish 2nd Build Info"
     rtPublishBuildInfo(
             serverId: serverId,
-            buildName: buildName2,
+            buildName: buildName,
             buildNumber: buildNumber2
+    )
+
+    stage "Create 3rd Build Info"
+    rtBuildInfo(
+            buildName: buildName,
+            buildNumber: buildNumber3,
+            maxBuilds: 1,
+            doNotDiscardBuilds: [buildNumber1],
+            deleteBuildArtifacts: true
+    )
+
+    stage "Publish 3rd Build Info"
+    rtPublishBuildInfo(
+            serverId: serverId,
+            buildName: buildName,
+            buildNumber: buildNumber3
     )
 }

--- a/src/test/resources/integration/pipelines/declarative/buildRetention.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/buildRetention.pipeline
@@ -11,8 +11,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Create 1st Build Info"

--- a/src/test/resources/integration/pipelines/declarative/collectIssues.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/collectIssues.pipeline
@@ -10,7 +10,7 @@ node("TestSlave") {
                 id: serverId,
                 url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
                 username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-                password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+                password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
         )
 
         def buildName = "declarative:collectIssues test"

--- a/src/test/resources/integration/pipelines/declarative/collectIssues.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/collectIssues.pipeline
@@ -9,8 +9,8 @@ node("TestSlave") {
         rtServer(
                 id: serverId,
                 url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-                username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-                password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+                username: "${env.JENKINS_PLATFORM_USERNAME}",
+                password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
         )
 
         def buildName = "declarative:collectIssues test"

--- a/src/test/resources/integration/pipelines/declarative/conan.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/conan.pipeline
@@ -13,8 +13,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Configure Conan Client"

--- a/src/test/resources/integration/pipelines/declarative/conan.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/conan.pipeline
@@ -14,7 +14,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Configure Conan Client"

--- a/src/test/resources/integration/pipelines/declarative/deleteProps.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/deleteProps.pipeline
@@ -9,8 +9,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Upload"

--- a/src/test/resources/integration/pipelines/declarative/deleteProps.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/deleteProps.pipeline
@@ -10,7 +10,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Upload"

--- a/src/test/resources/integration/pipelines/declarative/dockerPull.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/dockerPull.pipeline
@@ -16,7 +16,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage('docker pull stage')

--- a/src/test/resources/integration/pipelines/declarative/dockerPull.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/dockerPull.pipeline
@@ -15,8 +15,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage('docker pull stage')

--- a/src/test/resources/integration/pipelines/declarative/dockerPush.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/dockerPush.pipeline
@@ -18,8 +18,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Config Build Info"

--- a/src/test/resources/integration/pipelines/declarative/dockerPush.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/dockerPush.pipeline
@@ -19,7 +19,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Config Build Info"

--- a/src/test/resources/integration/pipelines/declarative/dotnet.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/dotnet.pipeline
@@ -15,8 +15,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Configure .NET build"

--- a/src/test/resources/integration/pipelines/declarative/dotnet.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/dotnet.pipeline
@@ -16,7 +16,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Configure .NET build"

--- a/src/test/resources/integration/pipelines/declarative/downloadByAql.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadByAql.pipeline
@@ -10,7 +10,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Download"

--- a/src/test/resources/integration/pipelines/declarative/downloadByAql.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadByAql.pipeline
@@ -9,8 +9,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Download"

--- a/src/test/resources/integration/pipelines/declarative/downloadByBuildOnly.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadByBuildOnly.pipeline
@@ -8,7 +8,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     def buildName = "declarative:downloadByBuildOnly test"

--- a/src/test/resources/integration/pipelines/declarative/downloadByBuildOnly.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadByBuildOnly.pipeline
@@ -7,8 +7,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     def buildName = "declarative:downloadByBuildOnly test"

--- a/src/test/resources/integration/pipelines/declarative/downloadByPattern.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadByPattern.pipeline
@@ -10,7 +10,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Download"

--- a/src/test/resources/integration/pipelines/declarative/downloadByPattern.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadByPattern.pipeline
@@ -9,8 +9,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Download"

--- a/src/test/resources/integration/pipelines/declarative/downloadByPatternAndBuild.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadByPatternAndBuild.pipeline
@@ -8,7 +8,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     def buildName = "declarative:downloadByPatternAndBuild test"

--- a/src/test/resources/integration/pipelines/declarative/downloadByPatternAndBuild.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadByPatternAndBuild.pipeline
@@ -7,8 +7,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     def buildName = "declarative:downloadByPatternAndBuild test"

--- a/src/test/resources/integration/pipelines/declarative/downloadByShaAndBuild.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadByShaAndBuild.pipeline
@@ -8,7 +8,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     def buildName = "declarative:downloadByShaAndBuild test"

--- a/src/test/resources/integration/pipelines/declarative/downloadByShaAndBuild.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadByShaAndBuild.pipeline
@@ -7,8 +7,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     def buildName = "declarative:downloadByShaAndBuild test"

--- a/src/test/resources/integration/pipelines/declarative/downloadByShaAndBuildName.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadByShaAndBuildName.pipeline
@@ -8,7 +8,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     def buildName = "declarative:downloadByShaAndBuildName test"

--- a/src/test/resources/integration/pipelines/declarative/downloadByShaAndBuildName.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadByShaAndBuildName.pipeline
@@ -7,8 +7,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     def buildName = "declarative:downloadByShaAndBuildName test"

--- a/src/test/resources/integration/pipelines/declarative/downloadFailNoOp.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadFailNoOp.pipeline
@@ -8,7 +8,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Download"

--- a/src/test/resources/integration/pipelines/declarative/downloadFailNoOp.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadFailNoOp.pipeline
@@ -7,8 +7,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Download"

--- a/src/test/resources/integration/pipelines/declarative/downloadNonExistingBuild.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadNonExistingBuild.pipeline
@@ -9,8 +9,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Upload"

--- a/src/test/resources/integration/pipelines/declarative/downloadNonExistingBuild.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/downloadNonExistingBuild.pipeline
@@ -10,7 +10,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Upload"

--- a/src/test/resources/integration/pipelines/declarative/go.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/go.pipeline
@@ -15,8 +15,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Configure Go build"

--- a/src/test/resources/integration/pipelines/declarative/go.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/go.pipeline
@@ -16,7 +16,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Configure Go build"

--- a/src/test/resources/integration/pipelines/declarative/goCustomModuleName.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/goCustomModuleName.pipeline
@@ -15,8 +15,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Configure Go build"

--- a/src/test/resources/integration/pipelines/declarative/goCustomModuleName.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/goCustomModuleName.pipeline
@@ -16,7 +16,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Configure Go build"

--- a/src/test/resources/integration/pipelines/declarative/gradle.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/gradle.pipeline
@@ -16,7 +16,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Configure Gradle build"

--- a/src/test/resources/integration/pipelines/declarative/gradle.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/gradle.pipeline
@@ -15,8 +15,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Configure Gradle build"

--- a/src/test/resources/integration/pipelines/declarative/gradleCiServer.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/gradleCiServer.pipeline
@@ -14,7 +14,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Configure Gradle build"

--- a/src/test/resources/integration/pipelines/declarative/gradleCiServer.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/gradleCiServer.pipeline
@@ -13,8 +13,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Configure Gradle build"

--- a/src/test/resources/integration/pipelines/declarative/gradleCiServerPublication.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/gradleCiServerPublication.pipeline
@@ -14,7 +14,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Configure Gradle build"

--- a/src/test/resources/integration/pipelines/declarative/gradleCiServerPublication.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/gradleCiServerPublication.pipeline
@@ -13,8 +13,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Configure Gradle build"

--- a/src/test/resources/integration/pipelines/declarative/maven.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/maven.pipeline
@@ -16,7 +16,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Configure Maven build"

--- a/src/test/resources/integration/pipelines/declarative/maven.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/maven.pipeline
@@ -15,8 +15,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Configure Maven build"

--- a/src/test/resources/integration/pipelines/declarative/mavenJib.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/mavenJib.pipeline
@@ -16,7 +16,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '') + '/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Configure Maven build"

--- a/src/test/resources/integration/pipelines/declarative/mavenJib.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/mavenJib.pipeline
@@ -15,8 +15,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '') + '/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Configure Maven build"

--- a/src/test/resources/integration/pipelines/declarative/mavenWrapper.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/mavenWrapper.pipeline
@@ -16,7 +16,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Configure Maven build"

--- a/src/test/resources/integration/pipelines/declarative/mavenWrapper.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/mavenWrapper.pipeline
@@ -15,8 +15,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Configure Maven build"

--- a/src/test/resources/integration/pipelines/declarative/npmCi.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/npmCi.pipeline
@@ -15,8 +15,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Configure npm build"

--- a/src/test/resources/integration/pipelines/declarative/npmCi.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/npmCi.pipeline
@@ -16,7 +16,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Configure npm build"

--- a/src/test/resources/integration/pipelines/declarative/npmCustomModuleName.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/npmCustomModuleName.pipeline
@@ -15,8 +15,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Configure npm build"

--- a/src/test/resources/integration/pipelines/declarative/npmCustomModuleName.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/npmCustomModuleName.pipeline
@@ -16,7 +16,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Configure npm build"

--- a/src/test/resources/integration/pipelines/declarative/npmInstall.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/npmInstall.pipeline
@@ -15,8 +15,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Configure npm build"

--- a/src/test/resources/integration/pipelines/declarative/npmInstall.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/npmInstall.pipeline
@@ -16,7 +16,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Configure npm build"

--- a/src/test/resources/integration/pipelines/declarative/nuget.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/nuget.pipeline
@@ -16,7 +16,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Configure NuGet build"

--- a/src/test/resources/integration/pipelines/declarative/nuget.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/nuget.pipeline
@@ -15,8 +15,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Configure NuGet build"

--- a/src/test/resources/integration/pipelines/declarative/pip.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/pip.pipeline
@@ -15,8 +15,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Configure pip build"

--- a/src/test/resources/integration/pipelines/declarative/pip.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/pip.pipeline
@@ -16,7 +16,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Configure pip build"

--- a/src/test/resources/integration/pipelines/declarative/promote.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/promote.pipeline
@@ -9,8 +9,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Upload"

--- a/src/test/resources/integration/pipelines/declarative/promote.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/promote.pipeline
@@ -10,7 +10,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Upload"

--- a/src/test/resources/integration/pipelines/declarative/rbCreateDistDel.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/rbCreateDistDel.pipeline
@@ -26,7 +26,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}",
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Upload files"

--- a/src/test/resources/integration/pipelines/declarative/rbCreateDistDel.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/rbCreateDistDel.pipeline
@@ -25,8 +25,8 @@ node("TestSlave") {
     jfrogInstance(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}",
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Upload files"

--- a/src/test/resources/integration/pipelines/declarative/rbCreateUpdateSign.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/rbCreateUpdateSign.pipeline
@@ -17,7 +17,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}",
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Upload files"

--- a/src/test/resources/integration/pipelines/declarative/rbCreateUpdateSign.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/rbCreateUpdateSign.pipeline
@@ -16,8 +16,8 @@ node("TestSlave") {
     jfrogInstance(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}",
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Upload files"

--- a/src/test/resources/integration/pipelines/declarative/setProps.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/setProps.pipeline
@@ -9,8 +9,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Upload"

--- a/src/test/resources/integration/pipelines/declarative/setProps.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/setProps.pipeline
@@ -10,7 +10,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Upload"

--- a/src/test/resources/integration/pipelines/declarative/upload.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/upload.pipeline
@@ -9,8 +9,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Upload"

--- a/src/test/resources/integration/pipelines/declarative/upload.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/upload.pipeline
@@ -10,7 +10,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Upload"

--- a/src/test/resources/integration/pipelines/declarative/uploadDownloadCustomModuleName.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/uploadDownloadCustomModuleName.pipeline
@@ -9,8 +9,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Upload"

--- a/src/test/resources/integration/pipelines/declarative/uploadDownloadCustomModuleName.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/uploadDownloadCustomModuleName.pipeline
@@ -10,7 +10,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Upload"

--- a/src/test/resources/integration/pipelines/declarative/uploadFailNoOp.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/uploadFailNoOp.pipeline
@@ -7,8 +7,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Upload"

--- a/src/test/resources/integration/pipelines/declarative/uploadFailNoOp.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/uploadFailNoOp.pipeline
@@ -8,7 +8,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Upload"

--- a/src/test/resources/integration/pipelines/declarative/uploadWithProps.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/uploadWithProps.pipeline
@@ -9,8 +9,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Upload"

--- a/src/test/resources/integration/pipelines/declarative/uploadWithProps.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/uploadWithProps.pipeline
@@ -10,7 +10,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Upload"

--- a/src/test/resources/integration/pipelines/declarative/xrayScanFailBuildFalse.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/xrayScanFailBuildFalse.pipeline
@@ -14,7 +14,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Configure Gradle build"

--- a/src/test/resources/integration/pipelines/declarative/xrayScanFailBuildFalse.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/xrayScanFailBuildFalse.pipeline
@@ -13,8 +13,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Configure Gradle build"

--- a/src/test/resources/integration/pipelines/declarative/xrayScanFailBuildTrue.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/xrayScanFailBuildTrue.pipeline
@@ -14,7 +14,7 @@ node("TestSlave") {
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
             username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     )
 
     stage "Configure Gradle build"

--- a/src/test/resources/integration/pipelines/declarative/xrayScanFailBuildTrue.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/xrayScanFailBuildTrue.pipeline
@@ -13,8 +13,8 @@ node("TestSlave") {
     rtServer(
             id: serverId,
             url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
-            username: "${env.JENKINS_ARTIFACTORY_USERNAME}",
-            password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     )
 
     stage "Configure Gradle build"

--- a/src/test/resources/integration/pipelines/scripted/append.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/append.pipeline
@@ -13,7 +13,7 @@ node {
         buildInfoUpload.number = "${BUILD_NUMBER}-2"
 
         stage "Configuration"
-            def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
 
         // Collect issues
         stage "Collect Issues"

--- a/src/test/resources/integration/pipelines/scripted/append.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/append.pipeline
@@ -13,7 +13,7 @@ node {
         buildInfoUpload.number = "${BUILD_NUMBER}-2"
 
         stage "Configuration"
-            def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
 
         // Collect issues
         stage "Collect Issues"

--- a/src/test/resources/integration/pipelines/scripted/buildAppend.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/buildAppend.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
 
     stage "Create 1st Build Info"
     def buildInfo1 = Artifactory.newBuildInfo()

--- a/src/test/resources/integration/pipelines/scripted/buildInfoProjects.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/buildInfoProjects.pipeline
@@ -4,21 +4,19 @@ node("TestSlave") {
     stage "Configuration"
     def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
 
-    stage "Create 1st Build Info"
+    stage "Create 1st Build Info Without Project"
     def buildInfo1 = Artifactory.newBuildInfo()
-    buildInfo1.name = "scripted:buildAppend test-1"
+    buildInfo1.name = "scripted:buildInfoProjects-1"
     buildInfo1.number = ${BUILD_NUMBER}
 
     stage "Publish 1st Build Info"
     rtServer.publishBuildInfo buildInfo1
 
-    stage "Create 2nd Build Info"
+    stage "Create 2nd Build Info With Project"
     def buildInfo2 = Artifactory.newBuildInfo()
-    buildInfo2.name = "scripted:buildAppend test-2"
+    buildInfo2.name = "scripted:buildInfoProjects-2"
     buildInfo2.number = "${BUILD_NUMBER}-2"
-
-    stage "Append build 1 to build 2"
-    rtServer.buildAppend(buildInfo2, buildInfo1.name, buildInfo1.number)
+    buildInfo2.project = "${PROJECT_KEY}"
 
     stage "Publish 2nd Build Info"
     rtServer.publishBuildInfo buildInfo2

--- a/src/test/resources/integration/pipelines/scripted/buildInfoProjects.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/buildInfoProjects.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
 
     stage "Create 1st Build Info Without Project"
     def buildInfo1 = Artifactory.newBuildInfo()

--- a/src/test/resources/integration/pipelines/scripted/buildRetention.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/buildRetention.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
 
     stage "Create 1st Build Info"
     def buildInfo1 = Artifactory.newBuildInfo()

--- a/src/test/resources/integration/pipelines/scripted/buildRetention.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/buildRetention.pipeline
@@ -6,7 +6,7 @@ node("TestSlave") {
 
     stage "Create 1st Build Info"
     def buildInfo1 = Artifactory.newBuildInfo()
-    buildInfo1.name = "scripted:buildAppend test-1"
+    buildInfo1.name = "scripted:buildRetention"
     buildInfo1.number = ${BUILD_NUMBER}
 
     stage "Publish 1st Build Info"
@@ -14,12 +14,18 @@ node("TestSlave") {
 
     stage "Create 2nd Build Info"
     def buildInfo2 = Artifactory.newBuildInfo()
-    buildInfo2.name = "scripted:buildAppend test-2"
+    buildInfo2.name = "scripted:buildRetention"
     buildInfo2.number = "${BUILD_NUMBER}-2"
-
-    stage "Append build 1 to build 2"
-    rtServer.buildAppend(buildInfo2, buildInfo1.name, buildInfo1.number)
 
     stage "Publish 2nd Build Info"
     rtServer.publishBuildInfo buildInfo2
+
+    stage "Create 3nd Build Info"
+    def buildInfo3 = Artifactory.newBuildInfo()
+    buildInfo3.name = "scripted:buildRetention"
+    buildInfo3.number = "${BUILD_NUMBER}-3"
+    buildInfo3.retention maxBuilds: 1, doNotDiscardBuilds: [${BUILD_NUMBER}], deleteBuildArtifacts: true
+
+    stage "Publish 3nd Build Info"
+    rtServer.publishBuildInfo buildInfo3
 }

--- a/src/test/resources/integration/pipelines/scripted/collectIssues.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/collectIssues.pipeline
@@ -4,7 +4,7 @@ node("TestSlave") {
     // Move to the scope of the test's git
     dir("${TEST_TEMP_FOLDER}") {
         stage "Configuration"
-            def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+            def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
 
             // Create build info
             def buildInfo = Artifactory.newBuildInfo()

--- a/src/test/resources/integration/pipelines/scripted/collectIssues.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/collectIssues.pipeline
@@ -4,7 +4,7 @@ node("TestSlave") {
     // Move to the scope of the test's git
     dir("${TEST_TEMP_FOLDER}") {
         stage "Configuration"
-            def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+            def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
 
             // Create build info
             def buildInfo = Artifactory.newBuildInfo()

--- a/src/test/resources/integration/pipelines/scripted/conan.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/conan.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:conan test"
     buildInfo.number = "${BUILD_NUMBER}"

--- a/src/test/resources/integration/pipelines/scripted/conan.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/conan.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:conan test"
     buildInfo.number = "${BUILD_NUMBER}"

--- a/src/test/resources/integration/pipelines/scripted/deleteProps.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/deleteProps.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:deleteProps test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/deleteProps.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/deleteProps.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:deleteProps test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/dockerPull.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/dockerPull.pipeline
@@ -7,7 +7,7 @@ node("TestSlave") {
     }
     def imageName = domainName + "hello-world:latest"
     def sourceRepo = "${env.JENKINS_ARTIFACTORY_DOCKER_PULL_REPO}"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
 
     stage "dockerPull"
     def rtDocker = Artifactory.docker (rtServer, "${env.JENKINS_ARTIFACTORY_DOCKER_HOST}")

--- a/src/test/resources/integration/pipelines/scripted/dockerPull.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/dockerPull.pipeline
@@ -7,7 +7,7 @@ node("TestSlave") {
     }
     def imageName = domainName + "hello-world:latest"
     def sourceRepo = "${env.JENKINS_ARTIFACTORY_DOCKER_PULL_REPO}"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
 
     stage "dockerPull"
     def rtDocker = Artifactory.docker (rtServer, "${env.JENKINS_ARTIFACTORY_DOCKER_HOST}")

--- a/src/test/resources/integration/pipelines/scripted/dockerPush.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/dockerPush.pipeline
@@ -9,7 +9,7 @@ node("TestSlave") {
     }
     def imageName = domainName + "jfrog_artifactory_jenkins_tests:2"
     def targetRepo = "${env.JENKINS_ARTIFACTORY_DOCKER_PUSH_REPO}"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")

--- a/src/test/resources/integration/pipelines/scripted/dockerPush.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/dockerPush.pipeline
@@ -9,7 +9,7 @@ node("TestSlave") {
     }
     def imageName = domainName + "jfrog_artifactory_jenkins_tests:2"
     def targetRepo = "${env.JENKINS_ARTIFACTORY_DOCKER_PUSH_REPO}"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")

--- a/src/test/resources/integration/pipelines/scripted/dotnet.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/dotnet.pipeline
@@ -8,7 +8,7 @@ env.DONT_COLLECT='FOO'
 env.COLLECT='BAR'
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")

--- a/src/test/resources/integration/pipelines/scripted/dotnet.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/dotnet.pipeline
@@ -8,7 +8,7 @@ env.DONT_COLLECT='FOO'
 env.COLLECT='BAR'
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")

--- a/src/test/resources/integration/pipelines/scripted/downloadByAql.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadByAql.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:downloadByAql test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/downloadByAql.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadByAql.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:downloadByAql test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/downloadByBuildOnly.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadByBuildOnly.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def firstBuildNumber = "${BUILD_NUMBER}-1"
     def secondBuildNumber = "${BUILD_NUMBER}-2"
     def thirdBuildNumber = "${BUILD_NUMBER}-3"

--- a/src/test/resources/integration/pipelines/scripted/downloadByBuildOnly.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadByBuildOnly.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def firstBuildNumber = "${BUILD_NUMBER}-1"
     def secondBuildNumber = "${BUILD_NUMBER}-2"
     def thirdBuildNumber = "${BUILD_NUMBER}-3"

--- a/src/test/resources/integration/pipelines/scripted/downloadByPattern.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadByPattern.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:downloadByPattern test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/downloadByPattern.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadByPattern.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:downloadByPattern test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/downloadByPatternAndBuild.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadByPatternAndBuild.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def firstBuildNumber = "${BUILD_NUMBER}-1"
     def secondBuildNumber = "${BUILD_NUMBER}-2"
     def thirdBuildNumber = "${BUILD_NUMBER}-3"

--- a/src/test/resources/integration/pipelines/scripted/downloadByPatternAndBuild.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadByPatternAndBuild.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def firstBuildNumber = "${BUILD_NUMBER}-1"
     def secondBuildNumber = "${BUILD_NUMBER}-2"
     def thirdBuildNumber = "${BUILD_NUMBER}-3"

--- a/src/test/resources/integration/pipelines/scripted/downloadByShaAndBuild.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadByShaAndBuild.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def firstBuildNumber = "${BUILD_NUMBER}-1"
     def secondBuildNumber = "${BUILD_NUMBER}-2"
     def thirdBuildNumber = "${BUILD_NUMBER}-3"

--- a/src/test/resources/integration/pipelines/scripted/downloadByShaAndBuild.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadByShaAndBuild.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def firstBuildNumber = "${BUILD_NUMBER}-1"
     def secondBuildNumber = "${BUILD_NUMBER}-2"
     def thirdBuildNumber = "${BUILD_NUMBER}-3"

--- a/src/test/resources/integration/pipelines/scripted/downloadByShaAndBuildName.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadByShaAndBuildName.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def firstBuildNumber = "${BUILD_NUMBER}-1"
     def secondBuildNumber = "${BUILD_NUMBER}-2"
     def thirdBuildNumber = "${BUILD_NUMBER}-3"

--- a/src/test/resources/integration/pipelines/scripted/downloadByShaAndBuildName.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadByShaAndBuildName.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def firstBuildNumber = "${BUILD_NUMBER}-1"
     def secondBuildNumber = "${BUILD_NUMBER}-2"
     def thirdBuildNumber = "${BUILD_NUMBER}-3"

--- a/src/test/resources/integration/pipelines/scripted/downloadFailNoOp.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadFailNoOp.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
 
     stage "Download"
     def downloadSpec = """{

--- a/src/test/resources/integration/pipelines/scripted/downloadFailNoOp.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadFailNoOp.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
 
     stage "Download"
     def downloadSpec = """{

--- a/src/test/resources/integration/pipelines/scripted/downloadNonExistingBuild.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadNonExistingBuild.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
 
     // First upload files and publish build
     def buildInfo = Artifactory.newBuildInfo()

--- a/src/test/resources/integration/pipelines/scripted/downloadNonExistingBuild.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadNonExistingBuild.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
 
     // First upload files and publish build
     def buildInfo = Artifactory.newBuildInfo()

--- a/src/test/resources/integration/pipelines/scripted/go.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/go.pipeline
@@ -8,7 +8,7 @@ env.DONT_COLLECT='FOO'
 env.COLLECT='BAR'
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")

--- a/src/test/resources/integration/pipelines/scripted/go.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/go.pipeline
@@ -8,7 +8,7 @@ env.DONT_COLLECT='FOO'
 env.COLLECT='BAR'
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")

--- a/src/test/resources/integration/pipelines/scripted/goCustomModuleName.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/goCustomModuleName.pipeline
@@ -6,7 +6,7 @@ import java.nio.file.Paths
 
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:goCustomModuleName test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/goCustomModuleName.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/goCustomModuleName.pipeline
@@ -6,7 +6,7 @@ import java.nio.file.Paths
 
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:goCustomModuleName test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/gradle.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/gradle.pipeline
@@ -8,7 +8,7 @@ env.DONT_COLLECT='FOO'
 env.COLLECT='BAR'
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")

--- a/src/test/resources/integration/pipelines/scripted/gradle.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/gradle.pipeline
@@ -8,7 +8,7 @@ env.DONT_COLLECT='FOO'
 env.COLLECT='BAR'
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")

--- a/src/test/resources/integration/pipelines/scripted/gradleCiServer.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/gradleCiServer.pipeline
@@ -6,7 +6,7 @@ import java.nio.file.Paths
 
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:gradle-ci test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/gradleCiServer.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/gradleCiServer.pipeline
@@ -6,7 +6,7 @@ import java.nio.file.Paths
 
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:gradle-ci test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/gradleCiServerPublication.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/gradleCiServerPublication.pipeline
@@ -6,7 +6,7 @@ import java.nio.file.Paths
 
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:gradle-ci-publication test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/gradleCiServerPublication.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/gradleCiServerPublication.pipeline
@@ -6,7 +6,7 @@ import java.nio.file.Paths
 
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:gradle-ci-publication test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/maven.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/maven.pipeline
@@ -8,7 +8,7 @@ env.DONT_COLLECT='FOO'
 env.COLLECT='BAR'
 node("TestSlave")  {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")

--- a/src/test/resources/integration/pipelines/scripted/maven.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/maven.pipeline
@@ -8,7 +8,7 @@ env.DONT_COLLECT='FOO'
 env.COLLECT='BAR'
 node("TestSlave")  {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")

--- a/src/test/resources/integration/pipelines/scripted/mavenJib.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/mavenJib.pipeline
@@ -8,7 +8,7 @@ env.DONT_COLLECT = 'FOO'
 env.COLLECT = 'BAR'
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '') + '/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '') + '/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")

--- a/src/test/resources/integration/pipelines/scripted/mavenJib.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/mavenJib.pipeline
@@ -8,7 +8,7 @@ env.DONT_COLLECT = 'FOO'
 env.COLLECT = 'BAR'
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '') + '/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '') + '/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")

--- a/src/test/resources/integration/pipelines/scripted/mavenWrapper.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/mavenWrapper.pipeline
@@ -8,7 +8,7 @@ env.DONT_COLLECT='FOO'
 env.COLLECT='BAR'
 node("TestSlave")  {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")

--- a/src/test/resources/integration/pipelines/scripted/mavenWrapper.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/mavenWrapper.pipeline
@@ -8,7 +8,7 @@ env.DONT_COLLECT='FOO'
 env.COLLECT='BAR'
 node("TestSlave")  {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")

--- a/src/test/resources/integration/pipelines/scripted/npmCi.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/npmCi.pipeline
@@ -8,7 +8,7 @@ env.DONT_COLLECT='FOO'
 env.COLLECT='BAR'
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")

--- a/src/test/resources/integration/pipelines/scripted/npmCi.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/npmCi.pipeline
@@ -8,7 +8,7 @@ env.DONT_COLLECT='FOO'
 env.COLLECT='BAR'
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")

--- a/src/test/resources/integration/pipelines/scripted/npmCustomModuleName.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/npmCustomModuleName.pipeline
@@ -8,7 +8,7 @@ env.DONT_COLLECT = 'FOO'
 env.COLLECT = 'BAR'
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '') + '/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '') + '/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")

--- a/src/test/resources/integration/pipelines/scripted/npmCustomModuleName.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/npmCustomModuleName.pipeline
@@ -8,7 +8,7 @@ env.DONT_COLLECT = 'FOO'
 env.COLLECT = 'BAR'
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '') + '/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '') + '/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")

--- a/src/test/resources/integration/pipelines/scripted/npmInstall.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/npmInstall.pipeline
@@ -8,7 +8,7 @@ env.DONT_COLLECT='FOO'
 env.COLLECT='BAR'
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")

--- a/src/test/resources/integration/pipelines/scripted/npmInstall.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/npmInstall.pipeline
@@ -8,7 +8,7 @@ env.DONT_COLLECT='FOO'
 env.COLLECT='BAR'
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")

--- a/src/test/resources/integration/pipelines/scripted/nuget.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/nuget.pipeline
@@ -8,7 +8,7 @@ env.DONT_COLLECT='FOO'
 env.COLLECT='BAR'
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")

--- a/src/test/resources/integration/pipelines/scripted/nuget.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/nuget.pipeline
@@ -8,7 +8,7 @@ env.DONT_COLLECT='FOO'
 env.COLLECT='BAR'
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")

--- a/src/test/resources/integration/pipelines/scripted/pip.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/pip.pipeline
@@ -8,7 +8,7 @@ env.DONT_COLLECT='FOO'
 env.COLLECT='BAR'
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")

--- a/src/test/resources/integration/pipelines/scripted/pip.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/pip.pipeline
@@ -8,7 +8,7 @@ env.DONT_COLLECT='FOO'
 env.COLLECT='BAR'
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")

--- a/src/test/resources/integration/pipelines/scripted/promote.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/promote.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:promotion test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/promote.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/promote.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:promotion test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/rbCreateDistDel.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/rbCreateDistDel.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def jfrogInstance = JFrog.newInstance url: "${env.JENKINS_PLATFORM_URL}", username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def jfrogInstance = JFrog.newInstance url: "${env.JENKINS_PLATFORM_URL}", username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def rtServer = jfrogInstance.artifactory
     def dsServer = jfrogInstance.distribution
     def releaseBundleName = "scripted:createDistributeDelete"

--- a/src/test/resources/integration/pipelines/scripted/rbCreateDistDel.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/rbCreateDistDel.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def jfrogInstance = JFrog.newInstance url: "${env.JENKINS_PLATFORM_URL}", username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def jfrogInstance = JFrog.newInstance url: "${env.JENKINS_PLATFORM_URL}", username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def rtServer = jfrogInstance.artifactory
     def dsServer = jfrogInstance.distribution
     def releaseBundleName = "scripted:createDistributeDelete"

--- a/src/test/resources/integration/pipelines/scripted/rbCreateUpdateSign.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/rbCreateUpdateSign.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def jfrogInstance = JFrog.newInstance url: "${env.JENKINS_PLATFORM_URL}", username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def jfrogInstance = JFrog.newInstance url: "${env.JENKINS_PLATFORM_URL}", username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def rtServer = jfrogInstance.artifactory
     def dsServer = jfrogInstance.distribution
     def releaseBundleName = "scripted:createUpdateSign"

--- a/src/test/resources/integration/pipelines/scripted/rbCreateUpdateSign.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/rbCreateUpdateSign.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def jfrogInstance = JFrog.newInstance url: "${env.JENKINS_PLATFORM_URL}", username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def jfrogInstance = JFrog.newInstance url: "${env.JENKINS_PLATFORM_URL}", username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def rtServer = jfrogInstance.artifactory
     def dsServer = jfrogInstance.distribution
     def releaseBundleName = "scripted:createUpdateSign"

--- a/src/test/resources/integration/pipelines/scripted/setProps.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/setProps.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:setProps test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/setProps.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/setProps.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:setProps test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/upload.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/upload.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:upload test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/upload.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/upload.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:upload test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/uploadDownloadCustomModuleName.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/uploadDownloadCustomModuleName.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:uploadDownloadCustomModuleName test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/uploadDownloadCustomModuleName.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/uploadDownloadCustomModuleName.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:uploadDownloadCustomModuleName test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/uploadFailNoOp.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/uploadFailNoOp.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
 
     stage "Upload"
     def uploadSpec = """{

--- a/src/test/resources/integration/pipelines/scripted/uploadFailNoOp.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/uploadFailNoOp.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
 
     stage "Upload"
     def uploadSpec = """{

--- a/src/test/resources/integration/pipelines/scripted/uploadWithProject.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/uploadWithProject.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:project upload test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/uploadWithProject.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/uploadWithProject.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:project upload test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/uploadWithProps.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/uploadWithProps.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:upload with props test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/uploadWithProps.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/uploadWithProps.pipeline
@@ -2,7 +2,7 @@ package integration.pipelines.scripted
 
 node("TestSlave") {
     stage "Configuration"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:upload with props test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/xrayScanFailBuildFalse.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/xrayScanFailBuildFalse.pipeline
@@ -6,7 +6,7 @@ import java.nio.file.Paths
 
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:xrayScanFailBuildFalse test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/xrayScanFailBuildFalse.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/xrayScanFailBuildFalse.pipeline
@@ -6,7 +6,7 @@ import java.nio.file.Paths
 
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:xrayScanFailBuildFalse test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/xrayScanFailBuildTrue.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/xrayScanFailBuildTrue.pipeline
@@ -6,7 +6,7 @@ import java.nio.file.Paths
 
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_ARTIFACTORY_PASSWORD}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:xrayScanFailBuildTrue test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/pipelines/scripted/xrayScanFailBuildTrue.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/xrayScanFailBuildTrue.pipeline
@@ -6,7 +6,7 @@ import java.nio.file.Paths
 
 node("TestSlave") {
     stage "Configure Artifactory"
-    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_ARTIFACTORY_USERNAME}", password: "${env.JENKINS_PLATFORM_ACCESS_TOKEN}"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.name = "scripted:xrayScanFailBuildTrue test"
     buildInfo.number = ${BUILD_NUMBER}

--- a/src/test/resources/integration/settings/jenkins-artifactory-tests-project-conf.json
+++ b/src/test/resources/integration/settings/jenkins-artifactory-tests-project-conf.json
@@ -1,0 +1,2 @@
+{"display_name":"Jenkins Test Project ${PROJECT_KEY}","description":"Project created by tests suite",
+  "admin_privileges":{"manage_members":true,"manage_resources":true,"index_resources":true},"storage_quota_bytes":1073741825,"project_key":"${PROJECT_KEY}"}


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----
Also replace `JENKINS_ARTIFACTORY_PASSWORD` env with `JENKINS_PLATFORM_ACCESS_TOKEN`