### PR TITLE
Bugfix - NPE in extractVcs when running on the master

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/PublishBuildInfoStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/PublishBuildInfoStep.java
@@ -2,6 +2,8 @@ package org.jfrog.hudson.pipeline.declarative.steps;
 
 import com.google.inject.Inject;
 import hudson.Extension;
+import hudson.FilePath;
+import org.apache.commons.lang3.ObjectUtils;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -61,7 +63,12 @@ public class PublishBuildInfoStep extends AbstractStepImpl {
                 throw new RuntimeException("Build " + DeclarativePipelineUtils.createBuildInfoId(build, step.buildName, step.buildNumber, step.project) + " does not exist!");
             }
             ArtifactoryServer server = DeclarativePipelineUtils.getArtifactoryServer(build, rootWs, step.serverId, true);
-            new PublishBuildInfoExecutor(build, listener, buildInfo, server, ws).execute();
+            /* If the user runs rtPublishBuildInfo on the master, there may be no workspace.
+             * In that case, we would prefer to try to collect the VCS from the root workspace of the job.
+             * Caveat - if the Git repository does not in the root workspace, the extract VCS will return an empty VCS object.
+             */
+            FilePath vcsWorkspace = ObjectUtils.defaultIfNull(ws, rootWs);
+            new PublishBuildInfoExecutor(build, listener, buildInfo, server, vcsWorkspace).execute();
             return null;
         }
 


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----

Resolves #471
Resolves #213

Fix the following NPE caused by running `rtPublishBuildInfo` without a node:
> java.lang.NullPointerException
	at org.jfrog.hudson.pipeline.common.Utils.extractVcs(Utils.java:127)
	at org.jfrog.hudson.pipeline.common.executors.PublishBuildInfoExecutor.execute(PublishBuildInfoExecutor.java:33)

The root cause is the attempt to run `filePath.act` on a null object.
Currently there are 2 FilePath objects:
* `rootWs` - The root workspace of the job. Never changes, always not null.
* `ws` - That is the actual working directory. If the user runs a step inside `dir{...}` scope, it will contain the actual directory. If the root step runs without a node, `ws` will be null.

The collect VCS logic relies on the `ws` object. This PR adds a fallback mechanism to use `rootWs` if `ws` is null.