### PR TITLE
Bugfix - NPE in Gradle jobs when deployer is empty

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/common/executors/GradleExecutor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/executors/GradleExecutor.java
@@ -74,7 +74,7 @@ public class GradleExecutor implements Executor {
         org.jfrog.build.api.Build generatedBuild = Utils.getGeneratedBuildInfo(build, listener, launcher, generatedBuildPath);
         // Add action only if artifacts were actually deployed and the build info was generated.
         // The build info gets generated only after running the "artifactoryPublish" task.
-        if (deployer.isDeployArtifacts() && CollectionUtils.isNotEmpty(generatedBuild.getModules())) {
+        if (deployer.isDeployArtifacts() && !deployer.isEmpty() && CollectionUtils.isNotEmpty(generatedBuild.getModules())) {
             addDeployedArtifactsActionFromModules(this.build, deployer.getArtifactoryServer().getArtifactoryUrl(), generatedBuild.getModules(), DeployDetails.PackageType.GRADLE);
         }
         buildInfo.append(generatedBuild);


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----

Resolves https://github.com/jfrog/jenkins-artifactory-plugin/issues/551#issuecomment-910445376

When the Gradle deployer is not defined, the artifactory server in the deployer is null. This behaviour leads to NPE in this line:
https://github.com/jfrog/jenkins-artifactory-plugin/blob/artifactory-3.13.0/src/main/java/org/jfrog/hudson/pipeline/common/executors/GradleExecutor.java#L76