### PR TITLE
Update JFrog Pipeline scripts

### DIFF
--- a/ci/pipelines.release.yml
+++ b/ci/pipelines.release.yml
@@ -50,11 +50,11 @@ pipelines:
             - test -n "$NEXT_DEVELOPMENT_VERSION" -a "$NEXT_DEVELOPMENT_VERSION" != "0.0.0"
 
             # Download JFrog CLI
-            - curl -fL https://getcli.jfrog.io | sh && chmod +x jfrog
+            - curl -fL https://getcli.jfrog.io | bash -s v2
 
             # Configure JFrog CLI
             - ./jfrog c add jenkins_artifactory --artifactory-url $int_jenkins_artifactory_rt_url --user=$int_jenkins_artifactory_rt_user --password=$int_jenkins_artifactory_rt_password --enc-password=false
-            - ./jfrog rt mvnc --server-id-deploy jenkins_artifactory --repo-deploy-releases releases --repo-deploy-snapshots snapshots
+            - ./jfrog rt mvnc --repo-deploy-releases releases --repo-deploy-snapshots snapshots
 
             # Sync changes with upstream
             - git pull upstream master

--- a/ci/pipelines.snapshot.yml
+++ b/ci/pipelines.snapshot.yml
@@ -17,8 +17,6 @@ pipelines:
         configuration:
           inputResources:
             - name: jenkinsSnapshotGit
-          integrations:
-            - name: ojo
         execution:
           onStart:
             - *UPDATE_COMMIT_STATUS
@@ -33,13 +31,13 @@ pipelines:
             - export JFROG_CLI_BUILD_NUMBER=$run_number
 
             # Download JFrog CLI
-            - curl -fL https://getcli.jfrog.io | sh && chmod +x jfrog
+            - curl -fL https://getcli.jfrog.io | bash -s v2
 
             # Configure JFrog CLI
-            - ./jfrog rt c ojo --url $int_ojo_rt_url --access-token=$int_ojo_rt_token
+            - ./jfrog c add releases --artifactory-url https://releases.jfrog.io/artifactory --access-token=$int_releases_temp_token
             - ./jfrog rt mvnc
-              --server-id-resolve ojo --repo-resolve-releases libs-release --repo-resolve-snapshots libs-snapshot
-              --server-id-deploy ojo --repo-deploy-releases oss-release-local --repo-deploy-snapshots oss-snapshot-local
+              --repo-resolve-releases libs-release --repo-resolve-snapshots libs-snapshot
+              --repo-deploy-releases oss-release-local --repo-deploy-snapshots oss-snapshot-local
 
             # Run install and publish
             - >


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----
Implemented the following changes in JFrog Pipeline's scripts:
- Replaced oss.jfrog.org with releases.jfrog.io
- Use jfrog-cli v2 instead of v1
- Removed the --server-id option, which has recently become optional 