### PR TITLE
Bugfix - Build-info ignores duplicate artifacts checksum

### DIFF
--- a/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
@@ -77,6 +77,27 @@ public class CommonITestsPipeline extends PipelineTestBase {
         }
     }
 
+    void downloadDuplications(String buildName, String scriptName) throws Exception {
+        Set<String> expectedDependencies = getTestFilesNamesByLayer(0);
+        WorkflowRun pipelineResults = null;
+
+        Files.list(FILES_PATH).filter(Files::isRegularFile)
+                .forEach(file -> uploadFile(artifactoryClient, file, getRepoKey(TestRepository.LOCAL_REPO1)));
+        try {
+            pipelineResults = runPipeline(scriptName, false);
+            for (int i = 1; i < 2; i++) {
+                for (String fileName : expectedDependencies) {
+                    assertTrue(isExistInWorkspace(slave, pipelineResults, scriptName+"-test-" + i, fileName));
+                }
+            }
+            Build buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER, null);
+            Module module = getAndAssertModule(buildInfo, buildName);
+            assertModuleDependencies(module, expectedDependencies);
+        } finally {
+            cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER);
+        }
+    }
+
     void downloadByAqlTest(String buildName) throws Exception {
         Set<String> expectedDependencies = getTestFilesNamesByLayer(0);
         WorkflowRun pipelineResults = null;
@@ -217,6 +238,18 @@ public class CommonITestsPipeline extends PipelineTestBase {
             Build buildInfo = getBuildInfo(artifactoryManager, buildName, BUILD_NUMBER, project);
             Module module = getAndAssertModule(buildInfo, buildName);
             assertModuleArtifacts(module, expectedArtifacts);
+        } finally {
+            cleanupBuilds(pipelineResults, buildName, project, BUILD_NUMBER);
+        }
+    }
+
+    void uploadDuplicationsTest(String buildName, String project, String pipelineName) throws Exception {
+        WorkflowRun pipelineResults = null;
+        try {
+            pipelineResults = runPipeline(pipelineName, false);
+            Build buildInfo = getBuildInfo(artifactoryManager, buildName, BUILD_NUMBER, project);
+            Module module = getAndAssertModule(buildInfo, buildName);
+            assertEquals(module.getArtifacts().size(), 6);
         } finally {
             cleanupBuilds(pipelineResults, buildName, project, BUILD_NUMBER);
         }

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
@@ -76,8 +76,8 @@ public class CommonITestsPipeline extends PipelineTestBase {
             cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER);
         }
     }
-
-    void downloadDuplications(String buildName, String scriptName) throws Exception {
+    // Download a single artifact from different paths in Artifactory must be included only once in the build-info.
+    void downloadDuplicationsTest(String buildName, String scriptName) throws Exception {
         Set<String> expectedDependencies = getTestFilesNamesByLayer(0);
         WorkflowRun pipelineResults = null;
 
@@ -242,7 +242,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
             cleanupBuilds(pipelineResults, buildName, project, BUILD_NUMBER);
         }
     }
-
+    // Upload a single artifact to different paths in Artifactory must include all of them in the build info.
     void uploadDuplicationsTest(String buildName, String project, String pipelineName) throws Exception {
         WorkflowRun pipelineResults = null;
         try {

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/ScriptedITest.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/ScriptedITest.java
@@ -17,6 +17,16 @@ public class ScriptedITest extends CommonITestsPipeline {
     }
 
     @Test
+    public void downloadDuplicationsPart1Test() throws Exception {
+        super.downloadDuplications("scripted:downloadDuplicationsPart1 test","downloadDuplicationsPart1");
+    }
+
+    @Test
+    public void downloadDuplicationsPart2Test() throws Exception {
+        super.downloadDuplications("scripted:downloadDuplicationsPart2 test","downloadDuplicationsPart2");
+    }
+
+    @Test
     public void downloadByAqlTest() throws Exception {
         super.downloadByAqlTest("scripted:downloadByAql test");
     }
@@ -49,6 +59,16 @@ public class ScriptedITest extends CommonITestsPipeline {
     @Test
     public void uploadTest() throws Exception {
         super.uploadTest("scripted:upload test", null, "upload");
+    }
+
+    @Test
+    public void uploadDuplicationsPart1Test() throws Exception {
+        super.uploadDuplicationsTest("scripted:uploadDuplicationsPart1 test", null, "uploadDuplicationsPart1");
+    }
+
+    @Test
+    public void uploadDuplicationsPart2Test() throws Exception {
+        super.uploadDuplicationsTest("scripted:uploadDuplicationsPart2 test", null, "uploadDuplicationsPart2");
     }
 
     @Test

--- a/src/test/resources/integration/pipelines/scripted/downloadDuplicationsPart1.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadDuplicationsPart1.pipeline
@@ -1,0 +1,26 @@
+package integration.pipelines.scripted
+
+node("TestSlave") {
+    stage "Configuration"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
+    def buildInfo = Artifactory.newBuildInfo()
+    buildInfo.name = "scripted:downloadDuplicationsPart1 test"
+    buildInfo.number = ${BUILD_NUMBER}
+
+    stage "Download"
+    for (i = 1; i <=2; i++) {
+        def downloadSpec = """{
+          "files": [
+            {
+              "pattern": "${LOCAL_REPO1}/*",
+              "target": "downloadDuplicationsPart1-test-${i}/",
+              "recursive": "false"
+            }
+         ]
+        }"""
+        rtServer.download spec: downloadSpec, buildInfo: buildInfo
+    }
+
+    stage "Publish Build Info"
+    rtServer.publishBuildInfo buildInfo
+}

--- a/src/test/resources/integration/pipelines/scripted/downloadDuplicationsPart2.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/downloadDuplicationsPart2.pipeline
@@ -1,0 +1,36 @@
+package integration.pipelines.scripted
+
+node("TestSlave") {
+    stage "Configuration"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
+    def buildInfo = Artifactory.newBuildInfo()
+    buildInfo.name = "scripted:downloadDuplicationsPart2 test"
+    buildInfo.number = ${BUILD_NUMBER}
+
+    stage "Download"
+
+    def downloadSpec = """{
+      "files": [
+        {
+          "pattern": "${LOCAL_REPO1}/*",
+          "target": "downloadDuplicationsPart2-test-1/",
+          "recursive": "false"
+        },
+        {
+          "pattern": "${LOCAL_REPO1}/*",
+          "target": "downloadDuplicationsPart2-test-2/",
+          "recursive": "false"
+        },
+        {
+          "pattern": "${LOCAL_REPO1}/*",
+          "target": "downloadDuplicationsPart2-test-3/",
+          "recursive": "false"
+        }
+     ]
+    }"""
+    rtServer.download spec: downloadSpec, buildInfo: buildInfo
+
+
+    stage "Publish Build Info"
+    rtServer.publishBuildInfo buildInfo
+}

--- a/src/test/resources/integration/pipelines/scripted/uploadDuplicationsPart1.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/uploadDuplicationsPart1.pipeline
@@ -1,0 +1,26 @@
+package integration.pipelines.scripted
+
+node("TestSlave") {
+    stage "Configuration"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
+    def buildInfo = Artifactory.newBuildInfo()
+    buildInfo.name = "scripted:uploadDuplicationsPart1 test"
+    buildInfo.number = ${BUILD_NUMBER}
+
+    stage "Upload"
+     for (i = 1; i <=2; i++) {
+        def uploadSpec = """{
+          "files": [
+            {
+              "pattern": "${FILES_DIR}",
+              "target": "${LOCAL_REPO1}/folder-${i}/",
+              "recursive": "false"
+            }
+         ]
+        }"""
+        rtServer.upload spec: uploadSpec, buildInfo: buildInfo
+    }
+
+    stage "Publish Build Info"
+    rtServer.publishBuildInfo buildInfo
+}

--- a/src/test/resources/integration/pipelines/scripted/uploadDuplicationsPart2.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/uploadDuplicationsPart2.pipeline
@@ -1,0 +1,28 @@
+package integration.pipelines.scripted
+
+node("TestSlave") {
+    stage "Configuration"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
+    def buildInfo = Artifactory.newBuildInfo()
+    buildInfo.name = "scripted:uploadDuplicationsPart2 test"
+    buildInfo.number = ${BUILD_NUMBER}
+
+    stage "Upload"
+    def uploadSpec = """{
+      "files": [
+        {
+          "pattern": "${FILES_DIR}",
+          "target": "${LOCAL_REPO1}/folder-1/",
+          "recursive": "false"
+        },     {
+          "pattern": "${FILES_DIR}",
+          "target": "${LOCAL_REPO1}/folder-2/",
+          "recursive": "false"
+        }
+     ]
+    }"""
+    rtServer.upload spec: uploadSpec, buildInfo: buildInfo
+
+    stage "Publish Build Info"
+    rtServer.publishBuildInfo buildInfo
+}


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----
Related: https://github.com/jfrog/build-info/pull/560