### PR TITLE
Reduce usages of Guava

### DIFF
--- a/src/main/java/org/jfrog/hudson/AbstractBuildWrapperDescriptor.java
+++ b/src/main/java/org/jfrog/hudson/AbstractBuildWrapperDescriptor.java
@@ -1,6 +1,5 @@
 package org.jfrog.hudson;
 
-import com.google.common.collect.Maps;
 import com.tikal.jenkins.plugins.multijob.MultiJobProject;
 import hudson.matrix.MatrixProject;
 import hudson.model.AbstractProject;
@@ -19,6 +18,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -155,7 +155,7 @@ public abstract class AbstractBuildWrapperDescriptor extends BuildWrapperDescrip
 
         ArrayList<PluginSettings> list = new ArrayList<>(pluginInfoList.size());
         for (UserPluginInfo p : pluginInfoList) {
-            Map<String, String> paramsMap = Maps.newHashMap();
+            Map<String, String> paramsMap = new HashMap<>();
             List<UserPluginInfoParam> params = p.getPluginParams();
             for (UserPluginInfoParam param : params) {
                 paramsMap.put(((String) param.getKey()), ((String) param.getDefaultValue()));

--- a/src/main/java/org/jfrog/hudson/ArtifactoryBuilder.java
+++ b/src/main/java/org/jfrog/hudson/ArtifactoryBuilder.java
@@ -17,7 +17,6 @@
 package org.jfrog.hudson;
 
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
-import com.google.common.collect.Lists;
 import hudson.Extension;
 import hudson.model.BuildableItem;
 import hudson.model.BuildableItemWithBuildWrappers;
@@ -54,6 +53,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -297,7 +297,7 @@ public class ArtifactoryBuilder extends GlobalConfiguration {
         }
 
         private void configureJFrogInstances(StaplerRequest req, JSONObject o) throws FormException {
-            List<JFrogPlatformInstance> jfrogInstances = Lists.newArrayList();
+            List<JFrogPlatformInstance> jfrogInstances = new ArrayList<>();
             Object jfrogInstancesObj = o.get("jfrogInstances"); // an array or single object
             if (!JSONNull.getInstance().equals(jfrogInstancesObj)) {
                 jfrogInstances = req.bindJSONToList(JFrogPlatformInstance.class, jfrogInstancesObj);

--- a/src/main/java/org/jfrog/hudson/ArtifactoryRedeployPublisher.java
+++ b/src/main/java/org/jfrog/hudson/ArtifactoryRedeployPublisher.java
@@ -16,10 +16,6 @@
 
 package org.jfrog.hudson;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher;
@@ -53,6 +49,7 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -377,11 +374,7 @@ public class ArtifactoryRedeployPublisher extends Recorder implements DeployerOv
 
     private boolean isBuildFromM2ReleasePlugin(AbstractBuild<?, ?> build) {
         List<Cause> causes = build.getCauses();
-        return !causes.isEmpty() && Iterables.any(causes, new Predicate<Cause>() {
-            public boolean apply(Cause input) {
-                return "org.jvnet.hudson.plugins.m2release.ReleaseCause".equals(input.getClass().getName());
-            }
-        });
+        return !causes.isEmpty() && causes.stream().anyMatch(input -> "org.jvnet.hudson.plugins.m2release.ReleaseCause".equals(input.getClass().getName()));
     }
 
     private boolean isM2Build(AbstractBuild<?, ?> build) {
@@ -394,7 +387,7 @@ public class ArtifactoryRedeployPublisher extends Recorder implements DeployerOv
     }
 
     protected List<MavenAbstractArtifactRecord> getArtifactRecordActions(MavenModuleSetBuild build) {
-        List<MavenAbstractArtifactRecord> actions = Lists.newArrayList();
+        List<MavenAbstractArtifactRecord> actions = new ArrayList<>();
         for (MavenBuild moduleBuild : build.getModuleLastBuilds().values()) {
             MavenAbstractArtifactRecord action = moduleBuild.getAction(MavenAbstractArtifactRecord.class);
             if (action != null) {
@@ -473,7 +466,7 @@ public class ArtifactoryRedeployPublisher extends Recorder implements DeployerOv
 
             ArrayList<PluginSettings> list = new ArrayList<PluginSettings>(pluginInfoList.size());
             for (UserPluginInfo p : pluginInfoList) {
-                Map<String, String> paramsMap = Maps.newHashMap();
+                Map<String, String> paramsMap = new HashMap<>();
                 List<UserPluginInfoParam> params = p.getPluginParams();
                 for (UserPluginInfoParam param : params) {
                     paramsMap.put(((String) param.getKey()), ((String) param.getDefaultValue()));

--- a/src/main/java/org/jfrog/hudson/ArtifactoryServer.java
+++ b/src/main/java/org/jfrog/hudson/ArtifactoryServer.java
@@ -38,6 +38,7 @@ import org.jfrog.hudson.util.converters.ArtifactoryServerConverter;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -168,7 +169,7 @@ public class ArtifactoryServer implements Serializable {
         CredentialsConfig credentialsConfig = CredentialManager.getPreferredDeployer(deployerOverrider, this);
         List<String> repositoryKeys = getLocalRepositoryKeys(credentialsConfig.provideCredentials(item));
         if (repositoryKeys == null || repositoryKeys.isEmpty()) {
-            return Lists.newArrayList();
+            return new ArrayList<>();
         }
         Collections.sort(repositoryKeys, new RepositoryComparator());
         return repositoryKeys;
@@ -178,7 +179,7 @@ public class ArtifactoryServer implements Serializable {
         CredentialsConfig credentialsConfig = CredentialManager.getPreferredDeployer(deployerOverrider, this);
         List<String> repositoryKeys = getLocalRepositoryKeys(credentialsConfig.provideCredentials(item));
         if (repositoryKeys == null || repositoryKeys.isEmpty()) {
-            return Lists.newArrayList();
+            return new ArrayList<>();
         }
         Collections.sort(repositoryKeys, Collections.reverseOrder(new RepositoryComparator()));
         return repositoryKeys;
@@ -205,7 +206,7 @@ public class ArtifactoryServer implements Serializable {
                 log.log(Level.WARNING,
                         "Could not obtain virtual repositories list from '" + url + "': " + e.getMessage());
             }
-            return Lists.newArrayList();
+            return new ArrayList<>();
         }
 
         return virtualRepositories;

--- a/src/main/java/org/jfrog/hudson/ServerDetails.java
+++ b/src/main/java/org/jfrog/hudson/ServerDetails.java
@@ -16,12 +16,12 @@
 
 package org.jfrog.hudson;
 
-import com.google.common.collect.Maps;
 import hudson.util.XStream2;
 import org.apache.commons.lang3.StringUtils;
 import org.jfrog.hudson.util.converters.ServerDetailsConverter;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -167,7 +167,7 @@ public class ServerDetails {
             stagingPlugin.setPluginName(userPluginKey);
         }
         if (userPluginParams != null) {
-            Map<String, String> paramsMap = Maps.newHashMap();
+            Map<String, String> paramsMap = new HashMap<>();
             String[] params = userPluginParams.split(" ");
             for (String param : params) {
                 String[] keyValue = param.split("=");

--- a/src/main/java/org/jfrog/hudson/UserPluginInfo.java
+++ b/src/main/java/org/jfrog/hudson/UserPluginInfo.java
@@ -1,8 +1,5 @@
 package org.jfrog.hudson;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-
 import java.util.*;
 
 /**
@@ -21,7 +18,7 @@ public class UserPluginInfo {
         pluginName = stagingPluginInfo.get("name").toString();
         Object params = stagingPluginInfo.get("params");
         if (params == null) {
-            pluginParams = Maps.newHashMap();
+            pluginParams = new HashMap<>();
         } else {
             pluginParams = (Map) params;
         }
@@ -29,7 +26,7 @@ public class UserPluginInfo {
 
     private UserPluginInfo(String name) {
         pluginName = name;
-        pluginParams = Maps.newHashMap();
+        pluginParams = new HashMap<>();
     }
 
     public String getPluginName() {
@@ -37,7 +34,7 @@ public class UserPluginInfo {
     }
 
     public List<UserPluginInfoParam> getPluginParams() {
-        List<UserPluginInfoParam> pluginParamList = Lists.newArrayList();
+        List<UserPluginInfoParam> pluginParamList = new ArrayList<>();
         for (Map.Entry paramEntry : ((Set<Map.Entry>) pluginParams.entrySet())) {
             pluginParamList.add(new UserPluginInfoParam(paramEntry.getKey(), paramEntry.getValue()));
         }

--- a/src/main/java/org/jfrog/hudson/action/ActionableHelper.java
+++ b/src/main/java/org/jfrog/hudson/action/ActionableHelper.java
@@ -40,6 +40,7 @@ import org.jfrog.hudson.util.publisher.PublisherFlexible;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -135,7 +136,7 @@ public abstract class ActionableHelper implements Serializable {
      * @return A list of builders that answer the class definition that are attached to the project.
      */
     public static <T extends Builder> List<T> getBuilder(Project<?, ?> project, Class<T> type) {
-        List<T> result = Lists.newArrayList();
+        List<T> result = new ArrayList<>();
         DescribableList<Builder, Descriptor<Builder>> builders = project.getBuildersList();
         for (Builder builder : builders) {
             if (type.isInstance(builder)) {

--- a/src/main/java/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator.java
@@ -1,6 +1,5 @@
 package org.jfrog.hudson.generic;
 
-import com.google.common.collect.Lists;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -51,6 +50,7 @@ import org.kohsuke.stapler.bind.JavaScriptMethod;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -360,7 +360,7 @@ public class ArtifactoryGenericConfigurator extends BuildWrapper implements Depl
 
     public List<Repository> getReleaseRepositoryList() {
         if (legacyDeployerDetails.getDeploySnapshotRepository() == null) {
-            return Lists.newArrayList();
+            return new ArrayList<>();
         }
         return RepositoriesUtils.collectRepositories(legacyDeployerDetails.getDeploySnapshotRepository().getKeyFromSelect());
     }

--- a/src/main/java/org/jfrog/hudson/generic/DependenciesDownloaderImpl.java
+++ b/src/main/java/org/jfrog/hudson/generic/DependenciesDownloaderImpl.java
@@ -1,7 +1,5 @@
 package org.jfrog.hudson.generic;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
 import hudson.FilePath;
 import hudson.remoting.VirtualChannel;
 import jenkins.MasterToSlaveFileCallable;
@@ -136,11 +134,7 @@ public class DependenciesDownloaderImpl implements DependenciesDownloader {
     }
 
     private boolean isResolvedOrParentOfResolvedFile(Set<String> resolvedFiles, final String path) {
-        return Iterables.any(resolvedFiles, new Predicate<String>() {
-            public boolean apply(String filePath) {
-                return StringUtils.equals(filePath, path) || StringUtils.startsWith(filePath, path);
-            }
-        });
+        return resolvedFiles.stream().anyMatch(filePath -> StringUtils.equals(filePath, path) || StringUtils.startsWith(filePath, path));
     }
 
     private static class DownloadFileCallable extends MasterToSlaveFileCallable<Map<String, String>> {

--- a/src/main/java/org/jfrog/hudson/generic/FilesResolverCallable.java
+++ b/src/main/java/org/jfrog/hudson/generic/FilesResolverCallable.java
@@ -1,6 +1,5 @@
 package org.jfrog.hudson.generic;
 
-import com.google.common.collect.Lists;
 import hudson.remoting.VirtualChannel;
 import jenkins.MasterToSlaveFileCallable;
 import org.apache.commons.lang3.StringUtils;
@@ -13,6 +12,7 @@ import org.jfrog.hudson.util.Credentials;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -40,7 +40,7 @@ public class FilesResolverCallable extends MasterToSlaveFileCallable<List<Depend
 
     public List<Dependency> invoke(File file, VirtualChannel channel) throws IOException {
         if (StringUtils.isEmpty(downloadSpec)) {
-            return Lists.newArrayList();
+            return new ArrayList<>();
         }
         SpecsHelper specsHelper = new SpecsHelper(log);
         ArtifactoryManager artifactoryManager = new ArtifactoryManager(serverUrl, username, password, accessToken, log);

--- a/src/main/java/org/jfrog/hudson/generic/GenericArtifactsDeployer.java
+++ b/src/main/java/org/jfrog/hudson/generic/GenericArtifactsDeployer.java
@@ -2,10 +2,7 @@ package org.jfrog.hudson.generic;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Sets;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Util;
@@ -40,6 +37,9 @@ import org.jfrog.hudson.util.SpecUtils;
 import java.io.File;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -60,7 +60,7 @@ public class GenericArtifactsDeployer {
     private BuildListener listener;
     private CredentialsConfig credentialsConfig;
     private EnvVars env;
-    private List<Artifact> artifactsToDeploy = Lists.newArrayList();
+    private List<Artifact> artifactsToDeploy = new ArrayList<>();
 
     public GenericArtifactsDeployer(Run build, ArtifactoryGenericConfigurator configurator,
                                     BuildListener listener, CredentialsConfig credentialsConfig)
@@ -170,7 +170,7 @@ public class GenericArtifactsDeployer {
             }
 
             // Option 2. Generic deploy - Fetch the artifacts details from workspace by using 'patternPairs'.
-            Set<DeployDetails> artifactsToDeploy = Sets.newHashSet();
+            Set<DeployDetails> artifactsToDeploy = new HashSet<>();
             Multimap<String, File> targetPathToFilesMap = buildTargetPathToFiles(workspace);
             for (Map.Entry<String, File> entry : targetPathToFilesMap.entries()) {
                 artifactsToDeploy.addAll(buildDeployDetailsFromFileEntry(entry));
@@ -182,7 +182,7 @@ public class GenericArtifactsDeployer {
         }
 
         private List<Artifact> convertDeployDetailsToArtifacts(Set<DeployDetails> details) {
-            List<Artifact> result = Lists.newArrayList();
+            List<Artifact> result = new ArrayList<>();
             for (DeployDetails detail : details) {
                 String ext = FilenameUtils.getExtension(detail.getFile().getName());
                 Artifact artifact = new ArtifactBuilder(detail.getFile().getName()).md5(detail.getMd5())
@@ -224,7 +224,7 @@ public class GenericArtifactsDeployer {
 
         private Set<DeployDetails> buildDeployDetailsFromFileEntry(Map.Entry<String, File> fileEntry)
                 throws IOException {
-            Set<DeployDetails> result = Sets.newHashSet();
+            Set<DeployDetails> result = new HashSet<>();
             String targetPath = fileEntry.getKey();
             File artifactFile = fileEntry.getValue();
             String path;
@@ -236,7 +236,7 @@ public class GenericArtifactsDeployer {
             path = StringUtils.replace(path, "//", "/");
 
             // calculate the sha1 checksum that is not given by Jenkins and add it to the deploy artifactsToDeploy
-            Map<String, String> checksums = Maps.newHashMap();
+            Map<String, String> checksums = new HashMap<>();
             try {
                 checksums = FileChecksumCalculator.calculateChecksums(artifactFile, SHA1, MD5);
             } catch (NoSuchAlgorithmException e) {

--- a/src/main/java/org/jfrog/hudson/gradle/ArtifactoryGradleConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/gradle/ArtifactoryGradleConfigurator.java
@@ -16,7 +16,6 @@
 
 package org.jfrog.hudson.gradle;
 
-import com.google.common.collect.Iterables;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -604,7 +603,7 @@ public class ArtifactoryGradleConfigurator extends BuildWrapper implements Deplo
     private Gradle getLastGradleBuild(AbstractProject project) {
         if (project instanceof Project) {
             List<Gradle> gradles = ActionableHelper.getBuilder((Project) project, Gradle.class);
-            return Iterables.getLast(gradles, null);
+            return gradles.stream().reduce((first, second) -> second).orElse(null);
         }
         return null;
     }

--- a/src/main/java/org/jfrog/hudson/gradle/ArtifactoryGradleConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/gradle/ArtifactoryGradleConfigurator.java
@@ -603,7 +603,9 @@ public class ArtifactoryGradleConfigurator extends BuildWrapper implements Deplo
     private Gradle getLastGradleBuild(AbstractProject project) {
         if (project instanceof Project) {
             List<Gradle> gradles = ActionableHelper.getBuilder((Project) project, Gradle.class);
-            return gradles.stream().reduce((first, second) -> second).orElse(null);
+           if (gradles != null && !gradles.isEmpty()) {
+                return gradles.get(gradles.size()-1);
+            }
         }
         return null;
     }

--- a/src/main/java/org/jfrog/hudson/gradle/GradleInitScriptWriter.java
+++ b/src/main/java/org/jfrog/hudson/gradle/GradleInitScriptWriter.java
@@ -16,7 +16,6 @@
 
 package org.jfrog.hudson.gradle;
 
-import com.google.common.base.Charsets;
 import hudson.EnvVars;
 import hudson.FilePath;
 import org.apache.commons.io.IOUtils;
@@ -25,6 +24,7 @@ import org.jfrog.hudson.util.PluginDependencyHelper;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 
 /**
@@ -50,7 +50,7 @@ public class GradleInitScriptWriter {
     public String generateInitScript(EnvVars env) throws IOException, InterruptedException {
         StringBuilder initScript = new StringBuilder();
         InputStream templateStream = getClass().getResourceAsStream("/initscripttemplate.gradle");
-        String templateAsString = IOUtils.toString(templateStream, Charsets.UTF_8.name());
+        String templateAsString = IOUtils.toString(templateStream, StandardCharsets.UTF_8.name());
         File extractorJar = PluginDependencyHelper.getExtractorJar(env);
         FilePath dependencyDir = PluginDependencyHelper.getActualDependencyDirectory(extractorJar, rootPath);
         String absoluteDependencyDirPath = dependencyDir.getRemote();

--- a/src/main/java/org/jfrog/hudson/ivy/ArtifactoryIvyFreeStyleConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/ivy/ArtifactoryIvyFreeStyleConfigurator.java
@@ -397,7 +397,9 @@ public class ArtifactoryIvyFreeStyleConfigurator extends BuildWrapper implements
     private Ant getLastAntBuild(AbstractProject project) {
         if (project instanceof Project) {
             List<Ant> ants = ActionableHelper.getBuilder((Project) project, Ant.class);
-            return ants.stream().reduce((first, second) -> second).orElse(null);
+          if (ants != null && !ants.isEmpty()) {
+                return ants.get(ants.size()-1);
+            }
         }
         return null;
     }

--- a/src/main/java/org/jfrog/hudson/ivy/ArtifactoryIvyFreeStyleConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/ivy/ArtifactoryIvyFreeStyleConfigurator.java
@@ -16,7 +16,6 @@
 
 package org.jfrog.hudson.ivy;
 
-import com.google.common.collect.Iterables;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -398,7 +397,7 @@ public class ArtifactoryIvyFreeStyleConfigurator extends BuildWrapper implements
     private Ant getLastAntBuild(AbstractProject project) {
         if (project instanceof Project) {
             List<Ant> ants = ActionableHelper.getBuilder((Project) project, Ant.class);
-            return Iterables.getLast(ants, null);
+            return ants.stream().reduce((first, second) -> second).orElse(null);
         }
         return null;
     }

--- a/src/main/java/org/jfrog/hudson/maven2/MavenBuildInfoDeployer.java
+++ b/src/main/java/org/jfrog/hudson/maven2/MavenBuildInfoDeployer.java
@@ -16,7 +16,6 @@
 
 package org.jfrog.hudson.maven2;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import hudson.maven.MavenBuild;
 import hudson.maven.MavenModule;
@@ -42,6 +41,7 @@ import org.jfrog.hudson.action.ActionableHelper;
 import org.jfrog.hudson.util.RepositoriesUtils;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -72,7 +72,7 @@ public class MavenBuildInfoDeployer extends AbstractBuildInfoDeployer {
 
     private void gatherModuleAndDependencyInfo(MavenModuleSetBuild mavenModulesBuild) {
         Map<MavenModule, MavenBuild> mavenBuildMap = mavenModulesBuild.getModuleLastBuilds();
-        List<Module> modules = Lists.newArrayList();
+        List<Module> modules = new ArrayList<>();
         for (Map.Entry<MavenModule, MavenBuild> moduleBuild : mavenBuildMap.entrySet()) {
             MavenModule mavenModule = moduleBuild.getKey();
             MavenBuild mavenBuild = moduleBuild.getValue();

--- a/src/main/java/org/jfrog/hudson/maven3/extractor/MavenExtractorEnvironment.java
+++ b/src/main/java/org/jfrog/hudson/maven3/extractor/MavenExtractorEnvironment.java
@@ -16,7 +16,6 @@
 
 package org.jfrog.hudson.maven3.extractor;
 
-import com.google.common.collect.Lists;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -52,6 +51,7 @@ import org.jfrog.hudson.util.publisher.PublisherFlexible;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -235,7 +235,7 @@ public class MavenExtractorEnvironment extends Environment {
             FilePath dependenciesDirectory = PluginDependencyHelper.getActualDependencyDirectory(maven3ExtractorJar, context.getBuiltOn().getRootPath());
 
             FilePath[] files = dependenciesDirectory.list(INCLUDED_FILES, EXCLUDED_FILES);
-            List<FilePath> jars = Lists.newArrayList();
+            List<FilePath> jars = new ArrayList<>();
             Collections.addAll(jars, files);
 
             return PlexusModuleContributor.of(jars);

--- a/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
@@ -66,6 +66,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
@@ -2,7 +2,6 @@ package org.jfrog.hudson.pipeline.common;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Maps;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -408,7 +407,7 @@ public class Utils {
     public static void appendBuildInfo(CpsScript cpsScript, Map<String, Object> stepVariables) {
         BuildInfo buildInfo = (BuildInfo) stepVariables.get(BUILD_INFO);
         if (buildInfo == null) {
-            buildInfo = (BuildInfo) cpsScript.invokeMethod("newBuildInfo", Maps.newLinkedHashMap());
+            buildInfo = (BuildInfo) cpsScript.invokeMethod("newBuildInfo", new LinkedHashMap<>());
             stepVariables.put(BUILD_INFO, buildInfo);
         }
         buildInfo.setCpsScript(cpsScript);

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/ArtifactoryServer.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/ArtifactoryServer.java
@@ -1,6 +1,5 @@
 package org.jfrog.hudson.pipeline.common.types;
 
-import com.google.common.collect.Maps;
 import hudson.model.Item;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
@@ -13,6 +12,7 @@ import org.jfrog.hudson.util.plugins.PluginsUtils;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -108,7 +108,7 @@ public class ArtifactoryServer implements Serializable {
             throw new IllegalArgumentException("Only the following arguments are allowed, " + keysAsList.toString());
         }
 
-        Map<String, Object> stepVariables = Maps.newLinkedHashMap(arguments);
+        Map<String, Object> stepVariables = new LinkedHashMap<>(arguments);
         stepVariables.put(SERVER, this);
         return stepVariables;
     }
@@ -139,7 +139,7 @@ public class ArtifactoryServer implements Serializable {
 
     @Whitelisted
     public void download(String spec, BuildInfo buildInfo, boolean failNoOp) {
-        Map<String, Object> downloadArguments = Maps.newLinkedHashMap();
+        Map<String, Object> downloadArguments = new LinkedHashMap<>();
         downloadArguments.put(SPEC, spec);
         downloadArguments.put(BUILD_INFO, buildInfo);
         downloadArguments.put(FAIL_NO_OP, failNoOp);
@@ -172,7 +172,7 @@ public class ArtifactoryServer implements Serializable {
 
     @Whitelisted
     public void upload(String spec, BuildInfo buildInfo, boolean failNoOp) {
-        Map<String, Object> uploadArguments = Maps.newLinkedHashMap();
+        Map<String, Object> uploadArguments = new LinkedHashMap<>();
         uploadArguments.put(SPEC, spec);
         uploadArguments.put(BUILD_INFO, buildInfo);
         uploadArguments.put(FAIL_NO_OP, failNoOp);
@@ -189,7 +189,7 @@ public class ArtifactoryServer implements Serializable {
             throw new IllegalArgumentException("Only the following arguments are allowed, " + keysAsList.toString());
         }
 
-        Map<String, Object> stepVariables = Maps.newLinkedHashMap(arguments);
+        Map<String, Object> stepVariables = new LinkedHashMap<>(arguments);
         stepVariables.put(SERVER, this);
         return stepVariables;
     }
@@ -210,7 +210,7 @@ public class ArtifactoryServer implements Serializable {
 
     @Whitelisted
     public void setProps(String spec, String props, boolean failNoOp) {
-        Map<String, Object> propsArguments = Maps.newLinkedHashMap();
+        Map<String, Object> propsArguments = new LinkedHashMap<>();
         propsArguments.put(SPEC, spec);
         propsArguments.put(PROPERTIES, props);
         propsArguments.put(FAIL_NO_OP, failNoOp);
@@ -233,7 +233,7 @@ public class ArtifactoryServer implements Serializable {
 
     @Whitelisted
     public void deleteProps(String spec, String props, boolean failNoOp) {
-        Map<String, Object> propsArguments = Maps.newLinkedHashMap();
+        Map<String, Object> propsArguments = new LinkedHashMap<>();
         propsArguments.put(SPEC, spec);
         propsArguments.put(PROPERTIES, props);
         propsArguments.put(FAIL_NO_OP, failNoOp);
@@ -243,7 +243,7 @@ public class ArtifactoryServer implements Serializable {
 
     @Whitelisted
     public void publishBuildInfo(BuildInfo buildInfo) {
-        Map<String, Object> stepVariables = Maps.newLinkedHashMap();
+        Map<String, Object> stepVariables = new LinkedHashMap<>();
         stepVariables.put(BUILD_INFO, buildInfo);
         stepVariables.put(SERVER, this);
 
@@ -253,7 +253,7 @@ public class ArtifactoryServer implements Serializable {
 
     @Whitelisted
     public void buildAppend(BuildInfo buildInfo, String buildName, String buildNumber) {
-        Map<String, Object> stepVariables = Maps.newLinkedHashMap();
+        Map<String, Object> stepVariables = new LinkedHashMap<>();
         stepVariables.put(BUILD_INFO, buildInfo);
         stepVariables.put(BUILD_NAME, buildName);
         stepVariables.put(BUILD_NUMBER, buildNumber);
@@ -265,7 +265,7 @@ public class ArtifactoryServer implements Serializable {
 
     @Whitelisted
     public void promote(Map<String, Object> promotionParams) {
-        Map<String, Object> stepVariables = Maps.newLinkedHashMap();
+        Map<String, Object> stepVariables = new LinkedHashMap<>();
         stepVariables.put("promotionConfig", Utils.createPromotionConfig(promotionParams, true));
         stepVariables.put(SERVER, this);
 
@@ -275,7 +275,7 @@ public class ArtifactoryServer implements Serializable {
 
     @Whitelisted
     public void distribute(Map<String, Object> distributionParams) {
-        Map<String, Object> stepVariables = Maps.newLinkedHashMap();
+        Map<String, Object> stepVariables = new LinkedHashMap<>();
         stepVariables.put("distributionConfig", Utils.createDistributionConfig(distributionParams));
         stepVariables.put(SERVER, this);
 
@@ -285,7 +285,7 @@ public class ArtifactoryServer implements Serializable {
 
     @Whitelisted
     public void xrayScan(Map<String, Object> xrayScanParams) {
-        Map<String, Object> stepVariables = Maps.newLinkedHashMap();
+        Map<String, Object> stepVariables = new LinkedHashMap<>();
         stepVariables.put("xrayScanConfig", Utils.createXrayScanConfig(xrayScanParams));
         stepVariables.put(SERVER, this);
 
@@ -299,7 +299,7 @@ public class ArtifactoryServer implements Serializable {
         if (!arguments.keySet().containsAll(mandatoryParams)) {
             throw new IllegalArgumentException(mandatoryParams.toString() + " are mandatory arguments");
         }
-        Map<String, Object> stepVariables = Maps.newLinkedHashMap();
+        Map<String, Object> stepVariables = new LinkedHashMap<>();
         stepVariables.put(SERVER, this);
         stepVariables.put(PATHS, arguments.get(PATHS));
         stepVariables.put(SPEC, arguments.get(SPEC));

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/ConanClient.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/ConanClient.java
@@ -1,11 +1,11 @@
 package org.jfrog.hudson.pipeline.common.types;
 
-import com.google.common.collect.Maps;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
 import org.jfrog.hudson.pipeline.common.types.buildInfo.BuildInfo;
 
 import java.io.Serializable;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.jfrog.hudson.pipeline.common.Utils.appendBuildInfo;
@@ -62,7 +62,7 @@ public class ConanClient implements Serializable {
     }
 
     private Map<String, Object> getRunCommandExecutionArguments(String command, BuildInfo buildInfo) {
-        Map<String, Object> stepVariables = Maps.newLinkedHashMap();
+        Map<String, Object> stepVariables = new LinkedHashMap<>();
         stepVariables.put("command", command);
         stepVariables.put("conanHome", getUserPath());
         stepVariables.put("buildInfo", buildInfo);

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/ConanRemote.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/ConanRemote.java
@@ -1,11 +1,11 @@
 package org.jfrog.hudson.pipeline.common.types;
 
-import com.google.common.collect.Maps;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
 import org.jfrog.hudson.pipeline.common.Utils;
 
 import java.io.Serializable;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
 
@@ -45,7 +45,7 @@ public class ConanRemote implements Serializable {
 
     private Map<String, Object> getAddRemoteExecutionArguments(ArtifactoryServer server, String serverName, String repo, boolean force, boolean verifySSL) {
         String serverUrl = Utils.buildConanRemoteUrl(server, repo);
-        Map<String, Object> stepVariables = Maps.newLinkedHashMap();
+        Map<String, Object> stepVariables = new LinkedHashMap<>();
         stepVariables.put("serverUrl", serverUrl);
         stepVariables.put("serverName", serverName);
         stepVariables.put("conanHome", conanHome);
@@ -55,7 +55,7 @@ public class ConanRemote implements Serializable {
     }
 
     private Map<String, Object> getAddUserExecutionArguments(ArtifactoryServer server, String serverName) {
-        Map<String, Object> stepVariables = Maps.newLinkedHashMap();
+        Map<String, Object> stepVariables = new LinkedHashMap<>();
         stepVariables.put("server", server);
         stepVariables.put("serverName", serverName);
         stepVariables.put("conanHome", conanHome);

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/DistributionServer.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/DistributionServer.java
@@ -1,6 +1,5 @@
 package org.jfrog.hudson.pipeline.common.types;
 
-import com.google.common.collect.Maps;
 import hudson.model.Item;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
@@ -280,7 +279,7 @@ public class DistributionServer implements Serializable {
         if (!allArgs.containsAll(actualArgs.keySet())) {
             throw new IllegalArgumentException("Only the following arguments are allowed: " + String.join(", ", allArgs));
         }
-        Map<String, Object> stepVariables = Maps.newLinkedHashMap(actualArgs);
+        Map<String, Object> stepVariables = new LinkedHashMap<>(actualArgs);
         stepVariables.put(SERVER, this);
         return stepVariables;
     }

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/Docker.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/Docker.java
@@ -1,13 +1,13 @@
 package org.jfrog.hudson.pipeline.common.types;
 
 import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Maps;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
 import org.jfrog.hudson.pipeline.common.types.buildInfo.BuildInfo;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.jfrog.hudson.pipeline.common.Utils.BUILD_INFO;
@@ -62,7 +62,7 @@ public class Docker implements Serializable {
 
     @Whitelisted
     public void push(String imageTag, String targetRepo, BuildInfo providedBuildInfo) {
-        Map<String, Object> dockerArguments = Maps.newLinkedHashMap();
+        Map<String, Object> dockerArguments = new LinkedHashMap<>();
         dockerArguments.put("image", imageTag);
         dockerArguments.put("targetRepo", targetRepo);
         dockerArguments.put(BUILD_INFO, providedBuildInfo);
@@ -87,7 +87,7 @@ public class Docker implements Serializable {
 
     @Whitelisted
     public void pull(String imageTag, String sourceRepo, BuildInfo providedBuildInfo) {
-        Map<String, Object> dockerArguments = Maps.newLinkedHashMap();
+        Map<String, Object> dockerArguments = new LinkedHashMap<>();
         dockerArguments.put("image", imageTag);
         dockerArguments.put("sourceRepo", sourceRepo);
         dockerArguments.put(BUILD_INFO, providedBuildInfo);
@@ -111,7 +111,7 @@ public class Docker implements Serializable {
 
     @Whitelisted
     public void createDockerBuild(String sourceRepo, String kanikoImageFile, String jibImageFiles, BuildInfo providedBuildInfo) {
-        Map<String, Object> dockerArguments = Maps.newLinkedHashMap();
+        Map<String, Object> dockerArguments = new LinkedHashMap<>();
         dockerArguments.put("kanikoImageFile", kanikoImageFile);
         dockerArguments.put("jibImageFiles", jibImageFiles);
         dockerArguments.put("sourceRepo", sourceRepo);

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/buildInfo/BuildRetention.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/buildInfo/BuildRetention.java
@@ -1,9 +1,9 @@
 package org.jfrog.hudson.pipeline.common.types.buildInfo;
 
-import com.google.common.collect.Lists;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.List;
@@ -16,7 +16,7 @@ public class BuildRetention implements Serializable {
 
     private boolean deleteBuildArtifacts;
     private int maxBuilds;
-    private List<String> doNotDiscardBuilds = Lists.newArrayList();
+    private List<String> doNotDiscardBuilds = new ArrayList<>();
     private int maxDays;
     private boolean async;
 
@@ -45,7 +45,7 @@ public class BuildRetention implements Serializable {
         this.maxDays = -1;
         this.deleteBuildArtifacts = false;
         this.maxBuilds = -1;
-        this.doNotDiscardBuilds = Lists.newArrayList();
+        this.doNotDiscardBuilds = new ArrayList<>();
         this.async = false;
     }
 
@@ -82,7 +82,7 @@ public class BuildRetention implements Serializable {
     @Whitelisted
     public void setDoNotDiscardBuilds(List<String> buildNumbersNotToBeDiscarded) {
         if (buildNumbersNotToBeDiscarded == null) {
-            this.doNotDiscardBuilds = Lists.newArrayList();
+            this.doNotDiscardBuilds = new ArrayList<>();
             return;
         }
         this.doNotDiscardBuilds = buildNumbersNotToBeDiscarded;

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/buildInfo/Env.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/buildInfo/Env.java
@@ -1,6 +1,5 @@
 package org.jfrog.hudson.pipeline.common.types.buildInfo;
 
-import com.google.common.collect.Maps;
 import hudson.EnvVars;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -14,6 +13,7 @@ import org.jfrog.hudson.pipeline.common.Utils;
 import java.io.Serializable;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
 
@@ -101,7 +101,7 @@ public class Env implements Serializable {
 
     @Whitelisted
     public void collect() {
-        Map<String, Object> stepVariables = Maps.newLinkedHashMap();
+        Map<String, Object> stepVariables = new LinkedHashMap<>();
         stepVariables.put("env", this);
 
         // Throws CpsCallableInvocation - Must be the last line in this method

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/buildInfo/Issues.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/buildInfo/Issues.java
@@ -1,6 +1,5 @@
 package org.jfrog.hudson.pipeline.common.types.buildInfo;
 
-import com.google.common.collect.Maps;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
 import org.jfrog.build.extractor.ci.IssueTracker;
@@ -8,6 +7,7 @@ import org.jfrog.hudson.pipeline.common.types.ArtifactoryServer;
 
 import java.io.Serializable;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -115,7 +115,7 @@ public class Issues implements Serializable {
      * */
     @Whitelisted
     public void collect(ArtifactoryServer server, String config) {
-        Map<String, Object> stepVariables = Maps.newLinkedHashMap();
+        Map<String, Object> stepVariables = new LinkedHashMap<>();
         stepVariables.put("issues", this);
         stepVariables.put("server", server);
         stepVariables.put("config", config);

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/builds/GoBuild.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/builds/GoBuild.java
@@ -1,12 +1,12 @@
 package org.jfrog.hudson.pipeline.common.types.builds;
 
-import com.google.common.collect.Maps;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jfrog.hudson.pipeline.common.types.buildInfo.BuildInfo;
 import org.jfrog.hudson.pipeline.common.types.deployers.CommonDeployer;
 import org.jfrog.hudson.pipeline.common.types.resolvers.CommonResolver;
 
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -68,7 +68,7 @@ public class GoBuild extends PackageManagerBuild {
     }
 
     private Map<String, Object> getGoArguments(String path, String module, BuildInfo buildInfo) {
-        Map<String, Object> stepVariables = Maps.newLinkedHashMap();
+        Map<String, Object> stepVariables = new LinkedHashMap<>();
         stepVariables.put(GO_BUILD, this);
         stepVariables.put(PATH, path);
         stepVariables.put(MODULE, module);

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/builds/GradleBuild.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/builds/GradleBuild.java
@@ -1,6 +1,5 @@
 package org.jfrog.hudson.pipeline.common.types.builds;
 
-import com.google.common.collect.Maps;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jfrog.hudson.pipeline.common.Utils;
 import org.jfrog.hudson.pipeline.common.types.buildInfo.BuildInfo;
@@ -8,6 +7,7 @@ import org.jfrog.hudson.pipeline.common.types.deployers.GradleDeployer;
 import org.jfrog.hudson.pipeline.common.types.resolvers.GradleResolver;
 
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -66,7 +66,7 @@ public class GradleBuild extends PackageManagerBuild {
     }
 
     private Map<String, Object> getRunArguments(String buildFile, String tasks, String switches, String rootDir, BuildInfo buildInfo) {
-        Map<String, Object> stepVariables = Maps.newLinkedHashMap();
+        Map<String, Object> stepVariables = new LinkedHashMap<>();
         stepVariables.put("gradleBuild", this);
         stepVariables.put("rootDir", rootDir);
         stepVariables.put("buildFile", buildFile);

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/builds/MavenBuild.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/builds/MavenBuild.java
@@ -1,12 +1,12 @@
 package org.jfrog.hudson.pipeline.common.types.builds;
 
-import com.google.common.collect.Maps;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jfrog.hudson.pipeline.common.types.buildInfo.BuildInfo;
 import org.jfrog.hudson.pipeline.common.types.deployers.MavenDeployer;
 import org.jfrog.hudson.pipeline.common.types.resolvers.MavenResolver;
 
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.jfrog.hudson.pipeline.common.Utils.appendBuildInfo;
@@ -82,7 +82,7 @@ public class MavenBuild extends PackageManagerBuild {
     }
 
     private Map<String, Object> getExecutionArguments(String pom, String goals, BuildInfo buildInfo) {
-        Map<String, Object> stepVariables = Maps.newLinkedHashMap();
+        Map<String, Object> stepVariables = new LinkedHashMap<>();
         stepVariables.put("mavenBuild", this);
         stepVariables.put("pom", pom);
         stepVariables.put("goals", goals);

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/builds/NpmBuild.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/builds/NpmBuild.java
@@ -1,12 +1,12 @@
 package org.jfrog.hudson.pipeline.common.types.builds;
 
-import com.google.common.collect.Maps;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jfrog.hudson.pipeline.common.types.buildInfo.BuildInfo;
 import org.jfrog.hudson.pipeline.common.types.deployers.CommonDeployer;
 import org.jfrog.hudson.pipeline.common.types.resolvers.CommonResolver;
 
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -76,7 +76,7 @@ public class NpmBuild extends PackageManagerBuild {
     }
 
     private Map<String, Object> getRunArguments(String path, BuildInfo buildInfo) {
-        Map<String, Object> stepVariables = Maps.newLinkedHashMap();
+        Map<String, Object> stepVariables = new LinkedHashMap<>();
         stepVariables.put(NPM_BUILD, this);
         stepVariables.put(PATH, path);
         stepVariables.put(BUILD_INFO, buildInfo);

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/builds/NugetBuild.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/builds/NugetBuild.java
@@ -1,11 +1,11 @@
 package org.jfrog.hudson.pipeline.common.types.builds;
 
-import com.google.common.collect.Maps;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jfrog.hudson.pipeline.common.types.buildInfo.BuildInfo;
 import org.jfrog.hudson.pipeline.common.types.resolvers.CommonResolver;
 
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -70,7 +70,7 @@ public class NugetBuild extends PackageManagerBuild {
 
 
     private Map<String, Object> getRunArguments(String module, BuildInfo buildInfo) {
-        Map<String, Object> stepVariables = Maps.newLinkedHashMap();
+        Map<String, Object> stepVariables = new LinkedHashMap<>();
         stepVariables.put(NUGET_BUILD, this);
         stepVariables.put(MODULE, module);
         stepVariables.put(BUILD_INFO, buildInfo);

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/builds/PipBuild.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/builds/PipBuild.java
@@ -1,11 +1,11 @@
 package org.jfrog.hudson.pipeline.common.types.builds;
 
-import com.google.common.collect.Maps;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jfrog.hudson.pipeline.common.types.buildInfo.BuildInfo;
 import org.jfrog.hudson.pipeline.common.types.resolvers.CommonResolver;
 
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -53,7 +53,7 @@ public class PipBuild extends PackageManagerBuild {
     }
 
     private Map<String, Object> getPipArguments(String args, String module, BuildInfo buildInfo, String javaArgs, String envActivation) {
-        Map<String, Object> stepVariables = Maps.newLinkedHashMap();
+        Map<String, Object> stepVariables = new LinkedHashMap<>();
         stepVariables.put(PIP_BUILD, this);
         stepVariables.put(ARGS, args);
         stepVariables.put(MODULE, module);

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/deployers/Deployer.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/deployers/Deployer.java
@@ -42,6 +42,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/deployers/Deployer.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/deployers/Deployer.java
@@ -2,7 +2,6 @@ package org.jfrog.hudson.pipeline.common.types.deployers;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Sets;
 import hudson.FilePath;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -299,7 +298,7 @@ public abstract class Deployer implements DeployerOverrider, Serializable {
                 String module = entry.getKey();
                 List<DeployDetails> paths = entry.getValue();
                 try {
-                    Set<DeployDetails> deployDetails = Sets.newLinkedHashSet();
+                    Set<DeployDetails> deployDetails = new LinkedHashSet<>();
                     for (DeployDetails artifact : paths) {
                         String artifactPath = artifact.getArtifactPath();
                         if (PatternMatcher.pathConflicts(artifactPath, deployer.getArtifactDeploymentPatterns().getPatternFilter())) {

--- a/src/main/java/org/jfrog/hudson/pipeline/scripted/dsl/ArtifactoryPipelineGlobal.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/scripted/dsl/ArtifactoryPipelineGlobal.java
@@ -1,7 +1,6 @@
 package org.jfrog.hudson.pipeline.scripted.dsl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Maps;
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
@@ -31,7 +30,7 @@ public class ArtifactoryPipelineGlobal implements Serializable {
 
     @Whitelisted
     public ArtifactoryServer server(String serverName) {
-        Map<String, Object> stepVariables = Maps.newLinkedHashMap();
+        Map<String, Object> stepVariables = new LinkedHashMap<>();
         stepVariables.put("artifactoryServerID", serverName);
         ArtifactoryServer server = (ArtifactoryServer) cpsScript.invokeMethod("getArtifactoryServer", stepVariables);
         server.setCpsScript(cpsScript);
@@ -45,7 +44,7 @@ public class ArtifactoryPipelineGlobal implements Serializable {
 
     @Whitelisted
     public Docker docker(ArtifactoryServer server, String host) {
-        Map<String, Object> dockerArguments = Maps.newLinkedHashMap();
+        Map<String, Object> dockerArguments = new LinkedHashMap<>();
         dockerArguments.put("server", server);
         if (host != null && !host.isEmpty()) {
             dockerArguments.put("host", host);
@@ -75,7 +74,7 @@ public class ArtifactoryPipelineGlobal implements Serializable {
 
     @Whitelisted
     public ArtifactoryServer newServer(String url, String username, String password) {
-        Map<String, Object> stepVariables = Maps.newLinkedHashMap();
+        Map<String, Object> stepVariables = new LinkedHashMap<>();
         stepVariables.put("url", url);
         stepVariables.put("username", username);
         stepVariables.put("password", password);
@@ -98,7 +97,7 @@ public class ArtifactoryPipelineGlobal implements Serializable {
 
     @Whitelisted
     public BuildInfo newBuildInfo() {
-        BuildInfo buildInfo = (BuildInfo) cpsScript.invokeMethod("newBuildInfo", Maps.newLinkedHashMap());
+        BuildInfo buildInfo = (BuildInfo) cpsScript.invokeMethod("newBuildInfo", new LinkedHashMap<>());
         buildInfo.setCpsScript(cpsScript);
         return buildInfo;
     }
@@ -119,49 +118,49 @@ public class ArtifactoryPipelineGlobal implements Serializable {
 
     @Whitelisted
     public MavenBuild newMavenBuild() {
-        MavenBuild mavenBuild = (MavenBuild) cpsScript.invokeMethod("newMavenBuild", Maps.newLinkedHashMap());
+        MavenBuild mavenBuild = (MavenBuild) cpsScript.invokeMethod("newMavenBuild", new LinkedHashMap<>());
         mavenBuild.setCpsScript(cpsScript);
         return mavenBuild;
     }
 
     @Whitelisted
     public GradleBuild newGradleBuild() {
-        GradleBuild gradleBuild = (GradleBuild) cpsScript.invokeMethod("newGradleBuild", Maps.newLinkedHashMap());
+        GradleBuild gradleBuild = (GradleBuild) cpsScript.invokeMethod("newGradleBuild", new LinkedHashMap<>());
         gradleBuild.setCpsScript(cpsScript);
         return gradleBuild;
     }
 
     @Whitelisted
     public NpmBuild newNpmBuild() {
-        NpmBuild npmBuild = (NpmBuild) cpsScript.invokeMethod("newNpmBuild", Maps.newLinkedHashMap());
+        NpmBuild npmBuild = (NpmBuild) cpsScript.invokeMethod("newNpmBuild", new LinkedHashMap<>());
         npmBuild.setCpsScript(cpsScript);
         return npmBuild;
     }
 
     @Whitelisted
     public GoBuild newGoBuild() {
-        GoBuild goBuild = (GoBuild) cpsScript.invokeMethod("newGoBuild", Maps.newLinkedHashMap());
+        GoBuild goBuild = (GoBuild) cpsScript.invokeMethod("newGoBuild", new LinkedHashMap<>());
         goBuild.setCpsScript(cpsScript);
         return goBuild;
     }
 
     @Whitelisted
     public PipBuild newPipBuild() {
-        PipBuild pipBuild = (PipBuild) cpsScript.invokeMethod("newPipBuild", Maps.newLinkedHashMap());
+        PipBuild pipBuild = (PipBuild) cpsScript.invokeMethod("newPipBuild", new LinkedHashMap<>());
         pipBuild.setCpsScript(cpsScript);
         return pipBuild;
     }
 
     @Whitelisted
     public NugetBuild newNugetBuild() {
-        NugetBuild nugetBuild = (NugetBuild) cpsScript.invokeMethod("newNugetBuild", Maps.newLinkedHashMap());
+        NugetBuild nugetBuild = (NugetBuild) cpsScript.invokeMethod("newNugetBuild", new LinkedHashMap<>());
         nugetBuild.setCpsScript(cpsScript);
         return nugetBuild;
     }
 
     @Whitelisted
     public NugetBuild newDotnetBuild() {
-        NugetBuild dotnetCliBuild = (NugetBuild) cpsScript.invokeMethod("newNugetBuild", Maps.newLinkedHashMap());
+        NugetBuild dotnetCliBuild = (NugetBuild) cpsScript.invokeMethod("newNugetBuild", new LinkedHashMap<>());
         dotnetCliBuild.setCpsScript(cpsScript);
         dotnetCliBuild.SetUseDotnetCli(true);
         return dotnetCliBuild;
@@ -176,7 +175,7 @@ public class ArtifactoryPipelineGlobal implements Serializable {
         }
         client.setUserPath(userPath);
         client.setCpsScript(cpsScript);
-        LinkedHashMap<String, Object> args = Maps.newLinkedHashMap();
+        LinkedHashMap<String, Object> args = new LinkedHashMap<>();
         args.put("client", client);
         cpsScript.invokeMethod("initConanClient", args);
         return client;
@@ -186,7 +185,7 @@ public class ArtifactoryPipelineGlobal implements Serializable {
     public ConanClient newConanClient() {
         ConanClient client = new ConanClient();
         client.setCpsScript(cpsScript);
-        LinkedHashMap<String, Object> args = Maps.newLinkedHashMap();
+        LinkedHashMap<String, Object> args = new LinkedHashMap<>();
         args.put("client", client);
         cpsScript.invokeMethod("initConanClient", args);
         return client;
@@ -201,7 +200,7 @@ public class ArtifactoryPipelineGlobal implements Serializable {
 
     @Whitelisted
     public void addInteractivePromotion(Map<String, Object> promotionArguments) {
-        Map<String, Object> stepVariables = Maps.newLinkedHashMap();
+        Map<String, Object> stepVariables = new LinkedHashMap<>();
         List<String> mandatoryParams = Arrays.asList(ArtifactoryServer.SERVER, "promotionConfig");
         List<String> allowedParams = Arrays.asList(ArtifactoryServer.SERVER, "promotionConfig", "displayName");
         if (!promotionArguments.keySet().containsAll(mandatoryParams)) {

--- a/src/main/java/org/jfrog/hudson/pipeline/scripted/dsl/JFrogPipelineGlobal.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/scripted/dsl/JFrogPipelineGlobal.java
@@ -1,12 +1,12 @@
 package org.jfrog.hudson.pipeline.scripted.dsl;
 
-import com.google.common.collect.Maps;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
 import org.jfrog.hudson.pipeline.common.types.JFrogPlatformInstance;
 
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class JFrogPipelineGlobal implements Serializable {
@@ -25,7 +25,7 @@ public class JFrogPipelineGlobal implements Serializable {
 
     @Whitelisted
     public JFrogPlatformInstance instance(String instanceId) {
-        Map<String, Object> stepVariables = Maps.newLinkedHashMap();
+        Map<String, Object> stepVariables = new LinkedHashMap<>();
         stepVariables.put("instanceId", instanceId);
         JFrogPlatformInstance instance = (JFrogPlatformInstance) cpsScript.invokeMethod("getJFrogPlatformInstance", stepVariables);
         instance.setCpsScript(cpsScript);

--- a/src/main/java/org/jfrog/hudson/release/ReleaseAction.java
+++ b/src/main/java/org/jfrog/hudson/release/ReleaseAction.java
@@ -20,7 +20,6 @@ import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.google.common.collect.Maps;
 import hudson.Util;
 import hudson.matrix.MatrixConfiguration;
 import hudson.matrix.MatrixProject;
@@ -44,6 +43,7 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -587,7 +587,7 @@ public abstract class ReleaseAction<P extends AbstractProject & BuildableItem,
             if (stagingStrategy.containsKey("moduleVersionsMap")) {
                 Map<String, ? extends Map<String, String>> moduleVersionsMap =
                         (Map<String, ? extends Map<String, String>>) stagingStrategy.get("moduleVersionsMap");
-                defaultModules = Maps.newHashMap();
+                defaultModules = new HashMap<>();
                 if (!moduleVersionsMap.isEmpty()) {
                     for (Map<String, String> moduleVersion : moduleVersionsMap.values()) {
                         String moduleId = moduleVersion.get("moduleId");

--- a/src/main/java/org/jfrog/hudson/release/gradle/BaseGradleReleaseAction.java
+++ b/src/main/java/org/jfrog/hudson/release/gradle/BaseGradleReleaseAction.java
@@ -16,7 +16,6 @@
 
 package org.jfrog.hudson.release.gradle;
 
-import com.google.common.collect.Maps;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Util;
@@ -103,7 +102,7 @@ public abstract class BaseGradleReleaseAction extends ReleaseAction<AbstractProj
             throw new IllegalStateException("Couldn't find workspace");
         }
 
-        Map<String, String> workspaceEnv = Maps.newHashMap();
+        Map<String, String> workspaceEnv = new HashMap<>();
         workspaceEnv.put("WORKSPACE", someWorkspace.getRemote());
 
         for (Builder builder : getBuilders()) {
@@ -229,8 +228,8 @@ public abstract class BaseGradleReleaseAction extends ReleaseAction<AbstractProj
 
     @Override
     protected void doPerModuleVersioning(StaplerRequest req) {
-        releaseVersionPerModule = Maps.newHashMap();
-        nextVersionPerModule = Maps.newHashMap();
+        releaseVersionPerModule = new HashMap<>();
+        nextVersionPerModule = new HashMap<>();
         Enumeration params = req.getParameterNames();
         while (params.hasMoreElements()) {
             String key = (String) params.nextElement();
@@ -244,8 +243,8 @@ public abstract class BaseGradleReleaseAction extends ReleaseAction<AbstractProj
 
     @Override
     protected void doPerModuleVersioning(Map<String, VersionedModule> defaultModules) {
-        releaseVersionPerModule = Maps.newHashMap();
-        nextVersionPerModule = Maps.newHashMap();
+        releaseVersionPerModule = new HashMap<>();
+        nextVersionPerModule = new HashMap<>();
 
         for (Map.Entry<String, VersionedModule> entry : defaultModules.entrySet()) {
             VersionedModule versionedModule = entry.getValue();
@@ -266,7 +265,7 @@ public abstract class BaseGradleReleaseAction extends ReleaseAction<AbstractProj
 
     @Override
     protected void prepareBuilderSpecificDefaultModules() {
-        defaultModules = Maps.newHashMap();
+        defaultModules = new HashMap<>();
 
         for (String releaseProperties : getReleaseProperties()) {
             defaultModules.put(releaseProperties, new VersionedModule(releaseProperties,

--- a/src/main/java/org/jfrog/hudson/release/gradle/GradleReleaseWrapper.java
+++ b/src/main/java/org/jfrog/hudson/release/gradle/GradleReleaseWrapper.java
@@ -16,7 +16,6 @@
 
 package org.jfrog.hudson.release.gradle;
 
-import com.google.common.collect.Maps;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
@@ -31,9 +30,10 @@ import org.jfrog.hudson.release.scm.git.GitCoordinator;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
-import java.util.Map;
+import java.util.HashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.Map;
 
 /**
  * A release wrapper for Gradle projects. Allows performing release steps on Gradle. This class is not a direct {@link
@@ -223,7 +223,7 @@ public class GradleReleaseWrapper {
         FilePath root = release.getModuleRoot(build.getEnvironment(listener));
         debuggingLogger.fine("Root directory is: " + root.getRemote());
         String[] modules = release.getReleaseProperties();
-        Map<String, String> modulesByName = Maps.newHashMap();
+        Map<String, String> modulesByName = new HashMap<>();
         for (String module : modules) {
             String version = releaseVersion ? release.getReleaseVersionFor(module) :
                     release.getCurrentVersionFor(module);

--- a/src/main/java/org/jfrog/hudson/release/maven/BaseMavenReleaseAction.java
+++ b/src/main/java/org/jfrog/hudson/release/maven/BaseMavenReleaseAction.java
@@ -16,7 +16,6 @@
 
 package org.jfrog.hudson.release.maven;
 
-import com.google.common.collect.Maps;
 import hudson.maven.MavenModule;
 import hudson.maven.MavenModuleSet;
 import hudson.maven.ModuleName;
@@ -35,6 +34,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -100,8 +100,8 @@ public abstract class BaseMavenReleaseAction extends ReleaseAction<MavenModuleSe
 
     @Override
     protected void doPerModuleVersioning(StaplerRequest req) {
-        releaseVersionPerModule = Maps.newHashMap();
-        nextVersionPerModule = Maps.newHashMap();
+        releaseVersionPerModule = new HashMap<>();
+        nextVersionPerModule = new HashMap<>();
         Enumeration params = req.getParameterNames();
         while (params.hasMoreElements()) {
             String key = (String) params.nextElement();
@@ -117,8 +117,8 @@ public abstract class BaseMavenReleaseAction extends ReleaseAction<MavenModuleSe
 
     @Override
     protected void doPerModuleVersioning(Map<String, VersionedModule> defaultModules) {
-        releaseVersionPerModule = Maps.newHashMap();
-        nextVersionPerModule = Maps.newHashMap();
+        releaseVersionPerModule = new HashMap<>();
+        nextVersionPerModule = new HashMap<>();
 
         for (Map.Entry<String, VersionedModule> entry : defaultModules.entrySet()) {
             VersionedModule versionedModule = entry.getValue();
@@ -174,7 +174,7 @@ public abstract class BaseMavenReleaseAction extends ReleaseAction<MavenModuleSe
 
     @Override
     protected void prepareBuilderSpecificDefaultModules() {
-        defaultModules = Maps.newHashMap();
+        defaultModules = new HashMap<>();
         if (project != null) {
             List<MavenModule> modules = project.getDisabledModules(false);
             for (MavenModule mavenModule : modules) {

--- a/src/main/java/org/jfrog/hudson/release/maven/MavenReleaseWrapper.java
+++ b/src/main/java/org/jfrog/hudson/release/maven/MavenReleaseWrapper.java
@@ -16,7 +16,6 @@
 
 package org.jfrog.hudson.release.maven;
 
-import com.google.common.collect.Maps;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -250,7 +249,7 @@ public class MavenReleaseWrapper extends BuildWrapper {
         // get the active modules only
         Collection<MavenModule> modules = mavenBuild.getProject().getDisabledModules(false);
 
-        Map<ModuleName, String> modulesByName = Maps.newHashMap();
+        Map<ModuleName, String> modulesByName = new HashMap<>();
         for (MavenModule module : modules) {
             String version = releaseVersion ? release.getReleaseVersionFor(module.getModuleName()) :
                     release.getNextVersionFor(module.getModuleName());

--- a/src/main/java/org/jfrog/hudson/release/maven/PomTransformer.java
+++ b/src/main/java/org/jfrog/hudson/release/maven/PomTransformer.java
@@ -16,13 +16,13 @@
 
 package org.jfrog.hudson.release.maven;
 
-import com.google.common.collect.Maps;
 import hudson.maven.ModuleName;
 import hudson.remoting.VirtualChannel;
 import jenkins.MasterToSlaveFileCallable;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -63,7 +63,7 @@ public class PomTransformer extends MasterToSlaveFileCallable<Boolean> {
         org.jfrog.build.extractor.maven.reader.ModuleName current = new org.jfrog.build.extractor.maven.reader.ModuleName(
                 currentModule.groupId, currentModule.artifactId);
 
-        Map<org.jfrog.build.extractor.maven.reader.ModuleName, String> modules = Maps.newLinkedHashMap();
+        Map<org.jfrog.build.extractor.maven.reader.ModuleName, String> modules = new LinkedHashMap<>();
         for (Map.Entry<ModuleName, String> entry : versionsByModule.entrySet()) {
             modules.put(new org.jfrog.build.extractor.maven.reader.ModuleName(
                     entry.getKey().groupId, entry.getKey().artifactId), entry.getValue());

--- a/src/main/java/org/jfrog/hudson/release/promotion/UnifiedPromoteBuildAction.java
+++ b/src/main/java/org/jfrog/hudson/release/promotion/UnifiedPromoteBuildAction.java
@@ -237,12 +237,12 @@ public class UnifiedPromoteBuildAction extends TaskAction implements BuildBadgeA
     public List<String> getRepositoryKeys() throws IOException {
         final BuildInfoAwareConfigurator configurator = getFirstConfigurator();
         if (configurator == null) {
-            return Lists.newArrayList();
+            return new ArrayList<>();
         }
 
         ArtifactoryServer artifactoryServer = configurator.getArtifactoryServer();
         if (artifactoryServer == null) {
-            return Lists.newArrayList();
+            return new ArrayList<>();
         }
         List<String> repos = artifactoryServer.
                 getReleaseRepositoryKeysFirst((DeployerOverrider) configurator, build.getParent());
@@ -330,7 +330,7 @@ public class UnifiedPromoteBuildAction extends TaskAction implements BuildBadgeA
             String pluginName = pluginSettings.getString("pluginName");
             if (!UserPluginInfo.NO_PLUGIN_KEY.equals(pluginName)) {
                 PluginSettings settings = new PluginSettings();
-                Map<String, String> paramMap = Maps.newHashMap();
+                Map<String, String> paramMap = new HashMap<>();
                 settings.setPluginName(pluginName);
                 Map<String, Object> filteredPluginSettings = Maps.filterKeys(pluginSettings,
                         input -> StringUtils.isNotBlank(input) && !"pluginName".equals(input));

--- a/src/main/java/org/jfrog/hudson/util/ErrorResponse.java
+++ b/src/main/java/org/jfrog/hudson/util/ErrorResponse.java
@@ -1,11 +1,10 @@
 package org.jfrog.hudson.util;
 
-import com.google.common.collect.Lists;
-
+import java.util.ArrayList;
 import java.util.List;
 
 public class ErrorResponse {
-    List<Error> errors = Lists.newArrayList();
+    List<Error> errors = new ArrayList<>();
 
     public ErrorResponse(int status, String message) {
         errors.add(new Error(status, message != null ? message : ""));

--- a/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
@@ -61,6 +61,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
@@ -17,7 +17,6 @@
 package org.jfrog.hudson.util;
 
 import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
 import hudson.EnvVars;
@@ -444,7 +443,7 @@ public class ExtractorUtils {
      * Get the list of build numbers that are to be kept forever.
      */
     public static List<String> getBuildNumbersNotToBeDeleted(Run build) {
-        List<String> notToDelete = Lists.newArrayList();
+        List<String> notToDelete = new ArrayList<>();
         List<? extends Run<?, ?>> builds = build.getParent().getBuilds();
         for (Run<?, ?> run : builds) {
             if (run.isKeepLog()) {

--- a/src/main/java/org/jfrog/hudson/util/FormValidations.java
+++ b/src/main/java/org/jfrog/hudson/util/FormValidations.java
@@ -1,6 +1,5 @@
 package org.jfrog.hudson.util;
 
-import com.google.common.base.Strings;
 import hudson.Util;
 import hudson.util.FormValidation;
 import org.apache.commons.lang3.StringUtils;
@@ -27,7 +26,7 @@ public abstract class FormValidations {
      * @return {@link hudson.util.FormValidation.ok()} if valid or empty, error otherwise
      */
     public static FormValidation validateEmails(String emails) {
-        if (!Strings.isNullOrEmpty(emails)) {
+        if (emails != null && !emails.isEmpty()) {
             String[] recipients = StringUtils.split(emails, " ");
             for (String email : recipients) {
                 FormValidation validation = validateInternetAddress(email);
@@ -46,7 +45,7 @@ public abstract class FormValidations {
      * @return {@link hudson.util.FormValidation.ok()} if valid or empty, error otherwise
      */
     public static FormValidation validateInternetAddress(String address) {
-        if (Strings.isNullOrEmpty(address)) {
+        if (address == null || address.isEmpty()) {
             return FormValidation.ok();
         }
         Matcher matcher = VALID_EMAIL_PATTERN.matcher(address);
@@ -68,4 +67,5 @@ public abstract class FormValidations {
 
         return FormValidation.ok();
     }
+
 }

--- a/src/main/java/org/jfrog/hudson/util/IssuesTrackerHelper.java
+++ b/src/main/java/org/jfrog/hudson/util/IssuesTrackerHelper.java
@@ -1,6 +1,5 @@
 package org.jfrog.hudson.util;
 
-import com.google.common.collect.Sets;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.plugins.jira.JiraSite;
@@ -18,6 +17,7 @@ import org.jfrog.hudson.util.plugins.PluginsUtils;
 
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -44,7 +44,7 @@ public class IssuesTrackerHelper {
             issueTrackerVersion = getJiraVersion(site);
             StringBuilder affectedIssuesBuilder = new StringBuilder();
             StringBuilder deploymentPropertiesBuilder = new StringBuilder();
-            Set<String> issueIds = Sets.newHashSet(manuallyCollectIssues(build, site, listener));
+            Set<String> issueIds = new HashSet<>(manuallyCollectIssues(build, site, listener));
             for (String issueId : issueIds) {
                 if (!site.existsIssue(issueId)) {
                     continue;

--- a/src/main/java/org/jfrog/hudson/util/PropertyUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/PropertyUtils.java
@@ -17,7 +17,6 @@
 package org.jfrog.hudson.util;
 
 import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import hudson.EnvVars;
 import hudson.FilePath;
@@ -31,6 +30,7 @@ import org.jfrog.hudson.release.gradle.GradleModule;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.logging.Logger;
@@ -62,7 +62,7 @@ public class PropertyUtils {
     public static Map<String, String> getModulesPropertiesFromPropFile(FilePath gradlePropPath, String[] propKeys)
             throws IOException, InterruptedException {
         Properties gradleProps = loadGradleProperties(gradlePropPath);
-        Map<String, String> versionsByPropKey = Maps.newLinkedHashMap();
+        Map<String, String> versionsByPropKey = new LinkedHashMap<>();
         for (String propKey : propKeys) {
             if (gradleProps.containsKey(propKey)) {
                 versionsByPropKey.put(propKey, gradleProps.getProperty(propKey));

--- a/src/main/java/org/jfrog/hudson/util/RepositoriesUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/RepositoriesUtils.java
@@ -1,7 +1,5 @@
 package org.jfrog.hudson.util;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Lists;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.Hudson;
@@ -13,7 +11,9 @@ import org.jfrog.build.extractor.clientConfiguration.client.artifactory.Artifact
 import org.jfrog.hudson.*;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.jfrog.hudson.util.ProxyUtils.createProxyConfiguration;
 
@@ -24,7 +24,7 @@ public abstract class RepositoriesUtils {
 
     public static List<String> getReleaseRepositoryKeysFirst(DeployerOverrider deployer, ArtifactoryServer server) throws IOException {
         if (server == null) {
-            return Lists.newArrayList();
+            return new ArrayList<>();
         }
 
         return server.getReleaseRepositoryKeysFirst(deployer, null);
@@ -32,7 +32,7 @@ public abstract class RepositoriesUtils {
 
     public static List<String> getSnapshotRepositoryKeysFirst(DeployerOverrider deployer, ArtifactoryServer server) throws IOException {
         if (server == null) {
-            return Lists.newArrayList();
+            return new ArrayList<>();
         }
 
         return server.getSnapshotRepositoryKeysFirst(deployer, null);
@@ -42,7 +42,7 @@ public abstract class RepositoriesUtils {
                                                                    DeployerOverrider deployerOverrider,
                                                                    ArtifactoryServer server) {
         if (server == null) {
-            return Lists.newArrayList();
+            return new ArrayList<>();
         }
 
         return server.getVirtualRepositoryKeys(resolverOverrider, null);
@@ -52,11 +52,7 @@ public abstract class RepositoriesUtils {
         List<VirtualRepository> virtualRepositories;
 
         List<String> keys = artifactoryManager.getVirtualRepositoriesKeys();
-        virtualRepositories = Lists.newArrayList(Lists.transform(keys, new Function<String, VirtualRepository>() {
-            public VirtualRepository apply(String from) {
-                return new VirtualRepository(from, from);
-            }
-        }));
+        virtualRepositories = keys.stream().map(from -> new VirtualRepository(from, from)).collect(Collectors.toList());
 
         return virtualRepositories;
     }
@@ -161,7 +157,7 @@ public abstract class RepositoriesUtils {
     }
 
     public static List<Repository> createRepositoriesList(List<String> repositoriesValueList) {
-        List<Repository> repositories = Lists.newArrayList();
+        List<Repository> repositories = new ArrayList<>();
         for (String repositoryKey : repositoriesValueList) {
             Repository repository = new Repository(repositoryKey);
             repositories.add(repository);
@@ -171,7 +167,7 @@ public abstract class RepositoriesUtils {
 
     public static List<VirtualRepository> collectVirtualRepositories(List<VirtualRepository> repositories, String repoKey) {
         if (repositories == null) {
-            repositories = Lists.newArrayList();
+            repositories = new ArrayList<>();
         }
         if (StringUtils.isNotBlank(repoKey)) {
             for (VirtualRepository vr : repositories) {
@@ -186,7 +182,7 @@ public abstract class RepositoriesUtils {
     }
 
     public static List<Repository> collectRepositories(String repoKey) {
-        List<Repository> repositories = Lists.newArrayList();
+        List<Repository> repositories = new ArrayList<>();
         if (StringUtils.isNotBlank(repoKey)) {
             Repository r = new Repository(repoKey);
             repositories.add(r);

--- a/src/main/java/org/jfrog/hudson/util/RepositoriesUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/RepositoriesUtils.java
@@ -52,6 +52,9 @@ public abstract class RepositoriesUtils {
         List<VirtualRepository> virtualRepositories;
 
         List<String> keys = artifactoryManager.getVirtualRepositoriesKeys();
+        if (keys == null) {
+            return new ArrayList<>();
+        }
         virtualRepositories = keys.stream().map(from -> new VirtualRepository(from, from)).collect(Collectors.toList());
 
         return virtualRepositories;

--- a/src/main/java/org/jfrog/hudson/util/converters/ArtifactoryBuilderConverter.java
+++ b/src/main/java/org/jfrog/hudson/util/converters/ArtifactoryBuilderConverter.java
@@ -1,6 +1,5 @@
 package org.jfrog.hudson.util.converters;
 
-import com.google.common.collect.Lists;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import hudson.util.XStream2;
 import org.jfrog.hudson.ArtifactoryBuilder;
@@ -14,7 +13,7 @@ import java.util.logging.Logger;
 
 public class ArtifactoryBuilderConverter extends XStream2.PassthruConverter<ArtifactoryBuilder.DescriptorImpl> {
     Logger logger = Logger.getLogger(ArtifactoryBuilderConverter.class.getName());
-    List<String> converterErrors = Lists.newArrayList();
+    List<String> converterErrors = new ArrayList<>();
 
     public ArtifactoryBuilderConverter(XStream2 xstream) {
         super(xstream);

--- a/src/main/java/org/jfrog/hudson/util/converters/ArtifactoryServerConverter.java
+++ b/src/main/java/org/jfrog/hudson/util/converters/ArtifactoryServerConverter.java
@@ -1,6 +1,5 @@
 package org.jfrog.hudson.util.converters;
 
-import com.google.common.collect.Lists;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import hudson.util.XStream2;
 import org.apache.commons.lang3.StringUtils;
@@ -10,6 +9,7 @@ import org.jfrog.hudson.util.Credentials;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -18,7 +18,7 @@ import java.util.logging.Logger;
  */
 public class ArtifactoryServerConverter extends XStream2.PassthruConverter<ArtifactoryServer> {
     Logger logger = Logger.getLogger(ArtifactoryServerConverter.class.getName());
-    List<String> converterErrors = Lists.newArrayList();
+    List<String> converterErrors = new ArrayList<>();
 
     public ArtifactoryServerConverter(XStream2 xstream) {
         super(xstream);

--- a/src/main/java/org/jfrog/hudson/util/converters/CredentialsConfigConverter.java
+++ b/src/main/java/org/jfrog/hudson/util/converters/CredentialsConfigConverter.java
@@ -1,6 +1,5 @@
 package org.jfrog.hudson.util.converters;
 
-import com.google.common.collect.Lists;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import hudson.util.XStream2;
 
@@ -9,11 +8,12 @@ import org.jfrog.hudson.util.Credentials;
 
 import java.lang.reflect.Field;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.logging.Logger;
 
 public class CredentialsConfigConverter extends XStream2.PassthruConverter<CredentialsConfig> {
     Logger logger = Logger.getLogger(CredentialsConfigConverter.class.getName());
-    List<String> converterErrors = Lists.newArrayList();
+    List<String> converterErrors = new ArrayList<>();
 
     public CredentialsConfigConverter(XStream2 xstream) {
         super(xstream);

--- a/src/main/java/org/jfrog/hudson/util/converters/DeployerResolverOverriderConverter.java
+++ b/src/main/java/org/jfrog/hudson/util/converters/DeployerResolverOverriderConverter.java
@@ -16,7 +16,6 @@
 
 package org.jfrog.hudson.util.converters;
 
-import com.google.common.collect.Lists;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import hudson.util.XStream2;
 import org.apache.commons.lang3.StringUtils;
@@ -29,6 +28,7 @@ import org.jfrog.hudson.maven3.ArtifactoryMaven3NativeConfigurator;
 import org.jfrog.hudson.util.Credentials;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
@@ -42,7 +42,7 @@ import java.util.logging.Logger;
 @SuppressWarnings("deprecation")
 public class DeployerResolverOverriderConverter<T> extends XStream2.PassthruConverter<T> {
     Logger logger = Logger.getLogger(DeployerResolverOverriderConverter.class.getName());
-    List<String> converterErrors = Lists.newArrayList();
+    List<String> converterErrors = new ArrayList<>();
     // List of configurators that contain the useMavenPatterns parameter to be overridden
     List<String> useMavenPatternsOverrideList = Arrays.asList(ArtifactoryGradleConfigurator.class.getSimpleName(),
             ArtifactoryIvyConfigurator.class.getSimpleName(), ArtifactoryIvyFreeStyleConfigurator.class.getSimpleName());

--- a/src/main/java/org/jfrog/hudson/util/converters/ServerDetailsConverter.java
+++ b/src/main/java/org/jfrog/hudson/util/converters/ServerDetailsConverter.java
@@ -1,6 +1,5 @@
 package org.jfrog.hudson.util.converters;
 
-import com.google.common.collect.Lists;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import hudson.util.XStream2;
 import org.apache.commons.lang3.StringUtils;
@@ -8,6 +7,7 @@ import org.jfrog.hudson.RepositoryConf;
 import org.jfrog.hudson.ServerDetails;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,7 +18,7 @@ import java.util.logging.Logger;
  */
 public class ServerDetailsConverter extends XStream2.PassthruConverter<ServerDetails> {
     Logger logger = Logger.getLogger(ServerDetailsConverter.class.getName());
-    List<String> converterErrors = Lists.newArrayList();
+    List<String> converterErrors = new ArrayList<>();
     // mapping of the old ServerDetails field to the corresponding new field
     private static final Map<String, String> newToOldFields;
 

--- a/src/test/java/org/jfrog/hudson/release/maven/PomTransformerTest.java
+++ b/src/test/java/org/jfrog/hudson/release/maven/PomTransformerTest.java
@@ -16,8 +16,6 @@
 
 package org.jfrog.hudson.release.maven;
 
-import com.google.common.collect.Maps;
-import com.google.common.io.Files;
 import hudson.maven.ModuleName;
 import org.jdom.input.SAXBuilder;
 import org.jfrog.build.extractor.maven.transformer.SnapshotNotAllowedException;
@@ -26,6 +24,7 @@ import org.junit.Test;
 import java.io.File;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -41,13 +40,13 @@ public class PomTransformerTest {
     @Test
     public void transformSimplePom() throws Exception {
         File pomFile = getResourceAsFile("/poms/parentonly/pom.xml");
-        HashMap<ModuleName, String> modules = Maps.newHashMap();
+        HashMap<ModuleName, String> modules = new HashMap<>();
         modules.put(new ModuleName("org.jfrog.test", "parent"), "2.2");
 
         new PomTransformer(new ModuleName("org.jfrog.test", "one"), modules, "", false).invoke(pomFile, null);
 
-        String pomStr = Files.toString(pomFile, Charset.defaultCharset());
-        String expectedStr = Files.toString(getResourceAsFile("/poms/parentonly/pom.expected.xml"),
+        String pomStr = new String(Files.readAllBytes(pomFile.toPath()), Charset.defaultCharset());
+        String expectedStr = new String(Files.readAllBytes(getResourceAsFile("/poms/parentonly/pom.expected.xml").toPath()),
                 Charset.defaultCharset());
 
         assertEquals(expectedStr, pomStr);
@@ -56,16 +55,16 @@ public class PomTransformerTest {
     @Test
     public void transformMultiPom() throws Exception {
         File pomFile = getResourceAsFile("/poms/multi/pom.xml");
-        Map<ModuleName, String> modules = Maps.newHashMap();
+        Map<ModuleName, String> modules = new HashMap<>();
         modules.put(new ModuleName("org.jfrog.test.nested", "nested1"), "3.6");
         modules.put(new ModuleName("org.jfrog.test.nested", "nested2"), "3.6");
         modules.put(new ModuleName("org.jfrog.test.nested", "two"), "3.6");
 
         new PomTransformer(new ModuleName("org.jfrog.test.nested", "two"), modules, "", false).invoke(pomFile, null);
 
-        String pomStr = Files.toString(pomFile, Charset.defaultCharset());
+        String pomStr = new String(Files.readAllBytes(pomFile.toPath()), Charset.defaultCharset());
         ;
-        String expectedStr = Files.toString(getResourceAsFile("/poms/multi/pom.expected.xml"),
+        String expectedStr = new String(Files.readAllBytes(getResourceAsFile("/poms/multi/pom.expected.xml").toPath()),
                 Charset.defaultCharset());
 
         assertEquals(expectedStr, pomStr);
@@ -74,14 +73,14 @@ public class PomTransformerTest {
     @Test
     public void transformScm() throws Exception {
         File pomFile = getResourceAsFile("/poms/scm/pom.xml");
-        HashMap<ModuleName, String> modules = Maps.newHashMap();
+        HashMap<ModuleName, String> modules = new HashMap<>();
         modules.put(new ModuleName("org.jfrog.test", "parent"), "1");
 
         new PomTransformer(new ModuleName("org.jfrog.test", "one"), modules,
                 "http://subversion.jfrog.org/test/tags/1", false).invoke(pomFile, null);
 
-        String pomStr = Files.toString(pomFile, Charset.defaultCharset());
-        String expectedStr = Files.toString(getResourceAsFile("/poms/scm/pom.expected.xml"), Charset.defaultCharset());
+        String pomStr = new String(Files.readAllBytes(pomFile.toPath()), Charset.defaultCharset());
+        String expectedStr = new String(Files.readAllBytes(getResourceAsFile("/poms/scm/pom.expected.xml").toPath()), Charset.defaultCharset());
 
         assertEquals(expectedStr, pomStr);
     }
@@ -89,7 +88,7 @@ public class PomTransformerTest {
     @Test
     public void snapshotsModule() throws Exception {
         File pomFile = getResourceAsFile("/poms/snapshots/pom-snapshot.xml");
-        Map<ModuleName, String> modules = Maps.newHashMap();
+        Map<ModuleName, String> modules = new HashMap<>();
         modules.put(new ModuleName("org.jfrog.test", "one"), "2.2-SNAPSHOT");
         try {
             new PomTransformer(new ModuleName("org.jfrog.test", "one"), modules, "", true).invoke(pomFile, null);
@@ -103,7 +102,7 @@ public class PomTransformerTest {
     @Test
     public void snapshotsInParent() throws Exception {
         File pomFile = getResourceAsFile("/poms/snapshots/pom-snapshot-parent.xml");
-        Map<ModuleName, String> modules = Maps.newHashMap();
+        Map<ModuleName, String> modules = new HashMap<>();
         try {
             new PomTransformer(new ModuleName("org.jfrog.test", "one"), modules, "", true).invoke(pomFile, null);
             fail("Pom contains snapshot in the parent and should fail");
@@ -117,7 +116,7 @@ public class PomTransformerTest {
     @Test
     public void snapshotsInDependenciesManagement() throws Exception {
         File pomFile = getResourceAsFile("/poms/snapshots/pom-snapshots-in-dep-management.xml");
-        Map<ModuleName, String> modules = Maps.newHashMap();
+        Map<ModuleName, String> modules = new HashMap<>();
         modules.put(new ModuleName("org.jfrog.test.nested", "nested1"), "3.6");
         modules.put(new ModuleName("org.jfrog.test.nested", "nested2"), "3.6");
         modules.put(new ModuleName("org.jfrog.test.nested", "four"), "3.6");
@@ -136,7 +135,7 @@ public class PomTransformerTest {
     @Test
     public void snapshotsInDependencies() throws Exception {
         File pomFile = getResourceAsFile("/poms/snapshots/pom-snapshots-in-dependencies.xml");
-        Map<ModuleName, String> modules = Maps.newHashMap();
+        Map<ModuleName, String> modules = new HashMap<>();
         modules.put(new ModuleName("org.jfrog.test.nested", "nested1"), "3.6");
         modules.put(new ModuleName("org.jfrog.test.nested", "nested2"), "3.6");
         modules.put(new ModuleName("org.jfrog.test.nested", "four"), "3.6");


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----
Guava's `Lists#newArrayList`, `Maps#newHashMap`, and `Sets#newHashSet` were quite handy in the days of Java 6, prior to the introduction of the diamond operator in Java 7. Nowadays, they are largely unnecessary since the native Java functionality with the diamond operator suffices. In this PR I am eliminating the usage of any of those Guava methods where they can be trivially replaced with native Java Platform functionality.