### PR TITLE
Add deprecated prefix to all items in the properties file

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/deployers/Deployer.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/deployers/Deployer.java
@@ -40,6 +40,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
@@ -488,8 +488,8 @@ public class ExtractorUtils {
                 Properties properties = new Properties();
                 properties.putAll(configuration.getAllRootConfig());
                 properties.putAll(configuration.getAllProperties());
-			    // Properties that have the 'artifactory.' prefix are deprecated.
-				// For backward compatibility reasons, both will be added to the props map.
+                // Properties that have the 'artifactory.' prefix are deprecated.
+                // For backward compatibility reasons, both will be added to the props map.
                 for (String key : properties.stringPropertyNames()) {
                     properties.put("artifactory." + key, properties.getProperty(key));
                 }

--- a/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
@@ -488,6 +488,11 @@ public class ExtractorUtils {
                 Properties properties = new Properties();
                 properties.putAll(configuration.getAllRootConfig());
                 properties.putAll(configuration.getAllProperties());
+			    // Properties that have the 'artifactory.' prefix are deprecated.
+				// For backward compatibility reasons, both will be added to the props map.
+                for (String key : properties.stringPropertyNames()) {
+                    properties.put("artifactory." + key, properties.getProperty(key));
+                }
                 OutputStream os = propertiesFile.write();
                 try {
                     properties.store(os, "");

--- a/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
@@ -490,6 +490,7 @@ public class ExtractorUtils {
                 properties.putAll(configuration.getAllProperties());
                 // Properties that have the 'artifactory.' prefix are deprecated.
                 // For backward compatibility reasons, both will be added to the props map.
+                // The build-info 2.32.3 is the last version to be using the deprecated properties as its primary.
                 for (String key : properties.stringPropertyNames()) {
                     properties.put("artifactory." + key, properties.getProperty(key));
                 }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----
Following [this commit](https://github.com/jfrog/build-info/commit/8e6da85721ea6c5a9fdeb338245ecbe022fe071e), all properties starting with 'artifactory.' have changed to the same thing without the 'artifactory.' prefix.
In addition, to support older versions of build-info-extractory, both of the properties forms will be written in the properties file.