### PR TITLE
Add gradle-enterprise-maven-extension-1.11.1.jar to mvn classpath

### DIFF
--- a/src/main/resources/org/jfrog/hudson/maven3/classworlds-freestyle.conf
+++ b/src/main/resources/org/jfrog/hudson/maven3/classworlds-freestyle.conf
@@ -4,4 +4,5 @@ set maven.home default ${user.home}/m2
 
 [plexus.core]
 load ${maven.home}/lib/*.jar
+load ${maven.home}/lib/ext/gradle-enterprise-maven-extension-*.jar
 load ${m3plugin.lib}/*.jar


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----
This PR adds the gradle-enterprise-maven-extension-1.11.1.jar (or any other version of this jar) to the maven classpath. This allows integrating this functionality into the Jenkina Artifactory Plugin's maven integration.
