### PR TITLE
Remove more usages of Guava

### DIFF
--- a/src/main/java/org/jfrog/hudson/ArtifactoryServer.java
+++ b/src/main/java/org/jfrog/hudson/ArtifactoryServer.java
@@ -16,7 +16,6 @@
 
 package org.jfrog.hudson;
 
-import com.google.common.collect.Lists;
 import hudson.model.Item;
 import hudson.model.TaskListener;
 import hudson.util.XStream2;
@@ -230,13 +229,15 @@ public class ArtifactoryServer implements Serializable {
     }
 
     public List<UserPluginInfo> getStagingUserPluginInfo(DeployerOverrider deployerOverrider, Item item) {
-        List<UserPluginInfo> infosToReturn = Lists.newArrayList(UserPluginInfo.NO_PLUGIN);
+        List<UserPluginInfo> infosToReturn = new ArrayList<>();
+        infosToReturn.add(UserPluginInfo.NO_PLUGIN);
         gatherUserPluginInfo(infosToReturn, "staging", deployerOverrider, item);
         return infosToReturn;
     }
 
     public List<UserPluginInfo> getPromotionsUserPluginInfo(DeployerOverrider deployerOverrider, Item item) {
-        List<UserPluginInfo> infosToReturn = Lists.newArrayList(UserPluginInfo.NO_PLUGIN);
+        List<UserPluginInfo> infosToReturn = new ArrayList<>();
+        infosToReturn.add(UserPluginInfo.NO_PLUGIN);
         gatherUserPluginInfo(infosToReturn, "promotions", deployerOverrider, item);
         return infosToReturn;
     }

--- a/src/main/java/org/jfrog/hudson/action/ActionableHelper.java
+++ b/src/main/java/org/jfrog/hudson/action/ActionableHelper.java
@@ -16,7 +16,6 @@
 
 package org.jfrog.hudson.action;
 
-import com.google.common.collect.Lists;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.matrix.MatrixConfiguration;
@@ -211,7 +210,9 @@ public abstract class ActionableHelper implements Serializable {
             String artifactoryServerName, AbstractProject project) {
         if (shouldReturnEmptyList(artifactoryServerName, project)) return Collections.emptyList();
 
-        return Lists.newArrayList(new ArtifactoryProjectAction(artifactoryServerName, project));
+        List<ArtifactoryProjectAction> projectActionList = new ArrayList<>();
+        projectActionList.add(new ArtifactoryProjectAction(artifactoryServerName, project));
+        return projectActionList;
     }
 
     private static boolean shouldReturnEmptyList(String artifactoryServerName, AbstractProject project) {
@@ -240,7 +241,9 @@ public abstract class ActionableHelper implements Serializable {
             return Collections.emptyList();
         }
 
-        return Lists.newArrayList(new ArtifactoryProjectAction(artifactoryServerName, buildName));
+        List<ArtifactoryProjectAction> projectActionList = new ArrayList<>();
+        projectActionList.add(new ArtifactoryProjectAction(artifactoryServerName, buildName));
+        return projectActionList;
     }
 
     /**

--- a/src/main/java/org/jfrog/hudson/generic/GenericBuildInfoDeployer.java
+++ b/src/main/java/org/jfrog/hudson/generic/GenericBuildInfoDeployer.java
@@ -16,7 +16,6 @@
 
 package org.jfrog.hudson.generic;
 
-import com.google.common.collect.Lists;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import org.jfrog.build.extractor.builder.ModuleBuilder;
@@ -25,6 +24,7 @@ import org.jfrog.build.extractor.ci.BuildInfo;
 import org.jfrog.build.extractor.ci.BuildRetention;
 import org.jfrog.build.extractor.ci.Dependency;
 import org.jfrog.build.api.dependency.BuildDependency;
+import org.jfrog.build.extractor.ci.Module;
 import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;
 import org.jfrog.build.extractor.retention.Utils;
 import org.jfrog.hudson.AbstractBuildInfoDeployer;
@@ -33,6 +33,7 @@ import org.jfrog.hudson.util.ExtractorUtils;
 
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -79,6 +80,8 @@ public class GenericBuildInfoDeployer extends AbstractBuildInfoDeployer {
                         ExtractorUtils.sanitizeBuildName(build.getParent().getDisplayName()) + ":" + build.getNumber())
                         .artifacts(deployedArtifacts);
         moduleBuilder.dependencies(publishedDependencies);
-        buildInfo.setModules(Lists.newArrayList(moduleBuilder.build()));
+        List<Module> modules = new ArrayList<>();
+        modules.add(moduleBuilder.build());
+        buildInfo.setModules(modules);
     }
 }

--- a/src/main/java/org/jfrog/hudson/maven2/MavenBuildInfoDeployer.java
+++ b/src/main/java/org/jfrog/hudson/maven2/MavenBuildInfoDeployer.java
@@ -16,7 +16,6 @@
 
 package org.jfrog.hudson.maven2;
 
-import com.google.common.collect.Sets;
 import hudson.maven.MavenBuild;
 import hudson.maven.MavenModule;
 import hudson.maven.MavenModuleSetBuild;
@@ -42,6 +41,7 @@ import org.jfrog.hudson.util.RepositoriesUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -106,9 +106,11 @@ public class MavenBuildInfoDeployer extends AbstractBuildInfoDeployer {
         if (dependenciesRecord != null) {
             Set<MavenDependency> dependencies = dependenciesRecord.getDependencies();
             for (MavenDependency dependency : dependencies) {
+                Set<String> scopes = new HashSet<>();
+                scopes.add(dependency.getScope());
                 DependencyBuilder dependencyBuilder = new DependencyBuilder()
                         .id(dependency.getId())
-                        .scopes(Sets.newHashSet(dependency.getScope()))
+                        .scopes(scopes)
                         .type(dependency.getType())
                         .md5(getMd5(dependency.getGroupId(), dependency.getFileName(), mavenBuild));
                 moduleBuilder.addDependency(dependencyBuilder.build());

--- a/src/main/java/org/jfrog/hudson/release/promotion/UnifiedPromoteBuildAction.java
+++ b/src/main/java/org/jfrog/hudson/release/promotion/UnifiedPromoteBuildAction.java
@@ -15,7 +15,6 @@
 
 package org.jfrog.hudson.release.promotion;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import hudson.model.*;
 import hudson.security.ACL;
@@ -36,6 +35,7 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -228,7 +228,9 @@ public class UnifiedPromoteBuildAction extends TaskAction implements BuildBadgeA
 
     @SuppressWarnings({"UnusedDeclaration"})
     public List<String> getTargetStatuses() {
-        return Lists.newArrayList(/*"Staged", */"Released", "Rolled-back");
+        List<String> targetStatuses = new ArrayList<>();
+        Collections.addAll(targetStatuses, /*"Staged", */"Released", "Rolled-back");
+        return targetStatuses;
     }
 
     /**
@@ -348,12 +350,16 @@ public class UnifiedPromoteBuildAction extends TaskAction implements BuildBadgeA
     private List<UserPluginInfo> getPromotionsUserPluginInfo() {
         final BuildInfoAwareConfigurator configurator = getFirstConfigurator();
         if (configurator == null) {
-            return Lists.newArrayList(UserPluginInfo.NO_PLUGIN);
+            List<UserPluginInfo> infosToReturn = new ArrayList<>();
+            infosToReturn.add(UserPluginInfo.NO_PLUGIN);
+            return infosToReturn;
         }
 
         ArtifactoryServer artifactoryServer = configurator.getArtifactoryServer();
         if (artifactoryServer == null) {
-            return Lists.newArrayList(UserPluginInfo.NO_PLUGIN);
+            List<UserPluginInfo> infosToReturn = new ArrayList<>();
+            infosToReturn.add(UserPluginInfo.NO_PLUGIN);
+            return infosToReturn;
         }
         return artifactoryServer.getPromotionsUserPluginInfo((DeployerOverrider) configurator, build.getParent());
     }

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
@@ -1,7 +1,6 @@
 package org.jfrog.hudson.pipeline.integration;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.collect.Sets;
 import hudson.EnvVars;
 import hudson.model.Result;
 import org.apache.commons.cli.MissingArgumentException;
@@ -35,6 +34,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -119,7 +120,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
     }
 
     void downloadByPatternAndBuildTest(String buildName) throws Exception {
-        Set<String> expectedDependencies = Sets.newHashSet("a.in");
+        Set<String> expectedDependencies = Collections.singleton("a.in");
         String buildNumber = BUILD_NUMBER + "-3";
         WorkflowRun pipelineResults = null;
 
@@ -185,8 +186,9 @@ public class CommonITestsPipeline extends PipelineTestBase {
      * Verify that we don't download files with same sha and different build name and build number.
      */
     void downloadByShaAndBuildTest(String buildName) throws Exception {
-        Set<String> expectedDependencies = Sets.newHashSet("a3");
-        Set<String> unexpected = Sets.newHashSet("a4", "a5");
+        Set<String> expectedDependencies = Collections.singleton("a3");
+        Set<String> unexpected = new HashSet<>();
+        Collections.addAll(unexpected, "a4", "a5");
         WorkflowRun pipelineResults = null;
 
         try {
@@ -210,8 +212,9 @@ public class CommonITestsPipeline extends PipelineTestBase {
      * Verify that we don't download files with same sha and build name and different build number.
      */
     void downloadByShaAndBuildNameTest(String buildName) throws Exception {
-        Set<String> expectedDependencies = Sets.newHashSet("a4");
-        Set<String> unexpected = Sets.newHashSet("a3", "a5");
+        Set<String> expectedDependencies = Collections.singleton("a4");
+        Set<String> unexpected = new HashSet<>();
+        Collections.addAll(unexpected, "a3", "a5");
         WorkflowRun pipelineResults = null;
         try {
             pipelineResults = runPipeline("downloadByShaAndBuildName", false);
@@ -277,7 +280,8 @@ public class CommonITestsPipeline extends PipelineTestBase {
     }
 
     void uploadWithPropsTest() throws Exception {
-        Set<String> uploadFiles = Sets.newHashSet("a.in", "b.in", "c.in");
+        Set<String> uploadFiles = new HashSet<>();
+        Collections.addAll(uploadFiles, "a.in", "b.in", "c.in");
         WorkflowRun build = runPipeline("uploadWithProps", false);
         for (String fileName : uploadFiles) {
             assertTrue(fileName + " doesn't exist locally", isExistInWorkspace(slave, build, "UploadWithProps-test", fileName));
@@ -307,7 +311,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
     }
 
     void mavenTest(String buildName, boolean useWrapper) throws Exception {
-        Set<String> expectedArtifacts = Sets.newHashSet("multi-3.7-SNAPSHOT.pom");
+        Set<String> expectedArtifacts = Collections.singleton("multi-3.7-SNAPSHOT.pom");
         WorkflowRun pipelineResults = null;
         try {
             pipelineResults = runPipeline(useWrapper ? "mavenWrapper" : "maven", false);
@@ -328,7 +332,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
 
     void mavenJibTest(String buildName) throws Exception {
         Assume.assumeFalse("Skipping Docker tests", SystemUtils.IS_OS_WINDOWS);
-        Set<String> expectedArtifacts = Sets.newHashSet("multi-3.7-SNAPSHOT.pom");
+        Set<String> expectedArtifacts = Collections.singleton("multi-3.7-SNAPSHOT.pom");
         WorkflowRun pipelineResults = null;
         try {
             pipelineResults = runPipeline("mavenJib", false);
@@ -376,7 +380,8 @@ public class CommonITestsPipeline extends PipelineTestBase {
     }
 
     void gradleCiServerTest(String buildName) throws Exception {
-        Set<String> expectedArtifacts = Sets.newHashSet(pipelineType.toString() + "-gradle-example-ci-server-1.0.jar", "ivy-1.0.xml", pipelineType.toString() + "-gradle-example-ci-server-1.0.pom");
+        Set<String> expectedArtifacts = new HashSet<>();
+        Collections.addAll(expectedArtifacts, pipelineType.toString() + "-gradle-example-ci-server-1.0.jar", "ivy-1.0.xml", pipelineType.toString() + "-gradle-example-ci-server-1.0.pom");
         WorkflowRun pipelineResults = null;
         try {
             pipelineResults = runPipeline("gradleCiServer", false);
@@ -397,7 +402,8 @@ public class CommonITestsPipeline extends PipelineTestBase {
     }
 
     void gradleCiServerPublicationTest(String buildName) throws Exception {
-        Set<String> expectedArtifacts = Sets.newHashSet(pipelineType.toString() + "-gradle-example-ci-server-publication-1.0.jar", pipelineType.toString() + "-gradle-example-ci-server-publication-1.0.pom");
+        Set<String> expectedArtifacts = new HashSet<>();
+        Collections.addAll(expectedArtifacts, pipelineType.toString() + "-gradle-example-ci-server-publication-1.0.jar", pipelineType.toString() + "-gradle-example-ci-server-publication-1.0.pom");
         WorkflowRun pipelineResults = null;
         try {
             pipelineResults = runPipeline("gradleCiServerPublication", false);
@@ -421,8 +427,9 @@ public class CommonITestsPipeline extends PipelineTestBase {
     }
 
     void npmTest(String pipelineName, String buildName, String moduleName) throws Exception {
-        Set<String> expectedArtifact = Sets.newHashSet("package-name1:0.0.1");
-        Set<String> expectedDependencies = Sets.newHashSet("big-integer:1.6.40", "is-number:7.0.0");
+        Set<String> expectedArtifact = Collections.singleton("package-name1:0.0.1");
+        Set<String> expectedDependencies = new HashSet<>();
+        Collections.addAll(expectedDependencies, "big-integer:1.6.40", "is-number:7.0.0");
         WorkflowRun pipelineResults = null;
         try {
             pipelineResults = runPipeline(pipelineName, false);
@@ -437,8 +444,10 @@ public class CommonITestsPipeline extends PipelineTestBase {
     }
 
     void goTest(String pipelineName, String buildName, String moduleName) throws Exception {
-        Set<String> expectedArtifact = Sets.newHashSet("github.com/you/hello:v1.0.0.zip", "github.com/you/hello:v1.0.0.mod", "github.com/you/hello:v1.0.0.info");
-        Set<String> expectedDependencies = Sets.newHashSet("rsc.io/sampler:v1.3.0", "golang.org/x/text:v0.0.0-20170915032832-14c0d48ead0c", "rsc.io/quote:v1.5.2");
+        Set<String> expectedArtifact = new HashSet<>();
+        Collections.addAll(expectedArtifact, "github.com/you/hello:v1.0.0.zip", "github.com/you/hello:v1.0.0.mod", "github.com/you/hello:v1.0.0.info");
+        Set<String> expectedDependencies = new HashSet<>();
+        Collections.addAll(expectedDependencies, "rsc.io/sampler:v1.3.0", "golang.org/x/text:v0.0.0-20170915032832-14c0d48ead0c", "rsc.io/quote:v1.5.2");
         WorkflowRun pipelineResults = null;
         try {
             pipelineResults = runPipeline(pipelineName, false);
@@ -530,7 +539,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
     }
 
     void setPropsTest(String buildName) throws Exception {
-        Set<String> expectedDependencies = Sets.newHashSet("a.in");
+        Set<String> expectedDependencies = Collections.singleton("a.in");
         WorkflowRun pipelineResults = null;
         try {
             pipelineResults = runPipeline("setProps", false);
@@ -552,7 +561,8 @@ public class CommonITestsPipeline extends PipelineTestBase {
     }
 
     void deletePropsTest(String buildName) throws Exception {
-        Set<String> expectedDependencies = Sets.newHashSet("b.in", "c.in");
+        Set<String> expectedDependencies = new HashSet<>();
+        Collections.addAll(expectedDependencies, "b.in", "c.in");
         WorkflowRun pipelineResults = null;
         try {
             pipelineResults = runPipeline("deleteProps", false);


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----
Guava's `Lists#newArrayList`, `Maps#newHashMap`, and `Sets#newHashSet` were quite handy in the days of Java 6, prior to the introduction of the diamond operator in Java 7. Nowadays, they are largely unnecessary since the native Java functionality with the diamond operator suffices. In this PR I am eliminating the usage of any of those Guava methods where they can be trivially replaced with native Java Platform functionality.