### PR TITLE
Add sha2 in getArtifacts & getDependencies

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/types/File.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/types/File.java
@@ -14,6 +14,7 @@ public class File implements Serializable {
     private String remotePath;
     private String md5;
     private String sha1;
+    private String sha256;
 
     public File() {
     }
@@ -23,6 +24,7 @@ public class File implements Serializable {
         this.remotePath = baseBuildFileBean.getRemotePath();
         this.md5 = baseBuildFileBean.getMd5();
         this.sha1 = baseBuildFileBean.getSha1();
+        this.sha256 = baseBuildFileBean.getSha256();
     }
 
     @Whitelisted
@@ -43,6 +45,11 @@ public class File implements Serializable {
     @Whitelisted
     public String getSha1() {
         return sha1;
+    }
+
+    @Whitelisted
+    public String getSha256() {
+        return sha256;
     }
 
     @Override
@@ -67,6 +74,7 @@ public class File implements Serializable {
         return "{localPath='" + localPath + "\', " +
                 "remotePath='" + remotePath + "\', " +
                 "md5=" + md5 + ", " +
+                "sha256=" + sha256 + ", " +
                 "sha1=" + sha1 + "}";
     }
 }

--- a/src/main/java/org/jfrog/hudson/pipeline/types/File.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/types/File.java
@@ -71,8 +71,8 @@ public class File implements Serializable {
 
     @Override
     public String toString() {
-        return "{localPath='" + localPath + "\', " +
-                "remotePath='" + remotePath + "\', " +
+        return "{localPath='" + localPath + "', " +
+                "remotePath='" + remotePath + "', " +
                 "md5=" + md5 + ", " +
                 "sha256=" + sha256 + ", " +
                 "sha1=" + sha1 + "}";


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----
Sha2 property is missing in `buildInfo.getArtifacts()` & `buildInfo.getDependencies()`.
This PR adds this property, for example:
```
[
  {localPath='.../.jenkins/workspace/upload/example.gif', remotePath='example.gif', 
  md5=5ae64b18b98a20fb8c4830cb948e361d, 
  sha256=76aab4ae1bc25344406c67f78f9a3f9a3a4d08325f9872fbd38072af3c036c38, 
  sha1=66af7ebf37464e3100f8036ecd2ca4f2c3ef2d68}
]
```
Related: https://github.com/jfrog/build-info/pull/605.