### PR TITLE
Stay on step context Node when finding root workspace

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
@@ -79,10 +79,10 @@ public class Utils {
      * @throws InterruptedException if context.get fails.
      */
     public static FilePath extractRootWorkspace(StepContext context, WorkflowRun build, FilePath cwd) throws IOException, InterruptedException {
-        // get the current node from context
+        // Get the current node from context
         Node node = context.get(Node.class);
 
-        // get the workspace from the flow (if it matches the context's node)
+        // Get the workspace from the flow (if it matches the context's node)
         FilePath flowWorkspace = extractRootWorkspaceFromFlow(build.getExecution(), node);
         if (flowWorkspace != null) {
             return flowWorkspace;
@@ -99,8 +99,8 @@ public class Utils {
      * Walk all flow nodes and find the top most workspace action. This
      * action would represent the root workspace for the workflow run.
      *
-     * @param execution the execution of the workflow run.
-     * @param contextNode Node for the current step context or null.
+     * @param execution   - The execution of the workflow run.
+     * @param contextNode - Node for the current step context or null.
      * @return the root workspace from the flow node tree, or null if none exist.
      */
     private static FilePath extractRootWorkspaceFromFlow(FlowExecution execution, Node contextNode) {
@@ -111,7 +111,7 @@ public class Utils {
         FilePath rootPath = null;
         for (FlowNode node : flowWalker) {
             WorkspaceAction workspaceAction = node.getAction(WorkspaceAction.class);
-            // stay on the contextNode if not null
+            // Stay on the contextNode if not null
             if (workspaceAction != null && ((contextNode != null && contextNode.getNodeName() == workspaceAction.getNode()) || contextNode == null)) {
                 FilePath rootWorkspace = workspaceAction.getWorkspace();
                 if (rootWorkspace != null) {

--- a/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
@@ -112,7 +112,7 @@ public class Utils {
         for (FlowNode node : flowWalker) {
             WorkspaceAction workspaceAction = node.getAction(WorkspaceAction.class);
             // Stay on the contextNode if not null
-            if (workspaceAction != null && ((contextNode != null && contextNode.getNodeName() == workspaceAction.getNode()) || contextNode == null)) {
+            if (workspaceAction != null && (contextNode == null || StringUtils.equals(contextNode.getNodeName(), workspaceAction.getNode()))) {
                 FilePath rootWorkspace = workspaceAction.getWorkspace();
                 if (rootWorkspace != null) {
                     rootPath = rootWorkspace;


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----
This change #432 broke finding the root workspace in a very specific circumstance:
* two parallel stages running on different agents (Linux and Windows)
* resource locks used to control stage timings - i.e. to prevent publishing on platform before the other successfully builds

The pseudo pipeline below illustrates how the issue can be triggered:
```
pipeline {
    agent none
    stages {
        stage('Build and Publish') {
            failFast true
            parallel {
                stage('Build and Publish - Linux') {
                    agent { label 'linux' }
                    stages {
                        stage("Build - Linux") { steps { lock(resource: "linux-publish") { compile() } } }
                        stage('Publish - Linux') { steps { lock(resource: "linux-publish", extra: [[resource: "windows-publish"]]) { publish() } } }
                    }
                }
                stage('Build and Publish - Windows') {
                    agent { label 'windows' }
                    stages {
                        stage("Build - Windows") { steps { lock(resource: "windows-publish") { compile() } } }
                        stage('Publish - Windows') { steps { lock(resource: "windows-publish", extra: [[resource: "linux-publish"]]) { publish() } } }
                    }
                }
            }
        }
    }
}
```
where the `publish()` steps are what call the RT steps.

The behavior I see is that the root workspace found is for the wrong Node (the Linux node for the stage running on Windows). Obviously this breaks things.

This PR checks that the root workspace found is on the same Node as the step's context, if not null.