### PR TITLE
Bugfix - Can't promote builds with projects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
         <!--Skip integration tests unless explicitly requested with -DskipITs=false-->
         <skipITs>true</skipITs>
 
-        <buildinfo.version>2.33.3</buildinfo.version>
-        <buildinfo.gradle.version>4.26.3</buildinfo.gradle.version>
+        <buildinfo.version>2.34.0</buildinfo.version>
+        <buildinfo.gradle.version>4.27.0</buildinfo.gradle.version>
     </properties>
 
     <repositories>
@@ -60,6 +60,12 @@
             <id>jenkins-public</id>
             <name>jenkins-public</name>
             <url>https://repo.jenkins-ci.org/public</url>
+        </repository>
+        <repository>
+            <snapshots/>
+            <id>releases</id>
+            <name>libs-releases</name>
+            <url>https://releases.jfrog.io/artifactory/oss-releases</url>
         </repository>
         <repository>
             <snapshots/>

--- a/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
@@ -304,7 +304,7 @@ public class Utils {
     public static PromotionConfig createPromotionConfig(Map<String, Object> promotionParams, boolean isTargetRepositoryMandatory) {
         final String targetRepository = "targetRepo";
         List<String> mandatoryParams = new ArrayList<>(Arrays.asList(BUILD_NAME, BUILD_NUMBER));
-        List<String> allowedParams = Arrays.asList(BUILD_NAME, BUILD_NUMBER, targetRepository, "sourceRepo", "status", "comment", "includeDependencies", "copy", "failFast");
+        List<String> allowedParams = Arrays.asList(BUILD_NAME, BUILD_NUMBER, "project", targetRepository, "sourceRepo", "status", "comment", "includeDependencies", "copy", "failFast");
 
         if (isTargetRepositoryMandatory) {
             mandatoryParams.add(targetRepository);

--- a/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
@@ -6,7 +6,6 @@ import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.*;
-import hudson.plugins.git.util.BuildData;
 import hudson.remoting.Channel;
 import hudson.remoting.LocalChannel;
 import hudson.remoting.VirtualChannel;
@@ -49,11 +48,7 @@ import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.jfrog.hudson.pipeline.common.types.ArtifactoryServer.BUILD_NAME;
-import static org.jfrog.hudson.pipeline.common.types.ArtifactoryServer.BUILD_NUMBER;
-import static org.jfrog.hudson.pipeline.common.types.ArtifactoryServer.PROJECT;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.jfrog.hudson.pipeline.common.types.ArtifactoryServer.*;
 import static org.jfrog.hudson.util.SerializationUtils.createMapper;
@@ -330,6 +325,7 @@ public class Utils {
         org.jfrog.hudson.release.promotion.PromotionConfig promotionConfig = new org.jfrog.hudson.release.promotion.PromotionConfig();
         promotionConfig.setBuildName(pipelinePromotionConfig.getBuildName());
         promotionConfig.setBuildNumber(pipelinePromotionConfig.getBuildNumber());
+        promotionConfig.setProject(pipelinePromotionConfig.getProject());
         promotionConfig.setTargetRepo(pipelinePromotionConfig.getTargetRepo());
         promotionConfig.setSourceRepo(pipelinePromotionConfig.getSourceRepo());
         promotionConfig.setStatus(pipelinePromotionConfig.getStatus());

--- a/src/main/java/org/jfrog/hudson/pipeline/common/executors/PromotionExecutor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/executors/PromotionExecutor.java
@@ -25,9 +25,9 @@ public class PromotionExecutor implements Executor {
     private final TaskListener listener;
     private final PromotionConfig promotionConfig;
     private final StepContext context;
-    private Run build;
+    private final Run<?, ?> build;
 
-    public PromotionExecutor(ArtifactoryServer server, Run build, TaskListener listener, StepContext context,
+    public PromotionExecutor(ArtifactoryServer server, Run<?, ?> build, TaskListener listener, StepContext context,
                              PromotionConfig promotionConfig) {
         this.server = server;
         this.build = build;
@@ -54,14 +54,13 @@ public class PromotionExecutor implements Executor {
         logInfo();
 
         boolean status = PromotionUtils.promoteAndCheckResponse(promotionBuilder.build(), artifactoryManager, listener,
-                promotionConfig.getBuildName(), promotionConfig.getBuildNumber());
+                promotionConfig.getBuildName(), promotionConfig.getBuildNumber(), promotionConfig.getProject());
         if (!status) {
             context.onFailure(new Exception("Build promotion failed"));
         }
     }
 
     private void logInfo() {
-
         StringBuilder strBuilder = new StringBuilder()
                 .append("Promoting '").append(promotionConfig.getBuildName()).append("' ")
                 .append("#").append(promotionConfig.getBuildNumber())
@@ -91,6 +90,6 @@ public class PromotionExecutor implements Executor {
             strBuilder.append(", failing on first error");
         }
 
-        listener.getLogger().println(strBuilder.append(".").toString());
+        listener.getLogger().println(strBuilder.append("."));
     }
 }

--- a/src/main/java/org/jfrog/hudson/release/PromotionUtils.java
+++ b/src/main/java/org/jfrog/hudson/release/PromotionUtils.java
@@ -15,14 +15,14 @@ public class PromotionUtils {
      * Two stage promotion, dry run and actual promotion to verify correctness.
      */
     public static boolean promoteAndCheckResponse(Promotion promotion, ArtifactoryManager artifactoryManager, TaskListener listener,
-                                                  String buildName, String buildNumber) throws IOException {
+                                                  String buildName, String buildNumber, String project) throws IOException {
         // If failFast is true, perform dry run first
         if (promotion.isFailFast()) {
             promotion.setDryRun(true);
             listener.getLogger().println("Performing dry run promotion (no changes are made during dry run) ...");
 
             try {
-                artifactoryManager.stageBuild(buildName, buildNumber, promotion);
+                artifactoryManager.stageBuild(buildName, buildNumber, project, promotion);
                 listener.getLogger().println("Dry run finished successfully.\nPerforming promotion ...");
             } catch (IOException e) {
                 onPromotionFailFast(true, promotion.isFailFast());
@@ -33,7 +33,7 @@ public class PromotionUtils {
         // Perform promotion
         promotion.setDryRun(false);
         try {
-            artifactoryManager.stageBuild(buildName, buildNumber, promotion);
+            artifactoryManager.stageBuild(buildName, buildNumber, project, promotion);
         } catch (IOException e) {
             listener.error(e.getMessage());
             return false;

--- a/src/main/java/org/jfrog/hudson/release/promotion/PromotionConfig.java
+++ b/src/main/java/org/jfrog/hudson/release/promotion/PromotionConfig.java
@@ -12,6 +12,7 @@ public class PromotionConfig implements Serializable {
     private String id;
     private String buildName;
     private String buildNumber;
+    private String project;
     private String targetRepo;
     private String sourceRepo;
     private String status;
@@ -42,6 +43,14 @@ public class PromotionConfig implements Serializable {
 
     public void setBuildNumber(String buildNumber) {
         this.buildNumber = buildNumber;
+    }
+
+    public String getProject() {
+        return project;
+    }
+
+    public void setProject(String project) {
+        this.project = project;
     }
 
     public String getTargetRepo() {

--- a/src/main/java/org/jfrog/hudson/release/promotion/PromotionInfo.java
+++ b/src/main/java/org/jfrog/hudson/release/promotion/PromotionInfo.java
@@ -33,6 +33,10 @@ public class PromotionInfo implements Serializable {
         return this.promotionConfig.getBuildNumber();
     }
 
+    public String getProject() {
+        return this.promotionConfig.getProject();
+    }
+
     public BuildInfoAwareConfigurator getConfigurator() {
         return this.configurator;
     }

--- a/src/main/java/org/jfrog/hudson/release/promotion/UnifiedPromoteBuildAction.java
+++ b/src/main/java/org/jfrog/hudson/release/promotion/UnifiedPromoteBuildAction.java
@@ -339,9 +339,7 @@ public class UnifiedPromoteBuildAction extends TaskAction implements BuildBadgeA
                     paramMap.put(key, pluginSettings.getString(key));
                 }
                 paramMap.put("ciUser", ciUser);
-                if (!paramMap.isEmpty()) {
-                    settings.setParamMap(paramMap);
-                }
+                settings.setParamMap(paramMap);
                 setPromotionPlugin(settings);
             }
         }
@@ -407,7 +405,7 @@ public class UnifiedPromoteBuildAction extends TaskAction implements BuildBadgeA
                             .copy(useCopy)
                             .failFast(failFast);
 
-                    PromotionUtils.promoteAndCheckResponse(promotionBuilder.build(), artifactoryManager, listener, buildName, buildNumber);
+                    PromotionUtils.promoteAndCheckResponse(promotionBuilder.build(), artifactoryManager, listener, buildName, buildNumber, promotionCandidate.getProject());
                 }
 
                 build.save();

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/DeclarativeITest.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/DeclarativeITest.java
@@ -73,7 +73,12 @@ public class DeclarativeITest extends CommonITestsPipeline {
 
     @Test
     public void promotionTest() throws Exception {
-        super.promotionTest("declarative:promotion test");
+        super.promotionTest("promote", "declarative:promotion test", "");
+    }
+
+    @Test
+    public void promotionProjectTest() throws Exception {
+        super.promotionTest("promoteProject", "declarative:promotionProject test", PROJECT_KEY);
     }
 
     @Test

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/ScriptedITest.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/ScriptedITest.java
@@ -18,12 +18,12 @@ public class ScriptedITest extends CommonITestsPipeline {
 
     @Test
     public void downloadDuplicationsPart1Test() throws Exception {
-        super.downloadDuplicationsTest("scripted:downloadDuplicationsPart1 test","downloadDuplicationsPart1");
+        super.downloadDuplicationsTest("scripted:downloadDuplicationsPart1 test", "downloadDuplicationsPart1");
     }
 
     @Test
     public void downloadDuplicationsPart2Test() throws Exception {
-        super.downloadDuplicationsTest("scripted:downloadDuplicationsPart2 test","downloadDuplicationsPart2");
+        super.downloadDuplicationsTest("scripted:downloadDuplicationsPart2 test", "downloadDuplicationsPart2");
     }
 
     @Test
@@ -93,7 +93,12 @@ public class ScriptedITest extends CommonITestsPipeline {
 
     @Test
     public void promotionTest() throws Exception {
-        super.promotionTest("scripted:promotion test");
+        super.promotionTest("promote", "scripted:promotion test", "");
+    }
+
+    @Test
+    public void promotionProjectTest() throws Exception {
+        super.promotionTest("promoteProject", "scripted:promotionProject test", PROJECT_KEY);
     }
 
     @Test

--- a/src/test/resources/integration/pipelines/declarative/promoteProject.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/promoteProject.pipeline
@@ -1,0 +1,73 @@
+package integration.pipelines.declarative
+
+node("TestSlave") {
+    def serverId = "Artifactory-1"
+    def buildName = "declarative:promotionProject test"
+    def buildNumber = "${BUILD_NUMBER}"
+
+    stage "Configuration"
+    rtServer(
+            id: serverId,
+            url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory',
+            username: "${env.JENKINS_PLATFORM_USERNAME}",
+            password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
+    )
+
+    stage "Upload"
+    rtUpload(
+            serverId: serverId,
+            buildName: buildName,
+            buildNumber: buildNumber,
+            project: "${PROJECT_KEY}",
+            spec: """{
+              "files": [
+                {
+                  "pattern": "${FILES_DIR}",
+                  "target": "${LOCAL_REPO1}/",
+                  "recursive": "false"
+                }
+             ]
+            }"""
+    )
+
+    stage "Download"
+    rtDownload(
+            serverId: serverId,
+            buildName: buildName,
+            buildNumber: buildNumber,
+            project: "${PROJECT_KEY}",
+            spec: """{
+              "files": [
+                {
+                  "pattern": "${LOCAL_REPO1}/*",
+                  "target": "promotion-test/"
+                }
+             ]
+            }"""
+    )
+
+    stage "Publish Build Info"
+    rtPublishBuildInfo(
+            serverId: serverId,
+            buildName: buildName,
+            buildNumber: buildNumber,
+            project: "${PROJECT_KEY}"
+    )
+
+    stage "Promotion"
+    rtPromote(
+            //Mandatory parameter
+            serverId: serverId,
+            targetRepo: "${LOCAL_REPO2}",
+
+            //Optional parameters
+            buildName: buildName,
+            buildNumber: buildNumber,
+            project: "${PROJECT_KEY}",
+            comment: "this is the promotion comment",
+            sourceRepo: "${LOCAL_REPO1}",
+            status: "Released",
+            includeDependencies: true,
+            failFast: true
+    )
+}

--- a/src/test/resources/integration/pipelines/scripted/promoteProject.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/promoteProject.pipeline
@@ -1,0 +1,53 @@
+package integration.pipelines.scripted
+
+node("TestSlave") {
+    stage "Configuration"
+    def rtServer = Artifactory.newServer url: "${env.JENKINS_PLATFORM_URL}".replaceFirst('/*$', '')+'/artifactory', username: "${env.JENKINS_PLATFORM_USERNAME}", password: "${env.JENKINS_PLATFORM_ADMIN_TOKEN}"
+    def buildInfo = Artifactory.newBuildInfo()
+    buildInfo.name = "scripted:promotionProject test"
+    buildInfo.number = ${BUILD_NUMBER}
+    buildInfo.project = "${PROJECT_KEY}"
+
+    stage "Upload"
+    def uploadSpec = """{
+      "files": [
+        {
+          "pattern": "${FILES_DIR}",
+          "target": "${LOCAL_REPO1}/",
+          "recursive": "false"
+        }
+     ]
+    }"""
+    rtServer.upload spec: uploadSpec, buildInfo: buildInfo
+
+    stage "Download"
+    def downloadSpec = """{
+      "files": [
+        {
+          "pattern": "${LOCAL_REPO1}/*",
+          "target": "promotion-test/"
+        }
+     ]
+    }"""
+    rtServer.download spec: downloadSpec, buildInfo: buildInfo
+
+    stage "Publish Build Info"
+    rtServer.publishBuildInfo buildInfo
+
+    stage "Promotion"
+    def promotionConfig = [
+            //Mandatory parameters
+            "buildName"          : buildInfo.name,
+            "buildNumber"        : buildInfo.number,
+            "project"            : buildInfo.project,
+            "targetRepo"         : "${LOCAL_REPO2}",
+
+            //Optional parameters
+            "comment"            : "this is the promotion comment",
+            "sourceRepo"         : "${LOCAL_REPO1}",
+            "status"             : "Released",
+            "includeDependencies": true,
+            "failFast"           : true,
+    ]
+    rtServer.promote promotionConfig
+}


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----

Depends on https://github.com/jfrog/build-info/pull/613
Resolves #627

Allow pipeline promotion and interactive promotion using project.