### PR TITLE
Temporary build docker-java locally

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,6 +82,16 @@ jobs:
           echo "MAVEN_HOME=$(which mvn)" >> $GITHUB_ENV
           echo "GRADLE_HOME=$(brew info gradle | grep /usr/local/Cellar/gradle | awk '{print $1}')" >> $GITHUB_ENV
 
+      # Install docker-java locally
+      - name: Install docker-java
+        run: |
+          git clone https://github.com/docker-java/docker-java.git
+          cd docker-java
+          git checkout 8e77a694
+          ./mvnw versions:set -DnewVersion=3.2.x-8e77a694
+          ./mvnw install -DskipTests
+          cd ..
+
       - name: Run tests
         env:
           JENKINS_PLATFORM_URL: ${{ secrets.JENKINS_PLATFORM_URL }}

--- a/pom.xml
+++ b/pom.xml
@@ -382,6 +382,18 @@
             <groupId>org.jfrog.buildinfo</groupId>
             <artifactId>build-info-extractor-docker</artifactId>
             <version>${buildinfo.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.github.docker-java</groupId>
+                    <artifactId>docker-java</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <!-- Warning - this is a temporary workaround supposed to be removed after the next release of docker-java -->
+            <groupId>com.github.docker-java</groupId>
+            <artifactId>docker-java</artifactId>
+            <version>3.2.x-8e77a694</version>
         </dependency>
         <dependency>
             <groupId>org.jfrog.buildinfo</groupId>

--- a/release/pipelines.release.yml
+++ b/release/pipelines.release.yml
@@ -46,6 +46,14 @@ pipelines:
             - test -n "$NEXT_VERSION" -a "$NEXT_VERSION" != "0.0.0"
             - test -n "$NEXT_DEVELOPMENT_VERSION" -a "$NEXT_DEVELOPMENT_VERSION" != "0.0.0"
 
+            # Install docker-java
+            - git clone https://github.com/docker-java/docker-java.git
+            - cd docker-java
+            - git checkout 8e77a694
+            - ./mvnw versions:set -DnewVersion=3.2.x-8e77a694
+            - ./mvnw install -DskipTests
+            - cd ..
+
             # Configure JFrog CLI
             - curl -fL https://install-cli.jfrog.io | sh
             - jf c rm --quiet

--- a/release/pipelines.snapshot.yml
+++ b/release/pipelines.snapshot.yml
@@ -31,6 +31,14 @@ pipelines:
             - export JFROG_CLI_BUILD_NUMBER=$run_number
             - export JFROG_CLI_BUILD_PROJECT=ecosys
 
+            # Install docker-java
+            - git clone https://github.com/docker-java/docker-java.git
+            - cd docker-java
+            - git checkout 8e77a694
+            - ./mvnw versions:set -DnewVersion=3.2.x-8e77a694
+            - ./mvnw install -DskipTests
+            - cd ..
+
             # Configure JFrog CLI
             - curl -fL https://install-cli.jfrog.io | sh
             - jf c rm --quiet


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----

Resolves #597 #625 
Temporary build the docker-java with https://github.com/docker-java/docker-java/commit/8e77a69467814c8500e5a360bfce46602ca841fb.
