### PR TITLE
Fix conan tests

### DIFF
--- a/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
@@ -459,7 +459,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
             BuildInfo buildInfo = artifactoryManager.getBuildInfo(buildName, BUILD_NUMBER, null);
             Module module = getAndAssertModule(buildInfo, "DownloadOnly");
             assertTrue(module.getDependencies().size() > 0);
-            module = getAndAssertModule(buildInfo, "fmt/8.0.1");
+            module = getAndAssertModule(buildInfo, "fmt/8.1.1");
             assertTrue(module.getArtifacts().size() > 0);
         } finally {
             cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER);

--- a/src/test/resources/integration/conan-example/conanfile.txt
+++ b/src/test/resources/integration/conan-example/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-fmt/[>=8.0.1]
+fmt/8.1.1
 
 [generators]
 cmake_paths

--- a/src/test/resources/integration/pipelines/declarative/conan.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/conan.pipeline
@@ -42,7 +42,7 @@ node("TestSlave") {
 
     rtConanRun(
         clientId: "myConanClient",
-        command: "upload fmt/8.0.1 --all -r conanTestRemote --confirm",
+        command: "upload fmt/8.1.1 --all -r conanTestRemote --confirm",
         buildName: buildName,
         buildNumber: buildNumber
     )

--- a/src/test/resources/integration/pipelines/scripted/conan.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/conan.pipeline
@@ -24,7 +24,7 @@ node("TestSlave") {
     conanClient.run(command: "install ./scripted-conan-example --build missing", buildInfo: buildInfo)
 
     stage "Conan Upload"
-    conanClient.run(command: "upload fmt/8.0.1 --all -r " + remoteName + " --confirm", buildInfo: buildInfo)
+    conanClient.run(command: "upload fmt/8.1.1 --all -r " + remoteName + " --confirm", buildInfo: buildInfo)
 
     stage "Publish build info"
     rtServer.publishBuildInfo buildInfo


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----

Versions were not matched in the Conan tests. `fmt/8.1.1` was downloaded, but we are looking for `fmt/8.0.1`.