### PR TITLE
Add Jenkins scoped credentials to credentials list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.2.1</version>
+            <version>2.3.19</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jfrog/hudson/ArtifactoryBuilder.java
+++ b/src/main/java/org/jfrog/hudson/ArtifactoryBuilder.java
@@ -98,7 +98,7 @@ public class ArtifactoryBuilder extends GlobalConfiguration {
         public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item project) {
             Jenkins jenkins = Jenkins.getInstanceOrNull();
             if (jenkins != null && jenkins.hasPermission(Jenkins.ADMINISTER)) {
-                return PluginsUtils.fillPluginCredentials(project, ACL.SYSTEM);
+                return PluginsUtils.fillPluginCredentials(project);
             }
             return new StandardListBoxModel();
         }

--- a/src/main/java/org/jfrog/hudson/util/plugins/PluginsUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/plugins/PluginsUtils.java
@@ -34,32 +34,28 @@ public class PluginsUtils {
 
     private static ObjectMapper mapper;
 
+    /**
+     * Populate credentials list from the Jenkins Credentials plugin. In use in UI jobs only.
+     *
+     * @param project - Jenkins project
+     * @return credentials list
+     */
     public static ListBoxModel fillPluginCredentials(Item project) {
         if (project == null || !project.hasPermission(Item.CONFIGURE)) {
             return new StandardListBoxModel();
         }
-        return fillPluginCredentials(project, ACL.SYSTEM);
-    }
-
-    public static ListBoxModel fillPluginCredentials(Item project, Authentication authentication) {
         List<DomainRequirement> domainRequirements = Collections.emptyList();
         return new StandardListBoxModel()
                 .includeEmptyValue()
-                .includeMatchingAs(
-                        authentication,
-                        project,
-                        StandardCredentials.class,
-                        domainRequirements,
+                // Add project scoped credentials:
+                .includeMatchingAs(ACL.SYSTEM, project, StandardCredentials.class, domainRequirements,
                         CredentialsMatchers.anyOf(
                                 CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class),
                                 CredentialsMatchers.instanceOf(StringCredentials.class),
                                 CredentialsMatchers.instanceOf(StandardCertificateCredentials.class)
-                        )
-                ).includeMatchingAs(
-                        authentication,
-                        Jenkins.get(),
-                        StandardCredentials.class,
-                        domainRequirements,
+                        ))
+                // Add Jenkins system scoped credentials
+                .includeMatchingAs(ACL.SYSTEM, Jenkins.get(), StandardCredentials.class, domainRequirements,
                         CredentialsMatchers.anyOf(
                                 CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class),
                                 CredentialsMatchers.instanceOf(StringCredentials.class),


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----

Fix #505 

Additionally to the credentials lookup in the Jenkins job scope, look for the credentials in the Jenkins instance scope. This way, System-scope credentials will be available to use.