### PR TITLE
Revert "Temporary build docker-java locally (#629)"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,16 +82,6 @@ jobs:
           echo "MAVEN_HOME=$(which mvn)" >> $GITHUB_ENV
           echo "GRADLE_HOME=$(brew info gradle | grep /usr/local/Cellar/gradle | awk '{print $1}')" >> $GITHUB_ENV
 
-      # Install docker-java locally
-      - name: Install docker-java
-        run: |
-          git clone https://github.com/docker-java/docker-java.git
-          cd docker-java
-          git checkout 8e77a694
-          ./mvnw versions:set -DnewVersion="3.2.x-8e77a694" -B
-          ./mvnw install -DskipTests -B
-          cd ..
-
       - name: Run tests
         env:
           JENKINS_PLATFORM_URL: ${{ secrets.JENKINS_PLATFORM_URL }}

--- a/pom.xml
+++ b/pom.xml
@@ -388,18 +388,6 @@
             <groupId>org.jfrog.buildinfo</groupId>
             <artifactId>build-info-extractor-docker</artifactId>
             <version>${buildinfo.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.github.docker-java</groupId>
-                    <artifactId>docker-java</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <!-- Warning - this is a temporary workaround supposed to be removed after the next release of docker-java -->
-            <groupId>com.github.docker-java</groupId>
-            <artifactId>docker-java</artifactId>
-            <version>3.2.x-8e77a694</version>
         </dependency>
         <dependency>
             <groupId>org.jfrog.buildinfo</groupId>

--- a/release/pipelines.release.yml
+++ b/release/pipelines.release.yml
@@ -46,14 +46,6 @@ pipelines:
             - test -n "$NEXT_VERSION" -a "$NEXT_VERSION" != "0.0.0"
             - test -n "$NEXT_DEVELOPMENT_VERSION" -a "$NEXT_DEVELOPMENT_VERSION" != "0.0.0"
 
-            # Install docker-java
-            - git clone https://github.com/docker-java/docker-java.git
-            - cd docker-java
-            - git checkout 8e77a694
-            - ./mvnw versions:set -DnewVersion=3.2.x-8e77a694
-            - ./mvnw install -DskipTests
-            - cd ..
-
             # Configure JFrog CLI
             - curl -fL https://install-cli.jfrog.io | sh
             - jf c rm --quiet

--- a/release/pipelines.snapshot.yml
+++ b/release/pipelines.snapshot.yml
@@ -31,14 +31,6 @@ pipelines:
             - export JFROG_CLI_BUILD_NUMBER=$run_number
             - export JFROG_CLI_BUILD_PROJECT=ecosys
 
-            # Install docker-java
-            - git clone https://github.com/docker-java/docker-java.git
-            - cd docker-java
-            - git checkout 8e77a694
-            - ./mvnw versions:set -DnewVersion=3.2.x-8e77a694
-            - ./mvnw install -DskipTests
-            - cd ..
-
             # Configure JFrog CLI
             - curl -fL https://install-cli.jfrog.io | sh
             - jf c rm --quiet


### PR DESCRIPTION
This reverts commit bbd6fcdf791e3247ed3a4593f6afd505ca30618a.

- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----

The workaround is no longer necessary after docker-java 3.2.13 release.