### PR TITLE
Distribution declarative steps should be unblocking

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/distribution/CreateReleaseBundleStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/distribution/CreateReleaseBundleStep.java
@@ -4,7 +4,7 @@ import com.google.inject.Inject;
 import hudson.Extension;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.jfrog.hudson.pipeline.ArtifactorySynchronousStepExecution;
+import org.jfrog.hudson.pipeline.ArtifactorySynchronousNonBlockingStepExecution;
 import org.jfrog.hudson.pipeline.common.executors.ReleaseBundleCreateExecutor;
 import org.jfrog.hudson.pipeline.common.types.DistributionServer;
 import org.jfrog.hudson.pipeline.declarative.utils.DeclarativePipelineUtils;
@@ -66,7 +66,7 @@ public class CreateReleaseBundleStep extends CreateUpdateReleaseBundleStep {
         this.dryRun = dryRun;
     }
 
-    public static class Execution extends ArtifactorySynchronousStepExecution<Void> {
+    public static class Execution extends ArtifactorySynchronousNonBlockingStepExecution<Void> {
 
         private final transient CreateReleaseBundleStep step;
 
@@ -88,7 +88,7 @@ public class CreateReleaseBundleStep extends CreateUpdateReleaseBundleStep {
         }
 
         @Override
-        public org.jfrog.hudson.ArtifactoryServer getUsageReportServer() throws Exception {
+        public org.jfrog.hudson.ArtifactoryServer getUsageReportServer() {
             return null;
         }
 

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/distribution/DeleteReleaseBundleStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/distribution/DeleteReleaseBundleStep.java
@@ -4,7 +4,7 @@ import com.google.inject.Inject;
 import hudson.Extension;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.jfrog.hudson.pipeline.ArtifactorySynchronousStepExecution;
+import org.jfrog.hudson.pipeline.ArtifactorySynchronousNonBlockingStepExecution;
 import org.jfrog.hudson.pipeline.common.executors.ReleaseBundleDeleteExecutor;
 import org.jfrog.hudson.pipeline.common.types.DistributionServer;
 import org.jfrog.hudson.pipeline.declarative.utils.DeclarativePipelineUtils;
@@ -63,7 +63,7 @@ public class DeleteReleaseBundleStep extends RemoteReleaseBundleStep {
         this.sync = sync;
     }
 
-    public static class Execution extends ArtifactorySynchronousStepExecution<Void> {
+    public static class Execution extends ArtifactorySynchronousNonBlockingStepExecution<Void> {
 
         private final transient DeleteReleaseBundleStep step;
 
@@ -83,7 +83,7 @@ public class DeleteReleaseBundleStep extends RemoteReleaseBundleStep {
         }
 
         @Override
-        public org.jfrog.hudson.ArtifactoryServer getUsageReportServer() throws Exception {
+        public org.jfrog.hudson.ArtifactoryServer getUsageReportServer() {
             return null;
         }
 

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/distribution/DistributeReleaseBundleStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/distribution/DistributeReleaseBundleStep.java
@@ -4,7 +4,7 @@ import com.google.inject.Inject;
 import hudson.Extension;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.jfrog.hudson.pipeline.ArtifactorySynchronousStepExecution;
+import org.jfrog.hudson.pipeline.ArtifactorySynchronousNonBlockingStepExecution;
 import org.jfrog.hudson.pipeline.common.executors.ReleaseBundleDistributeExecutor;
 import org.jfrog.hudson.pipeline.common.types.DistributionServer;
 import org.jfrog.hudson.pipeline.declarative.utils.DeclarativePipelineUtils;
@@ -56,7 +56,7 @@ public class DistributeReleaseBundleStep extends RemoteReleaseBundleStep {
         this.sync = sync;
     }
 
-    public static class Execution extends ArtifactorySynchronousStepExecution<Void> {
+    public static class Execution extends ArtifactorySynchronousNonBlockingStepExecution<Void> {
 
         private final transient DistributeReleaseBundleStep step;
 
@@ -76,7 +76,7 @@ public class DistributeReleaseBundleStep extends RemoteReleaseBundleStep {
         }
 
         @Override
-        public org.jfrog.hudson.ArtifactoryServer getUsageReportServer() throws Exception {
+        public org.jfrog.hudson.ArtifactoryServer getUsageReportServer() {
             return null;
         }
 

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/distribution/SignReleaseBundleStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/distribution/SignReleaseBundleStep.java
@@ -5,7 +5,7 @@ import hudson.Extension;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.jfrog.hudson.pipeline.ArtifactorySynchronousStepExecution;
+import org.jfrog.hudson.pipeline.ArtifactorySynchronousNonBlockingStepExecution;
 import org.jfrog.hudson.pipeline.common.executors.ReleaseBundleSignExecutor;
 import org.jfrog.hudson.pipeline.common.types.DistributionServer;
 import org.jfrog.hudson.pipeline.declarative.utils.DeclarativePipelineUtils;
@@ -44,7 +44,7 @@ public class SignReleaseBundleStep extends AbstractStepImpl {
         this.storingRepo = storingRepo;
     }
 
-    public static class Execution extends ArtifactorySynchronousStepExecution<Void> {
+    public static class Execution extends ArtifactorySynchronousNonBlockingStepExecution<Void> {
 
         private final transient SignReleaseBundleStep step;
 
@@ -64,7 +64,7 @@ public class SignReleaseBundleStep extends AbstractStepImpl {
         }
 
         @Override
-        public org.jfrog.hudson.ArtifactoryServer getUsageReportServer() throws Exception {
+        public org.jfrog.hudson.ArtifactoryServer getUsageReportServer() {
             return null;
         }
 

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/distribution/UpdateReleaseBundleStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/distribution/UpdateReleaseBundleStep.java
@@ -4,7 +4,7 @@ import com.google.inject.Inject;
 import hudson.Extension;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.jfrog.hudson.pipeline.ArtifactorySynchronousStepExecution;
+import org.jfrog.hudson.pipeline.ArtifactorySynchronousNonBlockingStepExecution;
 import org.jfrog.hudson.pipeline.common.executors.ReleaseBundleUpdateExecutor;
 import org.jfrog.hudson.pipeline.common.types.DistributionServer;
 import org.jfrog.hudson.pipeline.declarative.utils.DeclarativePipelineUtils;
@@ -66,7 +66,7 @@ public class UpdateReleaseBundleStep extends CreateUpdateReleaseBundleStep {
         this.dryRun = dryRun;
     }
 
-    public static class Execution extends ArtifactorySynchronousStepExecution<Void> {
+    public static class Execution extends ArtifactorySynchronousNonBlockingStepExecution<Void> {
 
         private final transient UpdateReleaseBundleStep step;
 
@@ -88,7 +88,7 @@ public class UpdateReleaseBundleStep extends CreateUpdateReleaseBundleStep {
         }
 
         @Override
-        public org.jfrog.hudson.ArtifactoryServer getUsageReportServer() throws Exception {
+        public org.jfrog.hudson.ArtifactoryServer getUsageReportServer() {
             return null;
         }
 


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----

Distribution declarative steps are long-running and interruptible and therefore should be [SynchronousNonBlockingStepExecution](https://javadoc.jenkins.io/plugin/workflow-step-api/org/jenkinsci/plugins/workflow/steps/SynchronousNonBlockingStepExecution.html) instead of [SynchronousStepExecution](https://javadoc.jenkins.io/plugin/workflow-step-api/org/jenkinsci/plugins/workflow/steps/SynchronousStepExecution.html).