### PR TITLE
Update plugin parent POM; use plugin BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,8 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.57</version>
+        <version>4.38</version>
+        <relativePath />
     </parent>
 
     <artifactId>artifactory</artifactId>
@@ -104,6 +105,18 @@
         </license>
     </licenses>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.235.x</artifactId>
+                <version>918.vae501d2cdc99</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
@@ -128,33 +141,18 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
-            <version>1.29</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-credentials</artifactId>
-            <version>1.18.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
-            <version>2.12</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>apache-httpcomponents-client-4-api</artifactId>
-            <version>4.5.10-1.0</version>
-            <exclusions>
-                <!-- An updated version of httpcomponents is received from the buildinfo dependency -->
-                <exclusion>
-                    <artifactId>httpcore</artifactId>
-                    <groupId>org.apache.httpcomponents</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>httpclient</artifactId>
-                    <groupId>org.apache.httpcomponents</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -164,7 +162,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>subversion</artifactId>
-            <version>2.15.1</version>
             <optional>true</optional>
             <exclusions>
                 <exclusion>
@@ -181,13 +178,11 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.22</version>
         </dependency>
         <dependency>
             <!-- The git plugin is set as optional due to HAP-771 -->
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>2.5.0</version>
             <optional>true</optional>
             <exclusions>
                 <exclusion>
@@ -199,18 +194,10 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.32</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>script-security</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>mailer</artifactId>
-            <version>1.24</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -226,7 +213,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
-            <version>1.18</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -247,12 +233,10 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.3.19</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>plain-credentials</artifactId>
-            <version>1.3</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -433,18 +417,6 @@
             <version>1.21</version>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-            <version>${slf4jVersion}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4jVersion}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>18.0</version>
@@ -484,32 +456,23 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>parameterized-trigger</artifactId>
+            <version>2.39</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.22</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.43</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>script-security</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-multibranch</artifactId>
-            <version>2.17</version>
             <optional>true</optional>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>script-security</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
@@ -527,7 +490,6 @@
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>jenkins-test-harness</artifactId>
-            <version>2.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -644,7 +606,6 @@
                                     <excludes>
                                         <!-- HAP-211 -->
                                         <exclude>com.thoughtworks.xstream:xstream</exclude>
-                                        <exclude>org.slf4j:slf4j-jdk14:*:jar:compile</exclude>
                                     </excludes>
                                 </bannedDependencies>
                             </rules>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
   This view is used to render the plugin list page.
 

--- a/src/main/resources/org/jfrog/hudson/ArtifactoryBuilder/global.jelly
+++ b/src/main/resources/org/jfrog/hudson/ArtifactoryBuilder/global.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"
          xmlns:f="/lib/form"
          xmlns:st="jelly:stapler"

--- a/src/main/resources/org/jfrog/hudson/ArtifactoryRedeployPublisher/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/ArtifactoryRedeployPublisher/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:r="/lib/jfrog" xmlns:st="jelly:stapler">
     <j:set var="uniqueId" value="${h.generateId()}"/>
     <f:dropdownList name="deployerDetails" title="${%Artifactory server}">

--- a/src/main/resources/org/jfrog/hudson/BuildInfoResultAction/summary.jelly
+++ b/src/main/resources/org/jfrog/hudson/BuildInfoResultAction/summary.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"
          xmlns:t="/lib/hudson">
     <t:summary icon="${it.iconFileName}">

--- a/src/main/resources/org/jfrog/hudson/XrayScanResultAction/summary.jelly
+++ b/src/main/resources/org/jfrog/hudson/XrayScanResultAction/summary.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"
          xmlns:t="/lib/hudson">
     <t:summary icon="${it.iconFileName}">

--- a/src/main/resources/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form"
          xmlns:r="/lib/jfrog" xmlns:st="jelly:stapler">
 

--- a/src/main/resources/org/jfrog/hudson/gradle/ArtifactoryGradleConfigurator/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/gradle/ArtifactoryGradleConfigurator/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--suppress XmlUnusedNamespaceDeclaration -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:r="/lib/jfrog">

--- a/src/main/resources/org/jfrog/hudson/ivy/ArtifactoryIvyConfigurator/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/ivy/ArtifactoryIvyConfigurator/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--suppress XmlUnusedNamespaceDeclaration -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:r="/lib/jfrog" xmlns:c="/lib/credentials">

--- a/src/main/resources/org/jfrog/hudson/ivy/ArtifactoryIvyFreeStyleConfigurator/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/ivy/ArtifactoryIvyFreeStyleConfigurator/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"
          xmlns:f="/lib/form"
          xmlns:r="/lib/jfrog"

--- a/src/main/resources/org/jfrog/hudson/maven3/ArtifactoryMaven3Configurator/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/maven3/ArtifactoryMaven3Configurator/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
   ~ Copyright (C) 2010 JFrog Ltd.
   ~

--- a/src/main/resources/org/jfrog/hudson/maven3/ArtifactoryMaven3NativeConfigurator/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/maven3/ArtifactoryMaven3NativeConfigurator/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:r="/lib/jfrog" xmlns:st="jelly:stapler">
     <j:set var="uniqueId" value="${h.generateId()}"/>
     <f:dropdownList name="resolverDetails" title="${%Artifactory server}">

--- a/src/main/resources/org/jfrog/hudson/maven3/Maven3Builder/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/maven3/Maven3Builder/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
   ~ Copyright (C) 2010 JFrog Ltd.
   ~

--- a/src/main/resources/org/jfrog/hudson/pipeline/action/DeployedGradleArtifactsAction/index.jelly
+++ b/src/main/resources/org/jfrog/hudson/pipeline/action/DeployedGradleArtifactsAction/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form">
     <l:layout title="Gradle Artifacts">
         <st:include it="${it.build}" page="sidepanel.jelly"/>

--- a/src/main/resources/org/jfrog/hudson/pipeline/action/DeployedGradleArtifactsAction/summary.jelly
+++ b/src/main/resources/org/jfrog/hudson/pipeline/action/DeployedGradleArtifactsAction/summary.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"
          xmlns:t="/lib/hudson">
     <j:if test="${!empty it.deployedArtifacts}">

--- a/src/main/resources/org/jfrog/hudson/pipeline/action/DeployedMavenArtifactsAction/index.jelly
+++ b/src/main/resources/org/jfrog/hudson/pipeline/action/DeployedMavenArtifactsAction/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form">
     <l:layout title="Maven Artifacts">
         <st:include it="${it.build}" page="sidepanel.jelly"/>

--- a/src/main/resources/org/jfrog/hudson/pipeline/action/DeployedMavenArtifactsAction/summary.jelly
+++ b/src/main/resources/org/jfrog/hudson/pipeline/action/DeployedMavenArtifactsAction/summary.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"
          xmlns:t="/lib/hudson">
     <j:if test="${!empty it.deployedArtifacts}">

--- a/src/main/resources/org/jfrog/hudson/release/PromoteBuildAction/badge.jelly
+++ b/src/main/resources/org/jfrog/hudson/release/PromoteBuildAction/badge.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
     <j:choose>
         <j:when test="${it.hasPromotionPermission()}">

--- a/src/main/resources/org/jfrog/hudson/release/PromoteBuildAction/progress.jelly
+++ b/src/main/resources/org/jfrog/hudson/release/PromoteBuildAction/progress.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <l:layout norefresh="true">

--- a/src/main/resources/org/jfrog/hudson/release/gradle/GradleReleaseAction/index.jelly
+++ b/src/main/resources/org/jfrog/hudson/release/gradle/GradleReleaseAction/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!-- displays a form to choose the next release and development version and re-schedules a build -->
 <!--suppress XmlUnusedNamespaceDeclaration -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"

--- a/src/main/resources/org/jfrog/hudson/release/maven/MavenReleaseAction/index.jelly
+++ b/src/main/resources/org/jfrog/hudson/release/maven/MavenReleaseAction/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!-- displays a form to choose the next release and development version and re-schedules a build -->
 <!--suppress XmlUnusedNamespaceDeclaration -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"

--- a/src/main/resources/org/jfrog/hudson/release/maven/MavenReleaseWrapper/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/release/maven/MavenReleaseWrapper/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--suppress XmlUnusedNamespaceDeclaration -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">

--- a/src/main/resources/org/jfrog/hudson/trigger/ArtifactoryMultibranchTrigger/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/trigger/ArtifactoryMultibranchTrigger/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:dropdownList name="details" title="${%Artifactory server}">
         <j:forEach var="s" items="${instance.jfrogInstances ?: descriptor.jfrogInstances}" varStatus="loop">

--- a/src/main/resources/org/jfrog/hudson/trigger/ArtifactoryTrigger/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/trigger/ArtifactoryTrigger/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:dropdownList name="details" title="${%Artifactory server}">
         <j:forEach var="s" items="${instance.jfrogInstances ?: descriptor.jfrogInstances}" varStatus="loop">


### PR DESCRIPTION
Updates the build of this plugin to conform to Jenkins best practices:

- Use the latest [plugin parent POM](https://github.com/jenkinsci/plugin-pom)
- Use the [plugin BOM](https://github.com/jenkinsci/bom) corresponding to the Jenkins baseline (2.235.x)

The references to SLF4J can be removed from this plugin, as Jenkins core has bundled SLF4J since at least 2.235.x.

- [x] This pull request is created in
  the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is
  not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jenkins-artifactory-plugin/actions/workflows/analysis.yml)
  passed.