### PR TITLE
Fix #652 by using `pomPath` instead of member variable `pomFile`

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/MavenDescriptorStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/MavenDescriptorStep.java
@@ -139,7 +139,7 @@ public class MavenDescriptorStep extends AbstractStepImpl {
         private void findPomModules(String filePath, String fileName, Map<ModuleName, String> result) {
             Model model;
             String pomPath = filePath + fileName;
-            try (BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(pomFile), StandardCharsets.UTF_8.name()))) {
+            try (BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(pomPath), StandardCharsets.UTF_8.name()))) {
                 MavenXpp3Reader reader = new MavenXpp3Reader();
                 model = reader.read(in);
             } catch (Exception e) {


### PR DESCRIPTION
- [x] This pull request is created in
  the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is
  not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jenkins-artifactory-plugin/actions/workflows/analysis.yml)
  passed.
-----
Unfortunatley, the unit tests that I were able to run locally weren't touching this changed part of the code.