### PR TITLE
Create workspace directories if missing

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/ArtifactorySynchronousNonBlockingStepExecution.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/ArtifactorySynchronousNonBlockingStepExecution.java
@@ -45,11 +45,12 @@ public abstract class ArtifactorySynchronousNonBlockingStepExecution<T> extends 
     @Override
     protected T run() throws Exception {
         try {
+            if (ws != null) {
+                ws.mkdirs();
+            }
             ArtifactoryServer server = getUsageReportServer();
             if (server != null) {
-                new Thread(() -> {
-                    server.reportUsage(getUsageReportFeatureName(), build, new JenkinsBuildInfoLog(listener));
-                }).start();
+                new Thread(() -> server.reportUsage(getUsageReportFeatureName(), build, new JenkinsBuildInfoLog(listener))).start();
             }
             return runStep();
         } finally {

--- a/src/main/java/org/jfrog/hudson/pipeline/ArtifactorySynchronousStepExecution.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/ArtifactorySynchronousStepExecution.java
@@ -45,11 +45,12 @@ public abstract class ArtifactorySynchronousStepExecution<T> extends Synchronous
     @Override
     protected T run() throws Exception {
         try {
+            if (ws != null) {
+                ws.mkdirs();
+            }
             ArtifactoryServer server = getUsageReportServer();
             if (server != null) {
-                new Thread(() -> {
-                    server.reportUsage(getUsageReportFeatureName(), build, new JenkinsBuildInfoLog(listener));
-                }).start();
+                new Thread(() -> server.reportUsage(getUsageReportFeatureName(), build, new JenkinsBuildInfoLog(listener))).start();
             }
             return runStep();
         } finally {


### PR DESCRIPTION
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jenkins-artifactory-plugin/actions/workflows/analysis.yml)
  passed.
-----

Fix the following issue:
> java.io.IOException: Process working directory '/Users/yahavi/.jenkins/workspace/maven-bug' doesn't exist!
	at hudson.Proc$LocalProc.<init>(Proc.java:252)
	at hudson.Proc$LocalProc.<init>(Proc.java:223)
	at hudson.Launcher$LocalLauncher.launch(Launcher.java:997)
	at hudson.Launcher$ProcStarter.start(Launcher.java:509)
	at hudson.Launcher$ProcStarter.join(Launcher.java:520)
	at org.jfrog.hudson.pipeline.common.Utils.launch(Utils.java:278)
Caused: java.lang.RuntimeException: Maven build failed. Couldn't execute Maven task. IOException: Process working directory '/Users/yahavi/.jenkins/workspace/maven-bug' doesn't exist!
	at org.jfrog.hudson.pipeline.common.Utils.launch(Utils.java:285)
	at org.jfrog.hudson.maven3.Maven3Builder.RunMaven(Maven3Builder.java:121)
	at org.jfrog.hudson.maven3.Maven3Builder.perform(Maven3Builder.java:116)

Step to reproduce: Run Maven project without git.