### PR TITLE
Add CopyOnWriteArrayList to SetModules in buildInfoDeployer

### DIFF
--- a/src/main/java/org/jfrog/hudson/maven2/MavenBuildInfoDeployer.java
+++ b/src/main/java/org/jfrog/hudson/maven2/MavenBuildInfoDeployer.java
@@ -45,6 +45,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Builds the build info. This class is used only when the Maven 3 extractor is not active.
@@ -72,7 +73,7 @@ public class MavenBuildInfoDeployer extends AbstractBuildInfoDeployer {
 
     private void gatherModuleAndDependencyInfo(MavenModuleSetBuild mavenModulesBuild) {
         Map<MavenModule, MavenBuild> mavenBuildMap = mavenModulesBuild.getModuleLastBuilds();
-        List<Module> modules = new ArrayList<>();
+        List<Module> modules = new CopyOnWriteArrayList<>();
         for (Map.Entry<MavenModule, MavenBuild> moduleBuild : mavenBuildMap.entrySet()) {
             MavenModule mavenModule = moduleBuild.getKey();
             MavenBuild mavenBuild = moduleBuild.getValue();

--- a/src/main/java/org/jfrog/hudson/pipeline/common/BuildInfoDeployer.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/BuildInfoDeployer.java
@@ -49,7 +49,7 @@ public class BuildInfoDeployer extends AbstractBuildInfoDeployer {
             buildInfo.setStartedDate(deployedBuildInfo.getStartDate());
         }
 
-        buildInfo.setModules(new CopyOnWriteArrayList<Module>(deployedBuildInfo.getModules()));
+        buildInfo.setModules(deployedBuildInfo.getModules());
 
         if (StringUtils.isNotEmpty(deployedBuildInfo.getName())) {
             buildInfo.setName(deployedBuildInfo.getName());

--- a/src/main/java/org/jfrog/hudson/pipeline/common/BuildInfoDeployer.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/BuildInfoDeployer.java
@@ -2,7 +2,6 @@ package org.jfrog.hudson.pipeline.common;
 
 import hudson.model.Run;
 import hudson.model.TaskListener;
-import jenkins.model.Jenkins;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jfrog.build.extractor.builder.BuildInfoBuilder;
@@ -14,12 +13,11 @@ import org.jfrog.build.extractor.clientConfiguration.client.artifactory.Artifact
 import org.jfrog.hudson.AbstractBuildInfoDeployer;
 import org.jfrog.hudson.BuildInfoResultAction;
 import org.jfrog.hudson.pipeline.common.types.buildInfo.BuildInfo;
-import org.jfrog.hudson.util.plugins.PluginsUtils;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
 /**
@@ -51,7 +49,7 @@ public class BuildInfoDeployer extends AbstractBuildInfoDeployer {
             buildInfo.setStartedDate(deployedBuildInfo.getStartDate());
         }
 
-        buildInfo.setModules(new ArrayList<Module>(deployedBuildInfo.getModules()));
+        buildInfo.setModules(new CopyOnWriteArrayList<Module>(deployedBuildInfo.getModules()));
 
         if (StringUtils.isNotEmpty(deployedBuildInfo.getName())) {
             buildInfo.setName(deployedBuildInfo.getName());

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/buildInfo/BuildInfo.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/buildInfo/BuildInfo.java
@@ -59,7 +59,7 @@ public class BuildInfo implements Serializable {
     private BuildRetention retention;
     // The candidates artifacts to be deployed in the 'deployArtifacts' step, sorted by module name.
     private Map<String, List<DeployDetails>> deployableArtifactsByModule = new ConcurrentHashMap<>();
-    private List<Vcs> vcs = new ArrayList<>();
+    private List<Vcs> vcs = new CopyOnWriteArrayList<>();
     private List<Module> modules = new CopyOnWriteArrayList<>();
     private Env env = new Env();
     private Issues issues = new Issues();


### PR DESCRIPTION
- [x] This pull request is created in
  the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is
  not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jenkins-artifactory-plugin/actions/workflows/analysis.yml)
  passed.
-----
SetModules uses an ordinary ArrayList and may throw ConcurrentModificationException.
To fix this, this PR adds CopyOnWriteArrayList instead.