### PR TITLE
Remove Cause.UserIdCause

### DIFF
--- a/src/main/java/org/jfrog/hudson/AbstractBuildInfoDeployer.java
+++ b/src/main/java/org/jfrog/hudson/AbstractBuildInfoDeployer.java
@@ -82,13 +82,13 @@ public class AbstractBuildInfoDeployer {
         if (userCause != null) {
             builder.principal(userCause);
         }
-
-        Cause.UpstreamCause parent = ActionableHelper.getUpstreamCause(build);
-        if (parent != null) {
-            String parentProject = ExtractorUtils.sanitizeBuildName(parent.getUpstreamProject());
-            int parentNumber = parent.getUpstreamBuild();
-            builder.parentName(parentProject);
-            builder.parentNumber(parentNumber + "");
+        String project = ActionableHelper.getUpstreamProject(build);
+        if (StringUtils.isNotBlank(project)) {
+            builder.parentName(project);
+            Integer parentNumber = ActionableHelper.getUpstreamBuild(build);
+            if (parentNumber != null){
+                builder.parentNumber(parentNumber + "");
+            }
             if (StringUtils.isBlank(userCause)) {
                 builder.principal("auto");
             }
@@ -131,11 +131,6 @@ public class AbstractBuildInfoDeployer {
         }
 
         BuildInfo buildInfo = builder.build();
-        // for backwards compatibility for Artifactory 2.2.3
-        if (parent != null) {
-            buildInfo.setParentName(parent.getUpstreamProject());
-        }
-
         return buildInfo;
     }
 

--- a/src/main/java/org/jfrog/hudson/action/ActionableHelper.java
+++ b/src/main/java/org/jfrog/hudson/action/ActionableHelper.java
@@ -171,20 +171,18 @@ public abstract class ActionableHelper implements Serializable {
      * @return The user id caused triggered the build of default principal if not found
      */
     public static String getUserCausePrincipal(Run build, String defaultPrincipal) {
-        Cause.UserIdCause userCause = getUserCause(build);
-        String principal = defaultPrincipal;
-        if (userCause != null && userCause.getUserId() != null) {
-            principal = userCause.getUserId();
+        String principal = getUserCause(build);
+        if (principal == null || StringUtils.isAllEmpty(principal)) {
+           return defaultPrincipal;
         }
         return principal;
     }
 
-    private static Cause.UserIdCause getUserCause(Run build) {
-        CauseAction action = ActionableHelper.getLatestAction(build, CauseAction.class);
-        if (action != null) {
-            for (Cause cause : action.getCauses()) {
+    private static String getUserCause(Run build) {
+        if (ActionableHelper.getLatestAction(build, CauseAction.class) != null) {
+            for (Cause cause : ActionableHelper.getLatestAction(build, CauseAction.class).getCauses()) {
                 if (cause instanceof Cause.UserIdCause) {
-                    return (Cause.UserIdCause) cause;
+                    return ((Cause.UserIdCause) cause).getUserId();
                 }
             }
         }

--- a/src/main/java/org/jfrog/hudson/action/ActionableHelper.java
+++ b/src/main/java/org/jfrog/hudson/action/ActionableHelper.java
@@ -145,16 +145,30 @@ public abstract class ActionableHelper implements Serializable {
         return result;
     }
 
-    public static Cause.UpstreamCause getUpstreamCause(Run build) {
-        CauseAction action = ActionableHelper.getLatestAction(build, CauseAction.class);
-        if (action != null) {
-            for (Cause cause : action.getCauses()) {
+
+    /**
+     * During pipeline run, jenkins tried to serialize the pipeline state, therefore, Cause.UserIdCause should not be assigned to a local variable.
+     * In order to get Cause.UserIdCause properties, use the getter below.
+     * @param build
+     * @return
+     */
+    private static Cause.UpstreamCause getUpstreamCause(Run build) {
+        if (ActionableHelper.getLatestAction(build, CauseAction.class) != null) {
+            for (Cause cause : ActionableHelper.getLatestAction(build, CauseAction.class).getCauses()) {
                 if (cause instanceof Cause.UpstreamCause) {
                     return (Cause.UpstreamCause) cause;
                 }
             }
         }
         return null;
+    }
+
+    public static String getUpstreamProject(Run build) {
+        return ActionableHelper.getUpstreamCause(build) != null ? ActionableHelper.getUpstreamCause(build).getUpstreamProject() : null;
+    }
+
+    public static Integer getUpstreamBuild(Run build) {
+        return ActionableHelper.getUpstreamCause(build) != null ? ActionableHelper.getUpstreamCause(build).getUpstreamBuild() : null;
     }
 
     /**
@@ -172,10 +186,7 @@ public abstract class ActionableHelper implements Serializable {
      */
     public static String getUserCausePrincipal(Run build, String defaultPrincipal) {
         String principal = getUserCause(build);
-        if (principal == null || StringUtils.isAllEmpty(principal)) {
-           return defaultPrincipal;
-        }
-        return principal;
+        return StringUtils.isBlank(principal) ? defaultPrincipal : principal;
     }
 
     private static String getUserCause(Run build) {

--- a/src/main/java/org/jfrog/hudson/jfpipelines/Utils.java
+++ b/src/main/java/org/jfrog/hudson/jfpipelines/Utils.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class Utils {
     /**
@@ -136,7 +137,7 @@ public class Utils {
      */
     @SuppressFBWarnings(value = "SE_BAD_FIELD")
     public static Map<String, String> createJobInfo(Run<?, ?> build) {
-        Cause.UserIdCause cause = build.getCause(Cause.UserIdCause.class);
+        String user = Objects.requireNonNull(build.getCause(Cause.UserIdCause.class)).getUserId();
         return new HashMap<String, String>() {{
             put("job-name", build.getParent().getName());
             put("job-number", String.valueOf(build.getNumber()));
@@ -145,8 +146,8 @@ public class Utils {
                 put("duration", String.valueOf(build.getDuration()));
             }
             put("build-url", build.getParent().getAbsoluteUrl() + build.getNumber());
-            if (cause != null) {
-                put("user", cause.getUserId());
+            if (user != null) {
+                put("user", user);
             }
         }};
     }

--- a/src/main/java/org/jfrog/hudson/jfpipelines/Utils.java
+++ b/src/main/java/org/jfrog/hudson/jfpipelines/Utils.java
@@ -18,7 +18,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
+import static org.jfrog.hudson.action.ActionableHelper.getUserCausePrincipal;
 
 public class Utils {
     /**
@@ -137,7 +137,6 @@ public class Utils {
      */
     @SuppressFBWarnings(value = "SE_BAD_FIELD")
     public static Map<String, String> createJobInfo(Run<?, ?> build) {
-        String user = Objects.requireNonNull(build.getCause(Cause.UserIdCause.class)).getUserId();
         return new HashMap<String, String>() {{
             put("job-name", build.getParent().getName());
             put("job-number", String.valueOf(build.getNumber()));
@@ -146,7 +145,8 @@ public class Utils {
                 put("duration", String.valueOf(build.getDuration()));
             }
             put("build-url", build.getParent().getAbsoluteUrl() + build.getNumber());
-            if (user != null) {
+            String user = getUserCausePrincipal(build, null);
+            if (StringUtils.isNotBlank(user)) {
                 put("user", user);
             }
         }};

--- a/src/main/java/org/jfrog/hudson/maven2/ArtifactsDeployer.java
+++ b/src/main/java/org/jfrog/hudson/maven2/ArtifactsDeployer.java
@@ -180,10 +180,13 @@ public class ArtifactsDeployer {
             builder.addProperty(BuildInfoFields.BUILD_ROOT, identifier);
         }
 
-        Cause.UpstreamCause parent = ActionableHelper.getUpstreamCause(mavenModuleSetBuild);
-        if (parent != null) {
-            builder.addProperty(BuildInfoFields.BUILD_PARENT_NAME, ExtractorUtils.sanitizeBuildName(parent.getUpstreamProject()))
-                    .addProperty(BuildInfoFields.BUILD_PARENT_NUMBER, parent.getUpstreamBuild() + "");
+        String upstreamProject = ActionableHelper.getUpstreamProject(mavenModuleSetBuild);
+        if (StringUtils.isNotBlank(upstreamProject)) {
+            builder.addProperty(BuildInfoFields.BUILD_PARENT_NAME, ExtractorUtils.sanitizeBuildName(upstreamProject));
+            Integer upstreamBuild = ActionableHelper.getUpstreamBuild(mavenModuleSetBuild);
+            if (upstreamBuild != null) {
+                builder.addProperty(BuildInfoFields.BUILD_PARENT_NUMBER, upstreamBuild + "");
+            }
         }
         String revision = ExtractorUtils.getVcsRevision(env);
         if (StringUtils.isNotBlank(revision)) {

--- a/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
@@ -413,7 +413,7 @@ public class Utils {
     public static void addParentBuildProps(ArrayListMultimap<String, String> properties, Run build) {
         String buildName = ActionableHelper.getUpstreamProject(build);
         if (StringUtils.isBlank(buildName)) {
-        return;
+            return;
         }
         properties.put(BuildInfoFields.BUILD_PARENT_NAME, ExtractorUtils.sanitizeBuildName(buildName));
         Integer buildNumber = ActionableHelper.getUpstreamBuild(build);

--- a/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
@@ -411,10 +411,14 @@ public class Utils {
     }
 
     public static void addParentBuildProps(ArrayListMultimap<String, String> properties, Run build) {
-        Cause.UpstreamCause parent = ActionableHelper.getUpstreamCause(build);
-        if (parent != null) {
-            properties.put(BuildInfoFields.BUILD_PARENT_NAME, ExtractorUtils.sanitizeBuildName(parent.getUpstreamProject()));
-            properties.put(BuildInfoFields.BUILD_PARENT_NUMBER, parent.getUpstreamBuild() + "");
+        String buildName = ActionableHelper.getUpstreamProject(build);
+        if (StringUtils.isBlank(buildName)) {
+        return;
+        }
+        properties.put(BuildInfoFields.BUILD_PARENT_NAME, ExtractorUtils.sanitizeBuildName(buildName));
+        Integer buildNumber = ActionableHelper.getUpstreamBuild(build);
+        if (buildNumber != null) {
+            properties.put(BuildInfoFields.BUILD_PARENT_NUMBER, buildNumber+ "");
         }
     }
 

--- a/src/main/java/org/jfrog/hudson/util/BuildUniqueIdentifierHelper.java
+++ b/src/main/java/org/jfrog/hudson/util/BuildUniqueIdentifierHelper.java
@@ -3,6 +3,7 @@ package org.jfrog.hudson.util;
 import hudson.matrix.Combination;
 import hudson.matrix.MatrixRun;
 import hudson.model.*;
+import org.apache.commons.lang3.StringUtils;
 import org.jfrog.hudson.ArtifactoryRedeployPublisher;
 import org.jfrog.hudson.BuildInfoAwareConfigurator;
 import org.jfrog.hudson.action.ActionableHelper;
@@ -48,20 +49,23 @@ public class BuildUniqueIdentifierHelper {
     }
 
     private static AbstractBuild<?, ?> getUpstreamBuild(AbstractBuild<?, ?> build) {
-        AbstractBuild<?, ?> upstreamBuild;
-        Cause.UpstreamCause cause = ActionableHelper.getUpstreamCause(build);
-        if (cause == null) {
+        String project = ActionableHelper.getUpstreamProject(build);
+        if (StringUtils.isBlank(project)) {
             return null;
         }
-        AbstractProject<?, ?> upstreamProject = getProject(cause.getUpstreamProject());
+        AbstractProject<?, ?> upstreamProject = getProject(project);
         if (upstreamProject == null) {
-            debuggingLogger.fine("No project found answering for the name: " + cause.getUpstreamProject());
+            debuggingLogger.fine("No project found answering for the name: " + project);
             return null;
         }
-        upstreamBuild = upstreamProject.getBuildByNumber(cause.getUpstreamBuild());
+        Integer buildNumber = ActionableHelper.getUpstreamBuild(build);
+        if (buildNumber == null) {
+            return null;
+        }
+        AbstractBuild<?, ?> upstreamBuild = upstreamProject.getBuildByNumber(buildNumber);
         if (upstreamBuild == null) {
             debuggingLogger.fine(
-                    "No build with name: " + upstreamProject.getName() + " and number: " + cause.getUpstreamBuild());
+                    "No build with name: " + upstreamProject.getName() + " and number: " + buildNumber);
         }
         return upstreamBuild;
     }

--- a/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
@@ -366,14 +366,17 @@ public class ExtractorUtils {
         }
 
         String userName = null;
-        Cause.UpstreamCause parent = ActionableHelper.getUpstreamCause(build);
-        if (parent != null) {
-            String parentProject = sanitizeBuildName(parent.getUpstreamProject());
+        String upstreamProject = ActionableHelper.getUpstreamProject(build);
+        if (StringUtils.isNotBlank(project)) {
+            String parentProject = sanitizeBuildName(upstreamProject);
             configuration.info.setParentBuildName(parentProject);
             configuration.publisher.addMatrixParam(BuildInfoFields.BUILD_PARENT_NAME, parentProject);
-            String parentBuildNumber = parent.getUpstreamBuild() + "";
-            configuration.info.setParentBuildNumber(parentBuildNumber);
-            configuration.publisher.addMatrixParam(BuildInfoFields.BUILD_PARENT_NUMBER, parentBuildNumber);
+            Integer upstreamBuild = ActionableHelper.getUpstreamBuild(build);
+            if(upstreamBuild != null ){
+                String parentBuildNumber = upstreamBuild + "";
+                configuration.info.setParentBuildNumber(parentBuildNumber);
+                configuration.publisher.addMatrixParam(BuildInfoFields.BUILD_PARENT_NUMBER, parentBuildNumber);
+            }
             userName = "auto";
         }
 

--- a/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
@@ -372,7 +372,7 @@ public class ExtractorUtils {
             configuration.info.setParentBuildName(parentProject);
             configuration.publisher.addMatrixParam(BuildInfoFields.BUILD_PARENT_NAME, parentProject);
             Integer upstreamBuild = ActionableHelper.getUpstreamBuild(build);
-            if(upstreamBuild != null ){
+            if (upstreamBuild != null) {
                 String parentBuildNumber = upstreamBuild + "";
                 configuration.info.setParentBuildNumber(parentBuildNumber);
                 configuration.publisher.addMatrixParam(BuildInfoFields.BUILD_PARENT_NUMBER, parentBuildNumber);


### PR DESCRIPTION
- [x] This pull request is created in  the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is  not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jenkins-artifactory-plugin/actions/workflows/analysis.yml)
  passed.
-----
During pipeline run, jenkins tried to serialize the pipeline state to disc which resulted in this exception:
```
java.io.NotSerializableException: hudson.model.Cause$UserIdCause
```
The stack trace doesn't explicitly show the origin of the error, but it was during a call to ConanClient.run() with buildinfo enabled.
```
$ sh -c "conan info [...] -j ./conan_info.json [...] -s build_type=RelWithDebInfo "
JSON file created at '[...]/conan_info.json'
$ sh -c "conan_build_info [...]/conan_log.log --output [...]@2@tmp/artifactory/conan144090164989832600build-info "
```
According to [stackoverflow](https://stackoverflow.com/questions/50050076/jenkins-pipeline-java-io-notserializableexception-hudson-model-user-when-exec/50050466) it is problematic to assign `Cause.UserIdCause` to a local variable, which is done in the plugin.