### PR TITLE
Pom doesn't get deployed using Maven Install plugin 3+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
         <!--Skip integration tests unless explicitly requested with -DskipITs=false-->
         <skipITs>true</skipITs>
 
-        <buildinfo.version>2.37.1</buildinfo.version>
-        <buildinfo.gradle.version>4.29.1</buildinfo.gradle.version>
+        <buildinfo.version>2.37.2</buildinfo.version>
+        <buildinfo.gradle.version>4.29.2</buildinfo.gradle.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
- [x] This pull request is created in
  the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is
  not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jenkins-artifactory-plugin/actions/workflows/analysis.yml)
  passed.
-----

* Update build-info to 2.37.2 / 4.29.2
* Includes the following fix: https://github.com/jfrog/build-info/pull/670
