### PR TITLE
Support Maven opts from jvm.config file

### DIFF
--- a/src/test/resources/integration/maven-example/.mvn/jvm.config
+++ b/src/test/resources/integration/maven-example/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Xmx2048m -Xms1024m -XX:MaxPermSize=512m -Djava.awt.headless=true


### PR DESCRIPTION
- [x] This pull request is created in
  the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is
  not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jenkins-artifactory-plugin/actions/workflows/analysis.yml)
  passed.
-----

Fix #704 

Support reading the Maven options from `$MAVEN_PROJECTBASEDIR/.mvn/jvm.config`. 
Do the same as Maven does: 
https://github.com/apache/maven/blob/master/apache-maven/src/assembly/shared/init.cmd#L89