### PR TITLE
Fix ConcurrentModificationException in UnifiedPromoteBuildAction

### DIFF
--- a/src/main/java/org/jfrog/hudson/release/promotion/UnifiedPromoteBuildAction.java
+++ b/src/main/java/org/jfrog/hudson/release/promotion/UnifiedPromoteBuildAction.java
@@ -35,11 +35,8 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import javax.servlet.ServletException;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.jfrog.hudson.util.SerializationUtils.createMapper;
 
@@ -50,7 +47,7 @@ import static org.jfrog.hudson.util.SerializationUtils.createMapper;
  */
 public class UnifiedPromoteBuildAction extends TaskAction implements BuildBadgeAction {
     private final Run<?, ?> build;
-    private final Map<String, PromotionInfo> promotionCandidates = new HashMap<>();
+    private final Map<String, PromotionInfo> promotionCandidates = new ConcurrentHashMap<>();
     private String targetStatus;
     private String targetRepositoryKey;
     private String sourceRepositoryKey;


### PR DESCRIPTION
- [x] This pull request is created in
  the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is
  not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jenkins-artifactory-plugin/actions/workflows/analysis.yml)
  passed.
-----

Fix the following issue:
```
Caused: java.lang.RuntimeException: Failed to serialize org.jfrog.hudson.release.promotion.UnifiedPromoteBuildAction#promotionCandidates for class org.jfrog.hudson.release.promotion.UnifiedPromoteBuildAction
```

https://www.jfrog.com/jira/browse/HAP-1487?focusedCommentId=218664&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-218664