### PR TITLE
Fix Xray tests

### DIFF
--- a/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
@@ -685,8 +685,7 @@ public class CommonITestsPipeline extends PipelineTestBase {
                 assertNotNull(pipelineResults);
                 logs = pipelineResults.getLog();
             }
-            assertEquals(printTable, logs.contains(SECURITY_VIOLATIONS_TABLE_HEADLINE));
-            assertEquals(printTable, logs.contains(LICENSE_VIOLATIONS_TABLE_HEADLINE));
+            assertEquals(printTable, logs.contains("To review the Xray scan results, see the Xray Violations tab in the UI."));
             cleanupBuilds(pipelineResults, buildName, null, BUILD_NUMBER);
         }
     }


### PR DESCRIPTION
- [x] This pull request is created in
  the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is
  not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jenkins-artifactory-plugin/actions/workflows/analysis.yml)
  passed.
-----

The Xray results when failBuild=false are no longer available in the build log.