### PR TITLE
Support excluding build info module properties

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/buildInfo/BuildInfo.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/buildInfo/BuildInfo.java
@@ -21,6 +21,8 @@ import org.jfrog.build.extractor.ci.Dependency;
 import org.jfrog.build.extractor.ci.Module;
 import org.jfrog.build.extractor.ci.Vcs;
 import org.jfrog.build.client.DeployableArtifactDetail;
+import org.jfrog.build.extractor.clientConfiguration.IncludeExcludePatterns;
+import org.jfrog.build.extractor.clientConfiguration.PatternMatcher;
 import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;
 import org.jfrog.build.extractor.clientConfiguration.deploy.DeployDetails;
 import org.jfrog.build.extractor.clientConfiguration.deploy.DeployableArtifactsUtils;
@@ -352,7 +354,10 @@ public class BuildInfo implements Serializable {
     }
 
     public void filterVariables() {
-        this.getEnv().filter();
+        IncludeExcludePatterns pattern = this.getEnv().filter();
+        for (Module module : modules) {
+            module.getProperties().entrySet().removeIf(key -> PatternMatcher.pathConflicts(key.getKey().toString(), pattern));
+        }
     }
 
     public void captureVariables(EnvVars envVars, Run build, TaskListener listener) {

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/buildInfo/BuildInfo.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/buildInfo/BuildInfo.java
@@ -354,9 +354,14 @@ public class BuildInfo implements Serializable {
     }
 
     public void filterVariables() {
+        // Filter env variables.
         IncludeExcludePatterns pattern = this.getEnv().filter();
+        // Filter module properties.
         for (Module module : modules) {
-            module.getProperties().entrySet().removeIf(key -> PatternMatcher.pathConflicts(key.getKey().toString(), pattern));
+            Properties properties = module.getProperties();
+            if (properties != null) {
+                properties.entrySet().removeIf(key -> PatternMatcher.pathConflicts(key.getKey().toString(), pattern));
+            }
         }
     }
 

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/buildInfo/Env.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/buildInfo/Env.java
@@ -67,12 +67,15 @@ public class Env implements Serializable {
     }
 
     /**
-     * Filter environment variable before publish the build info
+     * Filter environment variables before publishing the build info.
+     *
+     * @return the include/exclude pattern
      */
-    public void filter() {
+    public IncludeExcludePatterns filter() {
         IncludeExcludePatterns pattern = filter.getPatternFilter();
         this.envVars.entrySet().removeIf(key -> PatternMatcher.pathConflicts(key.getKey(), pattern));
         this.sysVars.entrySet().removeIf(key -> PatternMatcher.pathConflicts(key.getKey(), pattern));
+        return pattern;
     }
 
     /**

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/CommonITestsPipeline.java
@@ -321,6 +321,8 @@ public class CommonITestsPipeline extends PipelineTestBase {
 
             Module module = getAndAssertModule(buildInfo, "org.jfrog.test:multi:3.7-SNAPSHOT");
             assertModuleArtifacts(module, expectedArtifacts);
+            String[] moduleExcludedProp = {"excluded.property.in.pom"};
+            assertFilteredProperties(module.getProperties(), "included.property.in.pom", moduleExcludedProp);
             assertTrue(CollectionUtils.isEmpty(module.getDependencies()));
             assertModuleContainsArtifactsAndDependencies(buildInfo, "org.jfrog.test:multi1:3.7-SNAPSHOT");
             assertModuleContainsArtifactsAndDependencies(buildInfo, "org.jfrog.test:multi2:3.7-SNAPSHOT");

--- a/src/test/java/org/jfrog/hudson/pipeline/integration/ITestUtils.java
+++ b/src/test/java/org/jfrog/hudson/pipeline/integration/ITestUtils.java
@@ -243,15 +243,26 @@ class ITestUtils {
      * @param buildInfo - Build-info object
      */
     static void assertFilteredProperties(BuildInfo buildInfo) {
-        Properties properties = buildInfo.getProperties();
+        String[] excludedProps = {"password", "psw", "secret", "key", "token", "DONT_COLLECT"};
+        assertFilteredProperties(buildInfo.getProperties(), "buildInfo.env.COLLECT", excludedProps);
+    }
+
+    /**
+     * Assert that properties were included/excluded as expected.
+     *
+     * @param properties    - Properties object
+     * @param includedProp  - expected included prop
+     * @param excludedProps - expected excluded props
+     */
+    static void assertFilteredProperties(Properties properties, String includedProp, String[] excludedProps) {
         assertNotNull(properties);
         String[] unfiltered = properties.keySet().stream()
                 .map(Object::toString)
                 .map(String::toLowerCase)
-                .filter(key -> StringUtils.containsAny(key, "password", "psw", "secret", "key", "token", "DONT_COLLECT"))
+                .filter(key -> StringUtils.containsAny(key, excludedProps))
                 .toArray(String[]::new);
-        assertTrue("The following environment variables should have been filtered: " + Arrays.toString(unfiltered), ArrayUtils.isEmpty(unfiltered));
-        assertTrue(properties.containsKey("buildInfo.env.COLLECT"));
+        assertTrue("The following properties should have been filtered: " + Arrays.toString(unfiltered), ArrayUtils.isEmpty(unfiltered));
+        assertTrue(properties.containsKey(includedProp));
     }
 
     /**

--- a/src/test/resources/integration/maven-example/pom.xml
+++ b/src/test/resources/integration/maven-example/pom.xml
@@ -17,6 +17,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <excluded.property.in.pom>should-ignore</excluded.property.in.pom>
+        <included.property.in.pom>should-collect</included.property.in.pom>
     </properties>
 
     <dependencies>

--- a/src/test/resources/integration/maven-example/pom.xml
+++ b/src/test/resources/integration/maven-example/pom.xml
@@ -17,8 +17,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <excluded.property.in.pom>should-ignore</excluded.property.in.pom>
-        <included.property.in.pom>should-collect</included.property.in.pom>
+        <included.property.in.pom>should-include</included.property.in.pom>
+        <excluded.property.in.pom>should-exclude</excluded.property.in.pom>
+        <password>should-exclude</password>
     </properties>
 
     <dependencies>

--- a/src/test/resources/integration/pipelines/declarative/maven.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/maven.pipeline
@@ -45,7 +45,7 @@ node("TestSlave") {
                 buildName: buildName,
                 buildNumber: buildNumber,
                 captureEnv: true,
-                excludeEnvPatterns: ["DONT_COLLECT"]
+                excludeEnvPatterns: ["DONT_COLLECT","excluded.property.in.pom"]
         )
     }
 

--- a/src/test/resources/integration/pipelines/declarative/mavenWrapper.pipeline
+++ b/src/test/resources/integration/pipelines/declarative/mavenWrapper.pipeline
@@ -45,7 +45,7 @@ node("TestSlave") {
                 buildName: buildName,
                 buildNumber: buildNumber,
                 captureEnv: true,
-                excludeEnvPatterns: ["DONT_COLLECT"]
+                excludeEnvPatterns: ["DONT_COLLECT","excluded.property.in.pom"]
         )
     }
 

--- a/src/test/resources/integration/pipelines/scripted/maven.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/maven.pipeline
@@ -12,6 +12,7 @@ node("TestSlave")  {
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")
+    buildInfo.env.filter.addExclude("excluded.property.in.pom")
     buildInfo.name = "scripted:maven test"
     buildInfo.number = ${BUILD_NUMBER}
 

--- a/src/test/resources/integration/pipelines/scripted/mavenWrapper.pipeline
+++ b/src/test/resources/integration/pipelines/scripted/mavenWrapper.pipeline
@@ -12,6 +12,7 @@ node("TestSlave")  {
     def buildInfo = Artifactory.newBuildInfo()
     buildInfo.env.capture = true
     buildInfo.env.filter.addExclude("DONT_COLLECT")
+    buildInfo.env.filter.addExclude("excluded.property.in.pom")
     buildInfo.name = "scripted:mavenWrapper test"
     buildInfo.number = ${BUILD_NUMBER}
 


### PR DESCRIPTION
- [x] This pull request is created in
  the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is
  not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jenkins-artifactory-plugin/actions/workflows/analysis.yml)
  passed.
-----
Use the include/exclude env patterns to also include/exclude build info module properties.