### PR TITLE
Escape non-ascii and more special characters in vcs properties (#737)

### DIFF
--- a/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
@@ -70,7 +70,7 @@ public class ExtractorUtils {
     public static final String GIT_BRANCH = "GIT_BRANCH";
     public static final String GIT_MESSAGE = "GIT_MESSAGE";
 
-    private final static Set<Character> PROPERTIES_SPECIAL_CHARS = new HashSet<>(Arrays.asList('|', ',', ';', '='));
+    private final static Set<Character> PROPERTIES_SPECIAL_CHARS = new HashSet<>(Arrays.asList('|', ',', ';', '=', '/', '?', '#', '[', ']', '@', '!', '$', '&', '\'', '(', ')', '*', '+', '%', '"'));
 
     private ExtractorUtils() {
         // utility class
@@ -159,8 +159,8 @@ public class ExtractorUtils {
             if (c == '\\') {
                 // Next char already escaped
                 escaped = true;
-            } else if (PROPERTIES_SPECIAL_CHARS.contains(c) && !escaped) {
-                // Special char but not escaped
+            } else if ((c > 127 || PROPERTIES_SPECIAL_CHARS.contains(c)) && !escaped) {
+                // Handle unescaped non-ascii or special char
                 builder.append("\\");
             } else {
                 escaped = false;

--- a/src/test/java/org/jfrog/hudson/util/EscapePropertyTest.java
+++ b/src/test/java/org/jfrog/hudson/util/EscapePropertyTest.java
@@ -23,6 +23,7 @@ public class EscapePropertyTest {
                 {"test \\\\ test", "test \\\\ test"},
                 {"id | tests = test1,test2;", "id \\| tests \\= test1\\,test2\\;"},
                 {"id \\| tests = test1,test2\\;", "id \\| tests \\= test1\\,test2\\;"},
+                {"/?#[]@!$&'()*+=%\"\u0080", "\\/\\?\\#\\[\\]\\@\\!\\$\\&\\'\\(\\)\\*\\+\\=\\%\\\"\\\u0080"},
         });
     }
 


### PR DESCRIPTION
- [x] This pull request is created in
  the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is
  not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jenkins-artifactory-plugin/actions/workflows/analysis.yml)
  passed.
-----

Builds on #756 by escaping more special characters as well as non-ASCII characters. Should fix #737.
