### PR TITLE
Revert "Make the Maven plugin optional (#749)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,6 @@
                     <groupId>org.apache.commons</groupId>
                 </exclusion>
             </exclusions>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
This reverts commit b52b11b5b01b972f260db20d73757c5321e82f75.

- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jenkins-artifactory-plugin/actions/workflows/analysis.yml)
  passed.
-----

Fix https://github.com/jfrog/jenkins-artifactory-plugin/issues/845
