### PR TITLE
Modernize plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,8 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.57</version>
+        <version>4.0</version>
+        <relativePath />
     </parent>
 
     <artifactId>artifactory</artifactId>
@@ -43,6 +44,7 @@
 
         <buildinfo.version>2.41.3</buildinfo.version>
         <buildinfo.gradle.version>4.33.3</buildinfo.gradle.version>
+        <slf4jVersion>2.0.7</slf4jVersion>
     </properties>
 
     <repositories>
@@ -75,6 +77,19 @@
         </repository>
     </repositories>
 
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <name>central</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+        </pluginRepository>
+        <pluginRepository>
+            <id>jenkins</id>
+            <name>jenkins-releases</name>
+            <url>https://repo.jenkins-ci.org/releases</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <developers>
         <developer>
             <id>eyalb</id>
@@ -103,6 +118,18 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.8.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -414,6 +441,11 @@
             <version>${buildinfo.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+            <version>4.1.79.Final</version>
+        </dependency>
+        <dependency>
             <groupId>org.jfrog.buildinfo</groupId>
             <artifactId>build-info-extractor-nuget</artifactId>
             <version>${buildinfo.version}</version>
@@ -530,7 +562,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
When I started, the master branch did not build.

<details>
  <summary>Error</summary>
  
  ```
❯ mvn verify
[INFO] Scanning for projects...
[WARNING] The POM for org.jenkins-ci.tools:maven-hpi-plugin:jar:3.12 is missing, no dependency information available
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[ERROR] Unresolveable build extension: Plugin org.jenkins-ci.tools:maven-hpi-plugin:3.12 or one of its dependencies could not be resolved: org.jenkins-ci.tools:maven-hpi-plugin:jar:3.12 was not found in https://repo.maven.apache.org/maven2 during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of central has elapsed or updates are forced @
[ERROR] Unknown packaging: hpi @ line 29, column 16
 @
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]
[ERROR]   The project org.jenkins-ci.plugins:artifactory:3.18.x-SNAPSHOT (/Users/rsomasunderam/src/gh/jfrog/jenkins-artifactory-plugin/pom.xml) has 2 errors
[ERROR]     Unresolveable build extension: Plugin org.jenkins-ci.tools:maven-hpi-plugin:3.12 or one of its dependencies could not be resolved: org.jenkins-ci.tools:maven-hpi-plugin:jar:3.12 was not found in https://repo.maven.apache.org/maven2 during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of central has elapsed or updates are forced -> [Help 2]
[ERROR]     Unknown packaging: hpi @ line 29, column 16
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
[ERROR] [Help 2] http://cwiki.apache.org/confluence/display/MAVEN/PluginManagerException
```
</details>

This change gets the build working.

- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jenkins-artifactory-plugin/actions/workflows/analysis.yml)
  passed.
-----
