### PR TITLE
Revert "Escape non-ascii and more special characters in vcs properties (#737)"

### DIFF
--- a/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
@@ -70,7 +70,7 @@ public class ExtractorUtils {
     public static final String GIT_BRANCH = "GIT_BRANCH";
     public static final String GIT_MESSAGE = "GIT_MESSAGE";
 
-    private final static Set<Character> PROPERTIES_SPECIAL_CHARS = new HashSet<>(Arrays.asList('|', ',', ';', '=', '/', '?', '#', '[', ']', '@', '!', '$', '&', '\'', '(', ')', '*', '+', '%', '"'));
+    private final static Set<Character> PROPERTIES_SPECIAL_CHARS = new HashSet<>(Arrays.asList('|', ',', ';', '='));
 
     private ExtractorUtils() {
         // utility class
@@ -159,8 +159,8 @@ public class ExtractorUtils {
             if (c == '\\') {
                 // Next char already escaped
                 escaped = true;
-            } else if ((c > 127 || PROPERTIES_SPECIAL_CHARS.contains(c)) && !escaped) {
-                // Handle unescaped non-ascii or special char
+            } else if (PROPERTIES_SPECIAL_CHARS.contains(c) && !escaped) {
+                // Special char but not escaped
                 builder.append("\\");
             } else {
                 escaped = false;

--- a/src/test/java/org/jfrog/hudson/util/EscapePropertyTest.java
+++ b/src/test/java/org/jfrog/hudson/util/EscapePropertyTest.java
@@ -23,7 +23,6 @@ public class EscapePropertyTest {
                 {"test \\\\ test", "test \\\\ test"},
                 {"id | tests = test1,test2;", "id \\| tests \\= test1\\,test2\\;"},
                 {"id \\| tests = test1,test2\\;", "id \\| tests \\= test1\\,test2\\;"},
-                {"/?#[]@!$&'()*+=%\"\u0080", "\\/\\?\\#\\[\\]\\@\\!\\$\\&\\'\\(\\)\\*\\+\\=\\%\\\"\\\u0080"},
         });
     }
 


### PR DESCRIPTION
Reverts jfrog/jenkins-artifactory-plugin#765

As mentioned by @davies147 in #827, this change seems to worsen the problem that it intended to fix.