### PR TITLE
Encrypt build info properties file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <!--Skip integration tests unless explicitly requested with -DskipITs=false-->
         <skipITs>true</skipITs>
 
-        <buildinfo.version>2.41.8</buildinfo.version>
+        <buildinfo.version>2.41.9</buildinfo.version>
         <buildinfo.gradle.version>5.1.12</buildinfo.gradle.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <skipITs>true</skipITs>
 
         <buildinfo.version>2.41.11</buildinfo.version>
-        <buildinfo.gradle.version>5.1.12</buildinfo.gradle.version>
+        <buildinfo.gradle.version>5.1.13</buildinfo.gradle.version>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <skipITs>true</skipITs>
 
         <buildinfo.version>2.41.x-SNAPSHOT</buildinfo.version>
-        <buildinfo.gradle.version>5.0.x-SNAPSHOT</buildinfo.gradle.version>
+        <buildinfo.gradle.version>5.1.10</buildinfo.gradle.version>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <!--Skip integration tests unless explicitly requested with -DskipITs=false-->
         <skipITs>true</skipITs>
 
-        <buildinfo.version>2.41.9</buildinfo.version>
+        <buildinfo.version>2.41.11</buildinfo.version>
         <buildinfo.gradle.version>5.1.12</buildinfo.gradle.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
         <!--Skip integration tests unless explicitly requested with -DskipITs=false-->
         <skipITs>true</skipITs>
 
-        <buildinfo.version>2.41.x-SNAPSHOT</buildinfo.version>
-        <buildinfo.gradle.version>5.1.10</buildinfo.gradle.version>
+        <buildinfo.version>2.41.8</buildinfo.version>
+        <buildinfo.gradle.version>5.1.12</buildinfo.gradle.version>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
         <!--Skip integration tests unless explicitly requested with -DskipITs=false-->
         <skipITs>true</skipITs>
 
-        <buildinfo.version>2.41.7</buildinfo.version>
-        <buildinfo.gradle.version>5.1.10</buildinfo.gradle.version>
+        <buildinfo.version>2.41.x-SNAPSHOT</buildinfo.version>
+        <buildinfo.gradle.version>5.0.x-SNAPSHOT</buildinfo.gradle.version>
     </properties>
 
     <repositories>

--- a/src/main/java/org/jfrog/hudson/gradle/ArtifactoryGradleConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/gradle/ArtifactoryGradleConfigurator.java
@@ -492,7 +492,7 @@ public class ArtifactoryGradleConfigurator extends BuildWrapper implements Deplo
 
                 try {
                     ExtractorUtils.addBuilderInfoArguments(env, build, listener,
-                            finalPublisherBuilder.build(), resolverContext, build.getWorkspace(), launcher);
+                            finalPublisherBuilder.build(), resolverContext, build.getWorkspace(), launcher, useArtifactoryGradlePlugin);
                 } catch (Exception e) {
                     log.println(e.getMessage());
                     throw new RuntimeException(e);

--- a/src/main/java/org/jfrog/hudson/ivy/ArtifactoryIvyConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/ivy/ArtifactoryIvyConfigurator.java
@@ -303,7 +303,7 @@ public class ArtifactoryIvyConfigurator extends AntIvyBuildWrapper implements De
             @Override
             public void buildEnvVars(Map<String, String> env) {
                 try {
-                    ExtractorUtils.addBuilderInfoArguments(env, build, listener, context, null, build.getWorkspace(), launcher);
+                    ExtractorUtils.addBuilderInfoArguments(env, build, listener, context, null, build.getWorkspace(), launcher, false);
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }

--- a/src/main/java/org/jfrog/hudson/ivy/ArtifactoryIvyFreeStyleConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/ivy/ArtifactoryIvyFreeStyleConfigurator.java
@@ -321,7 +321,7 @@ public class ArtifactoryIvyFreeStyleConfigurator extends BuildWrapper implements
                 try {
                     String actualDependencyDirPath = actualDependencyDirPath(build, launcher);
                     env.put("ARTIFACTORY_CACHE_LIBS", actualDependencyDirPath);
-                    ExtractorUtils.addBuilderInfoArguments(env, build, listener, finalPublisherContext, null, build.getWorkspace(), launcher);
+                    ExtractorUtils.addBuilderInfoArguments(env, build, listener, finalPublisherContext, null, build.getWorkspace(), launcher, false);
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }

--- a/src/main/java/org/jfrog/hudson/maven3/ArtifactoryMaven3Configurator.java
+++ b/src/main/java/org/jfrog/hudson/maven3/ArtifactoryMaven3Configurator.java
@@ -402,7 +402,7 @@ public class ArtifactoryMaven3Configurator extends BuildWrapper implements Deplo
             @Override
             public void buildEnvVars(Map<String, String> env) {
                 try {
-                    ExtractorUtils.addBuilderInfoArguments(env, build, listener, publisherContext, resolverContext, build.getWorkspace(), launcher);
+                    ExtractorUtils.addBuilderInfoArguments(env, build, listener, publisherContext, resolverContext, build.getWorkspace(), launcher, false);
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }

--- a/src/main/java/org/jfrog/hudson/maven3/extractor/MavenExtractorEnvironment.java
+++ b/src/main/java/org/jfrog/hudson/maven3/extractor/MavenExtractorEnvironment.java
@@ -138,7 +138,7 @@ public class MavenExtractorEnvironment extends Environment {
                 }
 
                 ArtifactoryClientConfiguration configuration = ExtractorUtils.addBuilderInfoArguments(
-                        env, build, buildListener, publisherContext, resolverContext, build.getWorkspace(), launcher);
+                        env, build, buildListener, publisherContext, resolverContext, build.getWorkspace(), launcher, false);
                 propertiesFilePath = configuration.getPropertiesFile();
             } catch (Exception e) {
                 throw new RuntimeException(e);

--- a/src/main/java/org/jfrog/hudson/pipeline/common/executors/EnvExtractor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/executors/EnvExtractor.java
@@ -35,7 +35,7 @@ public abstract class EnvExtractor implements Executor {
     private Launcher launcher;
     private FilePath tempDir;
     private EnvVars env;
-    protected boolean skipEncryption;
+    private final boolean skipEncryption;
 
     public EnvExtractor(Run build, BuildInfo buildInfo, Deployer publisher, Resolver resolver, TaskListener buildListener, Launcher launcher, FilePath tempDir, EnvVars env) {
         this(build, buildInfo, publisher, resolver, buildListener, launcher, tempDir, env, false);

--- a/src/main/java/org/jfrog/hudson/pipeline/common/executors/EnvExtractor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/executors/EnvExtractor.java
@@ -35,6 +35,7 @@ public abstract class EnvExtractor implements Executor {
     private Launcher launcher;
     private FilePath tempDir;
     private EnvVars env;
+    protected boolean skipEncryption;
 
     public EnvExtractor(Run build, BuildInfo buildInfo, Deployer publisher, Resolver resolver, TaskListener buildListener, Launcher launcher, FilePath tempDir, EnvVars env) {
         this.build = build;
@@ -87,7 +88,7 @@ public abstract class EnvExtractor implements Executor {
     }
 
     public void persistConfiguration(ArtifactoryClientConfiguration configuration) throws IOException, InterruptedException {
-        ExtractorUtils.persistConfiguration(configuration, env, tempDir, launcher);
+        ExtractorUtils.persistConfiguration(configuration, env, tempDir, launcher, skipEncryption);
         String propertiesFilePath = configuration.getPropertiesFile();
         env.put(BuildInfoConfigProperties.PROP_PROPS_FILE, propertiesFilePath);
     }

--- a/src/main/java/org/jfrog/hudson/pipeline/common/executors/EnvExtractor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/executors/EnvExtractor.java
@@ -38,6 +38,10 @@ public abstract class EnvExtractor implements Executor {
     protected boolean skipEncryption;
 
     public EnvExtractor(Run build, BuildInfo buildInfo, Deployer publisher, Resolver resolver, TaskListener buildListener, Launcher launcher, FilePath tempDir, EnvVars env) {
+        this(build, buildInfo, publisher, resolver, buildListener, launcher, tempDir, env, false);
+    }
+
+    public EnvExtractor(Run build, BuildInfo buildInfo, Deployer publisher, Resolver resolver, TaskListener buildListener, Launcher launcher, FilePath tempDir, EnvVars env, boolean skipEncryption) {
         this.build = build;
         this.buildInfo = buildInfo;
         this.buildListener = buildListener;
@@ -46,6 +50,7 @@ public abstract class EnvExtractor implements Executor {
         this.launcher = launcher;
         this.tempDir = tempDir;
         this.env = env;
+        this.skipEncryption = skipEncryption;
     }
 
     protected abstract void addExtraConfiguration(ArtifactoryClientConfiguration configuration);

--- a/src/main/java/org/jfrog/hudson/pipeline/common/executors/GradleExecutor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/executors/GradleExecutor.java
@@ -69,7 +69,7 @@ public class GradleExecutor implements Executor {
         ExtractorUtils.addVcsDetailsToEnv(new FilePath(ws, rootDir), extendedEnv, listener);
         tempDir = ExtractorUtils.createAndGetTempDir(ws);
         EnvExtractor envExtractor = new MavenGradleEnvExtractor(build,
-                buildInfo, deployer, gradleBuild.getResolver(), listener, launcher, tempDir, extendedEnv);
+                buildInfo, deployer, gradleBuild.getResolver(), listener, launcher, tempDir, extendedEnv, this.gradleBuild.isUsesPlugin());
         envExtractor.execute();
         ArgumentListBuilder args = getGradleExecutor();
         Utils.launch("Gradle", launcher, args, extendedEnv, listener, ws);

--- a/src/main/java/org/jfrog/hudson/pipeline/common/executors/GradleExecutor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/executors/GradleExecutor.java
@@ -69,7 +69,7 @@ public class GradleExecutor implements Executor {
         ExtractorUtils.addVcsDetailsToEnv(new FilePath(ws, rootDir), extendedEnv, listener);
         tempDir = ExtractorUtils.createAndGetTempDir(ws);
         EnvExtractor envExtractor = new MavenGradleEnvExtractor(build,
-                buildInfo, deployer, gradleBuild.getResolver(), listener, launcher, tempDir, extendedEnv, this.gradleBuild.isUsesPlugin());
+                buildInfo, deployer, gradleBuild.getResolver(), listener, launcher, tempDir, extendedEnv, gradleBuild.isUsesPlugin());
         envExtractor.execute();
         ArgumentListBuilder args = getGradleExecutor();
         Utils.launch("Gradle", launcher, args, extendedEnv, listener, ws);

--- a/src/main/java/org/jfrog/hudson/pipeline/common/executors/MavenExecutor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/executors/MavenExecutor.java
@@ -55,7 +55,7 @@ public class MavenExecutor implements Executor {
         ExtractorUtils.addVcsDetailsToEnv(new FilePath(ws, pom), extendedEnv, listener);
         FilePath tempDir = ExtractorUtils.createAndGetTempDir(ws);
         EnvExtractor envExtractor = new MavenGradleEnvExtractor(build,
-                buildInfo, deployer, mavenBuild.getResolver(), listener, launcher, tempDir, extendedEnv);
+                buildInfo, deployer, mavenBuild.getResolver(), listener, launcher, tempDir, extendedEnv, false);
         envExtractor.execute();
         String stepOpts = mavenBuild.getOpts();
         String mavenOpts = stepOpts + (

--- a/src/main/java/org/jfrog/hudson/pipeline/common/executors/MavenGradleEnvExtractor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/executors/MavenGradleEnvExtractor.java
@@ -16,8 +16,7 @@ import org.jfrog.hudson.pipeline.common.types.resolvers.Resolver;
 public class MavenGradleEnvExtractor extends EnvExtractor {
 
     public MavenGradleEnvExtractor(Run build, BuildInfo buildInfo, Deployer publisher, Resolver resolver, TaskListener buildListener, Launcher launcher, FilePath tempDir, EnvVars env, boolean skipEncryption) {
-        super(build, buildInfo, publisher, resolver, buildListener, launcher, tempDir, env);
-        this.skipEncryption = skipEncryption;
+        super(build, buildInfo, publisher, resolver, buildListener, launcher, tempDir, env, skipEncryption);
     }
 
     @Override

--- a/src/main/java/org/jfrog/hudson/pipeline/common/executors/MavenGradleEnvExtractor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/executors/MavenGradleEnvExtractor.java
@@ -15,8 +15,9 @@ import org.jfrog.hudson.pipeline.common.types.resolvers.Resolver;
  */
 public class MavenGradleEnvExtractor extends EnvExtractor {
 
-    public MavenGradleEnvExtractor(Run build, BuildInfo buildInfo, Deployer publisher, Resolver resolver, TaskListener buildListener, Launcher launcher, FilePath tempDir, EnvVars env) {
+    public MavenGradleEnvExtractor(Run build, BuildInfo buildInfo, Deployer publisher, Resolver resolver, TaskListener buildListener, Launcher launcher, FilePath tempDir, EnvVars env, boolean skipEncryption) {
         super(build, buildInfo, publisher, resolver, buildListener, launcher, tempDir, env);
+        this.skipEncryption = skipEncryption;
     }
 
     @Override

--- a/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
@@ -594,13 +594,9 @@ public class ExtractorUtils {
 
     private static void savePropertiesToFile(ArtifactoryClientConfiguration configuration, FilePath propertiesFile,
                                              Map<String, String> env, hudson.Launcher launcher, boolean skipEncryption) {
-        OutputStream outputStream = null;
-        try {
-            if (isSlaveEnvironment(launcher)) {
-                outputStream = Files.newOutputStream(new File(configuration.getPropertiesFile()).getCanonicalFile().toPath());
-            } else {
-                outputStream = propertiesFile.write();
-            }
+        try (OutputStream outputStream = isSlaveEnvironment(launcher) ?
+                Files.newOutputStream(new File(configuration.getPropertiesFile()).getCanonicalFile().toPath()) :
+                propertiesFile.write()) {
             if (skipEncryption) {
                 configuration.persistToPropertiesFile();
             } else {
@@ -611,10 +607,6 @@ public class ExtractorUtils {
         } catch (IOException | InterruptedException | InvalidAlgorithmParameterException | NoSuchPaddingException |
                  IllegalBlockSizeException | NoSuchAlgorithmException | BadPaddingException | InvalidKeyException e) {
             throw new RuntimeException(e);
-        } finally {
-            if (outputStream != null) {
-                IOUtils.closeQuietly(outputStream);
-            }
         }
     }
 

--- a/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
@@ -56,15 +56,20 @@ import org.jfrog.hudson.util.plugins.MultiConfigurationUtils;
 import org.jfrog.hudson.util.publisher.PublisherContext;
 
 import javax.annotation.Nullable;
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.file.Files;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -603,7 +608,8 @@ public class ExtractorUtils {
                 env.put(BuildInfoConfigProperties.PROP_PROPS_FILE_KEY, keyPair.getStringSecretKey());
                 env.put(BuildInfoConfigProperties.PROP_PROPS_FILE_KEY_IV, keyPair.getStringIv());
             }
-        } catch (IOException | InterruptedException e) {
+        } catch (IOException | InterruptedException | InvalidAlgorithmParameterException | NoSuchPaddingException |
+                 IllegalBlockSizeException | NoSuchAlgorithmException | BadPaddingException | InvalidKeyException e) {
             throw new RuntimeException(e);
         } finally {
             if (outputStream != null) {

--- a/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
@@ -40,6 +40,7 @@ import org.jfrog.build.extractor.ci.Vcs;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
 import org.jfrog.build.extractor.clientConfiguration.ClientProperties;
 import org.jfrog.build.extractor.clientConfiguration.IncludeExcludePatterns;
+import org.jfrog.build.extractor.clientConfiguration.util.encryption.EncryptionKeyPair;
 import org.jfrog.build.extractor.clientConfiguration.util.spec.SpecsHelper;
 import org.jfrog.hudson.ArtifactoryServer;
 import org.jfrog.hudson.CredentialsConfig;
@@ -598,8 +599,9 @@ public class ExtractorUtils {
             if (skipEncryption) {
                 configuration.persistToPropertiesFile();
             } else {
-                byte[] key = configuration.persistToEncryptedPropertiesFile(outputStream);
-                env.put(BuildInfoConfigProperties.PROP_PROPS_FILE_KEY, Base64.getEncoder().encodeToString((key)));
+                EncryptionKeyPair keyPair = configuration.persistToEncryptedPropertiesFile(outputStream);
+                env.put(BuildInfoConfigProperties.PROP_PROPS_FILE_KEY, keyPair.getStringSecretKey());
+                env.put(BuildInfoConfigProperties.PROP_PROPS_FILE_KEY_IV, keyPair.getStringIv());
             }
         } catch (IOException | InterruptedException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
- [ ] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jenkins-artifactory-plugin/actions/workflows/analysis.yml)
  passed.
-----
Encrypt build info properties file except when gradle uses plugins

Dependence on: 
* https://github.com/jfrog/artifactory-gradle-plugin/pull/94
* https://github.com/jfrog/build-info/pull/766
* https://github.com/jfrog/build-info/pull/769
* https://github.com/jfrog/build-info/pull/771