### PR TITLE
Write buildInfo.property file to agent (slave) instead of master FS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <!--Skip integration tests unless explicitly requested with -DskipITs=false-->
         <skipITs>true</skipITs>
 
-        <buildinfo.version>2.41.12</buildinfo.version>
+        <buildinfo.version>2.41.14</buildinfo.version>
         <buildinfo.gradle.version>5.1.14</buildinfo.gradle.version>
     </properties>
 

--- a/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
@@ -584,7 +584,7 @@ public class ExtractorUtils {
                                              Map<String, String> env, boolean skipEncryption) {
         try (OutputStream outputStream = propertiesFile.write()) {
             if (skipEncryption) {
-                configuration.persistToPropertiesFile();
+                configuration.persistToPropertiesFile(outputStream);
             } else {
                 EncryptionKeyPair keyPair = configuration.persistToEncryptedPropertiesFile(outputStream);
                 env.put(ENV_PROPERTIES_FILE_KEY, keyPair.getStringSecretKey());


### PR DESCRIPTION
- [ ] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jenkins-artifactory-plugin/actions/workflows/analysis.yml)
  passed.
-----
In the case we have a Windows Master and Linux Slaves, using `usesPlugin` flag, the buildinfo.properties file would get generated in master instead of agent/slave. 

it turned out that `.getCanonicalFile` [here](https://github.com/jfrog/build-info/blob/963f6918308c0900a4e74bc6905029b6dff8e3b7/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java#L241), makes the buildinfo.properties file path of the master filesystem instead of the slave/agent.

We passed the same stream as encrypting the file to resolve this issue.

Depends on:
* https://github.com/jfrog/build-info/pull/784