### PR TITLE
Upgrade dependencies required for jersey2-api plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <!-- Minimal version required by Pipeline dependencies in 2.14.0 -->
-        <jenkins.version>2.235.5</jenkins.version>
+        <jenkins.version>2.249.3</jenkins.version>
         <java.level>8</java.level>
         <!-- TODO: enforcer is full of upper bound dependency issues, including real ones -->
         <enforcer.skip>true</enforcer.skip>
@@ -537,6 +537,12 @@
             <version>2.4.21</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>jersey2-api</artifactId>
+            <version>2.35-1</version>
+        </dependency>
+
         <!--Tests-->
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -595,6 +595,22 @@
         <!--/Tests-->
     </dependencies>
 
+    <!-- TODO: can be removed when upgraded in org.mock-server.mockserver-netty -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>1.77</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>1.77</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -540,7 +540,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>jersey2-api</artifactId>
-            <version>2.35-1</version>
+            <version>2.35-8</version>
         </dependency>
 
         <!--Tests-->

--- a/pom.xml
+++ b/pom.xml
@@ -600,7 +600,7 @@
         <!--/Tests-->
     </dependencies>
 
-    <!-- TODO: can be removed when upgraded in org.mock-server.mockserver-netty -->
+    <!-- TODO: Remove this section when transitive dependencies are upgraded in our direct dependency org.mock-server.mockserver-netty -->
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -600,7 +600,7 @@
         <!--/Tests-->
     </dependencies>
 
-    <!-- TODO: Remove this section when transitive dependencies are upgraded in our direct dependency org.mock-server.mockserver-netty -->
+    <!-- TODO: Remove this section when these transitive dependencies are upgraded in our direct dependency org.mock-server.mockserver-netty -->
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <!-- Minimal version required by Pipeline dependencies in 2.14.0 -->
-        <jenkins.version>2.249.3</jenkins.version>
+        <jenkins.version>2.263.1</jenkins.version>
         <java.level>8</java.level>
         <!-- TODO: enforcer is full of upper bound dependency issues, including real ones -->
         <enforcer.skip>true</enforcer.skip>
@@ -143,7 +143,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>apache-httpcomponents-client-4-api</artifactId>
-            <version>4.5.10-1.0</version>
+            <version>4.5.13-1.0</version>
             <exclusions>
                 <!-- An updated version of httpcomponents is received from the buildinfo dependency -->
                 <exclusion>
@@ -541,6 +541,11 @@
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>jersey2-api</artifactId>
             <version>2.35-8</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jackson2-api</artifactId>
+            <version>2.13.2.20220328-281.v9ecc7a_5e834f</version>
         </dependency>
 
         <!--Tests-->

--- a/pom.xml
+++ b/pom.xml
@@ -543,11 +543,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>io.jenkins.plugins</groupId>
-            <artifactId>jersey2-api</artifactId>
-            <version>2.35-8</version>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jackson2-api</artifactId>
             <version>2.13.2.20220328-281.v9ecc7a_5e834f</version>

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/buildInfo/Env.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/buildInfo/Env.java
@@ -28,10 +28,10 @@ public class Env implements Serializable {
 
     private static final String apiKeySecretPrefix = "AKCp8";
     private static final int apiKeySecretMinimalLength = 73;
-    // jfrog-ignore
+    // jfrog-ignore - Prefix used to identify a reference token
     private static final String referenceTokenSecretPrefix = "cmVmdGtuOjAxOj";
     private static final int referenceTokenSecretMinimalLength = 64;
-    // jfrog-ignore
+    // jfrog-ignore - Prefix used to identify an access token
     private static final String accessTokenSecretPrefix = "eyJ2ZXIiOiIyIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYiLCJraWQiOiJ";
     private static final int accessTokenSecretMinimalLength = 0;
 

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/buildInfo/Env.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/buildInfo/Env.java
@@ -28,8 +28,10 @@ public class Env implements Serializable {
 
     private static final String apiKeySecretPrefix = "AKCp8";
     private static final int apiKeySecretMinimalLength = 73;
+    // jfrog-ignore
     private static final String referenceTokenSecretPrefix = "cmVmdGtuOjAxOj";
     private static final int referenceTokenSecretMinimalLength = 64;
+    // jfrog-ignore
     private static final String accessTokenSecretPrefix = "eyJ2ZXIiOiIyIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYiLCJraWQiOiJ";
     private static final int accessTokenSecretMinimalLength = 0;
 


### PR DESCRIPTION
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jenkins-artifactory-plugin/actions/workflows/analysis.yml)
  passed.
-----
Upgrade dependencies required after jersey2 introduction in #838 