### PR TITLE
switch to java 11

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Install Java
         uses: actions/setup-java@v3
         with:
-          java-version: "8"
+          java-version: "11"
           distribution: "temurin"
 
       - name: Configure Linux runner

--- a/.github/workflows/frogbot-scan-pr.yml
+++ b/.github/workflows/frogbot-scan-pr.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: "8"
+          java-version: "11"
           distribution: "temurin"
 
       - uses: jfrog/frogbot@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Java
         uses: actions/setup-java@v3
         with:
-          java-version: "8"
+          java-version: "11"
           distribution: "temurin"
 
       - name: Install NuGet


### PR DESCRIPTION
the workflows need to run on Java11 to be able to support new features and updates / fixes to the plugin.
eg.  #935 

this will be expected to fail as I am not an admin of this repo and should not have access to make these changes.
can either be merged by an admin with a prayer, or recreated by an admin and tested there.

- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jenkins-artifactory-plugin/actions/workflows/analysis.yml)
  passed.
-----
