### PR TITLE
Reduce usage of Guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
         <!--Skip integration tests unless explicitly requested with -DskipITs=false-->
         <skipITs>true</skipITs>
 
-        <buildinfo.version>2.41.14</buildinfo.version>
-        <buildinfo.gradle.version>5.1.14</buildinfo.gradle.version>
+        <buildinfo.version>2.41.21</buildinfo.version>
+        <buildinfo.gradle.version>5.2.2</buildinfo.gradle.version>
     </properties>
 
     <repositories>
@@ -425,13 +425,18 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.8.0</version>
+            <version>2.14.0</version>
         </dependency>
         <dependency>
             <!-- commons-compress is in use in the Go extractor -->
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.21</version>
+            <version>1.26.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.14.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
@@ -1,7 +1,6 @@
 package org.jfrog.hudson.pipeline.common;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ArrayListMultimap;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -27,6 +26,8 @@ import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jfrog.build.api.multiMap.Multimap;
+import org.jfrog.build.api.multiMap.SetMultimap;
 import org.jfrog.build.api.util.Log;
 import org.jfrog.build.client.ProxyConfiguration;
 import org.jfrog.build.extractor.ci.BuildInfoFields;
@@ -390,8 +391,8 @@ public class Utils {
         return ProxyUtils.createProxyConfiguration();
     }
 
-    public static ArrayListMultimap<String, String> getPropertiesMap(BuildInfo buildInfo, Run build, StepContext context) throws IOException, InterruptedException {
-        ArrayListMultimap<String, String> properties = ArrayListMultimap.create();
+    public static Multimap<String, String> getPropertiesMap(BuildInfo buildInfo, Run build, StepContext context) throws IOException, InterruptedException {
+        Multimap<String, String> properties = new SetMultimap<>();
 
         if (buildInfo.getName() != null) {
             properties.put(BuildInfoFields.BUILD_NAME, buildInfo.getName());
@@ -410,7 +411,7 @@ public class Utils {
         return properties;
     }
 
-    public static void addParentBuildProps(ArrayListMultimap<String, String> properties, Run build) {
+    public static void addParentBuildProps(Multimap<String, String> properties, Run build) {
         String buildName = ActionableHelper.getUpstreamProject(build);
         if (StringUtils.isBlank(buildName)) {
             return;
@@ -418,11 +419,11 @@ public class Utils {
         properties.put(BuildInfoFields.BUILD_PARENT_NAME, ExtractorUtils.sanitizeBuildName(buildName));
         Integer buildNumber = ActionableHelper.getUpstreamBuild(build);
         if (buildNumber != null) {
-            properties.put(BuildInfoFields.BUILD_PARENT_NUMBER, buildNumber+ "");
+            properties.put(BuildInfoFields.BUILD_PARENT_NUMBER, buildNumber + "");
         }
     }
 
-    public static void addVcsDetailsToProps(EnvVars env, ArrayListMultimap<String, String> properties) {
+    public static void addVcsDetailsToProps(EnvVars env, Multimap<String, String> properties) {
         String revision = ExtractorUtils.getVcsRevision(env);
         if (isNotBlank(revision)) {
             properties.put(BuildInfoFields.VCS_REVISION, revision);
@@ -439,10 +440,6 @@ public class Utils {
         if (isNotBlank(gitMessage)) {
             properties.put(BuildInfoFields.VCS_MESSAGE, gitMessage);
         }
-    }
-
-    public static String replaceTildeWithUserHome(String path) {
-        return path.replaceFirst("^~", System.getProperty("user.home"));
     }
 
     /**

--- a/src/main/java/org/jfrog/hudson/pipeline/common/executors/DockerPushExecutor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/executors/DockerPushExecutor.java
@@ -1,12 +1,12 @@
 package org.jfrog.hudson.pipeline.common.executors;
 
-import com.google.common.collect.ArrayListMultimap;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import org.apache.commons.lang3.StringUtils;
+import org.jfrog.build.api.multiMap.Multimap;
 import org.jfrog.hudson.pipeline.common.types.ArtifactoryServer;
 import org.jfrog.hudson.pipeline.common.types.buildInfo.BuildInfo;
 import org.jfrog.hudson.pipeline.common.types.deployers.CommonDeployer;
@@ -18,9 +18,9 @@ public class DockerPushExecutor extends BuildInfoProcessRunner {
     private String imageTag;
     private String targetRepo;
     private String host;
-    private ArrayListMultimap<String, String> properties;
+    private Multimap<String, String> properties;
 
-    public DockerPushExecutor(ArtifactoryServer pipelineServer, BuildInfo buildInfo, Run build, String imageTag, String targetRepo, String host, String javaArgs, Launcher launcher, ArrayListMultimap<String, String> properties, TaskListener listener, FilePath ws, EnvVars envVars) {
+    public DockerPushExecutor(ArtifactoryServer pipelineServer, BuildInfo buildInfo, Run build, String imageTag, String targetRepo, String host, String javaArgs, Launcher launcher, Multimap<String, String> properties, TaskListener listener, FilePath ws, EnvVars envVars) {
         super(buildInfo, launcher, javaArgs, ws, "", "", envVars, listener, build);
         this.server = pipelineServer;
         this.imageTag = imageTag;

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/Docker.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/Docker.java
@@ -1,8 +1,9 @@
 package org.jfrog.hudson.pipeline.common.types;
 
-import com.google.common.collect.ArrayListMultimap;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
+import org.jfrog.build.api.multiMap.ListMultimap;
+import org.jfrog.build.api.multiMap.Multimap;
 import org.jfrog.hudson.pipeline.common.types.buildInfo.BuildInfo;
 
 import java.io.Serializable;
@@ -23,7 +24,7 @@ public class Docker implements Serializable {
     private String host;
     private String javaArgs;
     // Properties to attach to the deployed docker layers.
-    private ArrayListMultimap<String, String> properties = ArrayListMultimap.create();
+    private Multimap<String, String> properties = new ListMultimap<>();
     private ArtifactoryServer server;
 
     public Docker() {

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/buildInfo/BuildInfo.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/buildInfo/BuildInfo.java
@@ -1,7 +1,6 @@
 package org.jfrog.hudson.pipeline.common.types.buildInfo;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ArrayListMultimap;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.model.Run;
@@ -12,15 +11,13 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
+import org.jfrog.build.api.multiMap.ListMultimap;
+import org.jfrog.build.api.multiMap.Multimap;
+import org.jfrog.build.api.multiMap.SetMultimap;
+import org.jfrog.build.client.DeployableArtifactDetail;
 import org.jfrog.build.extractor.builder.BuildInfoBuilder;
 import org.jfrog.build.extractor.builder.ModuleBuilder;
-import org.jfrog.build.extractor.ci.Artifact;
-import org.jfrog.build.extractor.ci.BaseBuildFileBean;
-import org.jfrog.build.extractor.ci.BuildInfoProperties;
-import org.jfrog.build.extractor.ci.Dependency;
-import org.jfrog.build.extractor.ci.Module;
-import org.jfrog.build.extractor.ci.Vcs;
-import org.jfrog.build.client.DeployableArtifactDetail;
+import org.jfrog.build.extractor.ci.*;
 import org.jfrog.build.extractor.clientConfiguration.IncludeExcludePatterns;
 import org.jfrog.build.extractor.clientConfiguration.PatternMatcher;
 import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;
@@ -33,16 +30,7 @@ import org.jfrog.hudson.util.BuildUniqueIdentifierHelper;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
@@ -377,7 +365,7 @@ public class BuildInfo implements Serializable {
         @Deprecated
         private String backwardCompatibleDeployableArtifactsPath;
         private TaskListener listener;
-        private ArrayListMultimap<String, String> propertiesMap;
+        private Multimap<String, String> propertiesMap;
         private final DeployDetails.PackageType packageType;
 
         DeployPathsAndPropsCallable(String deployableArtifactsPath, String backwardCompatibleDeployableArtifactsPath, TaskListener listener, BuildInfo buildInfo, DeployDetails.PackageType packageType) {
@@ -418,8 +406,8 @@ public class BuildInfo implements Serializable {
             }
         }
 
-        private ArrayListMultimap<String, String> getDeployableArtifactPropertiesMap(DeployableArtifactDetail artifact) {
-            ArrayListMultimap<String, String> properties = ArrayListMultimap.create();
+        private Multimap<String, String> getDeployableArtifactPropertiesMap(DeployableArtifactDetail artifact) {
+            Multimap<String, String> properties = new SetMultimap<>();
             if (MapUtils.isEmpty(artifact.getProperties())) {
                 // For backward computability, returns the necessary build info props if no props exists
                 // in DeployableArtifactDetail
@@ -433,8 +421,8 @@ public class BuildInfo implements Serializable {
             return properties;
         }
 
-        private ArrayListMultimap<String, String> getBuildPropertiesMap(BuildInfo buildInfo) {
-            ArrayListMultimap<String, String> properties = ArrayListMultimap.create();
+        private Multimap<String, String> getBuildPropertiesMap(BuildInfo buildInfo) {
+            Multimap<String, String> properties = new ListMultimap<>();
             properties.put("build.name", buildInfo.getName());
             properties.put("build.number", buildInfo.getNumber());
             properties.put("build.timestamp", buildInfo.getStartDate().getTime() + "");

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/deployers/Deployer.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/deployers/Deployer.java
@@ -1,7 +1,6 @@
 package org.jfrog.hudson.pipeline.common.types.deployers;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.collect.ArrayListMultimap;
 import hudson.FilePath;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -10,12 +9,14 @@ import jenkins.MasterToSlaveFileCallable;
 import org.apache.commons.io.FilenameUtils;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
-import org.jfrog.build.extractor.ci.Artifact;
-import org.jfrog.build.extractor.ci.Module;
+import org.jfrog.build.api.multiMap.ListMultimap;
+import org.jfrog.build.api.multiMap.Multimap;
 import org.jfrog.build.api.util.FileChecksumCalculator;
 import org.jfrog.build.api.util.Log;
 import org.jfrog.build.client.ProxyConfiguration;
 import org.jfrog.build.extractor.ModuleParallelDeployHelper;
+import org.jfrog.build.extractor.ci.Artifact;
+import org.jfrog.build.extractor.ci.Module;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryManagerBuilder;
 import org.jfrog.build.extractor.clientConfiguration.PatternMatcher;
 import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;
@@ -39,13 +40,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static org.jfrog.build.extractor.ModuleParallelDeployHelper.DEFAULT_DEPLOYMENT_THREADS;
 import static org.jfrog.hudson.pipeline.common.types.deployers.GradleDeployer.addDeployedGradleArtifactsToAction;
@@ -57,7 +52,7 @@ import static org.jfrog.hudson.pipeline.common.types.deployers.MavenDeployer.add
 public abstract class Deployer implements DeployerOverrider, Serializable {
     private boolean deployArtifacts = true;
     private boolean includeEnvVars;
-    private ArrayListMultimap<String, String> properties = ArrayListMultimap.create();
+    private Multimap<String, String> properties = new ListMultimap<>();
     private Filter artifactDeploymentPatterns = new Filter();
     private String customBuildName = "";
     private int threads = DEFAULT_DEPLOYMENT_THREADS;
@@ -118,11 +113,11 @@ public abstract class Deployer implements DeployerOverrider, Serializable {
         return this;
     }
 
-    public ArrayListMultimap<String, String> getProperties() {
+    public Multimap<String, String> getProperties() {
         return this.properties;
     }
 
-    public void setProperties(ArrayListMultimap<String, String> properties) {
+    public void setProperties(Multimap<String, String> properties) {
         this.properties = properties;
     }
 

--- a/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/docker/DockerPushStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/docker/DockerPushStep.java
@@ -1,11 +1,12 @@
 package org.jfrog.hudson.pipeline.declarative.steps.docker;
 
-import com.google.common.collect.ArrayListMultimap;
 import com.google.inject.Inject;
 import hudson.Extension;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jfrog.build.api.multiMap.ListMultimap;
+import org.jfrog.build.api.multiMap.Multimap;
 import org.jfrog.hudson.ArtifactoryServer;
 import org.jfrog.hudson.pipeline.ArtifactorySynchronousNonBlockingStepExecution;
 import org.jfrog.hudson.pipeline.common.Utils;
@@ -25,7 +26,7 @@ import java.io.IOException;
 @SuppressWarnings("unused")
 public class DockerPushStep extends AbstractStepImpl {
     static final String STEP_NAME = "rtDockerPush";
-    private final ArrayListMultimap<String, String> properties = ArrayListMultimap.create();
+    private final Multimap<String, String> properties = new ListMultimap<>();
     private final String serverId;
     private final String image;
     private final String targetRepo;

--- a/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/DockerPushStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/DockerPushStep.java
@@ -1,12 +1,12 @@
 package org.jfrog.hudson.pipeline.scripted.steps;
 
-import com.google.common.collect.ArrayListMultimap;
 import com.google.inject.Inject;
 import hudson.Extension;
 import org.apache.commons.cli.MissingArgumentException;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jfrog.build.api.multiMap.Multimap;
 import org.jfrog.hudson.pipeline.ArtifactorySynchronousNonBlockingStepExecution;
 import org.jfrog.hudson.pipeline.common.Utils;
 import org.jfrog.hudson.pipeline.common.executors.DockerPushExecutor;
@@ -26,11 +26,11 @@ public class DockerPushStep extends AbstractStepImpl {
     private String targetRepo;
     private String javaArgs;
     // Properties to attach to the deployed docker layers.
-    private ArrayListMultimap<String, String> properties;
+    private Multimap<String, String> properties;
 
     @DataBoundConstructor
     public DockerPushStep(String image, String host, String targetRepo,
-                          BuildInfo buildInfo, ArrayListMultimap<String, String> properties, ArtifactoryServer server, String javaArgs) {
+                          BuildInfo buildInfo, Multimap<String, String> properties, ArtifactoryServer server, String javaArgs) {
 
         this.image = image;
         this.host = host;
@@ -49,7 +49,7 @@ public class DockerPushStep extends AbstractStepImpl {
         return image;
     }
 
-    public ArrayListMultimap<String, String> getProperties() {
+    public Multimap<String, String> getProperties() {
         return properties;
     }
 
@@ -66,7 +66,7 @@ public class DockerPushStep extends AbstractStepImpl {
     }
 
     public static class Execution extends ArtifactorySynchronousNonBlockingStepExecution<BuildInfo> {
-    protected static final long serialVersionUID = 1L;
+        protected static final long serialVersionUID = 1L;
         private transient DockerPushStep step;
 
         @Inject

--- a/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
@@ -16,7 +16,6 @@
 
 package org.jfrog.hudson.util;
 
-import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
 import hudson.EnvVars;
@@ -30,6 +29,8 @@ import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
+import org.jfrog.build.api.multiMap.ListMultimap;
+import org.jfrog.build.api.multiMap.Multimap;
 import org.jfrog.build.api.util.NullLog;
 import org.jfrog.build.extractor.ci.BuildInfoConfigProperties;
 import org.jfrog.build.extractor.ci.BuildInfoFields;
@@ -600,7 +601,7 @@ public class ExtractorUtils {
                                                 ArtifactoryClientConfiguration.PublisherHandler publisher,
                                                 Map<String, String> env) {
         String deploymentProperties = Util.replaceMacro(context.getDeploymentProperties(), env);
-        ArrayListMultimap<String, String> params = ArrayListMultimap.create();
+        Multimap<String, String> params = new ListMultimap<>();
         SpecsHelper.fillPropertiesMap(deploymentProperties, params);
         publisher.addMatrixParams(params);
     }

--- a/src/main/java/org/jfrog/hudson/util/PropertyUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/PropertyUtils.java
@@ -16,8 +16,6 @@
 
 package org.jfrog.hudson.util;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Util;
@@ -25,6 +23,8 @@ import hudson.remoting.VirtualChannel;
 import jenkins.MasterToSlaveFileCallable;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.jfrog.build.api.multiMap.ListMultimap;
+import org.jfrog.build.api.multiMap.Multimap;
 import org.jfrog.hudson.release.gradle.GradleModule;
 
 import java.io.File;
@@ -56,7 +56,7 @@ public class PropertyUtils {
      * @param gradlePropPath The path of the gradle.properties file
      * @param propKeys       The property keys that should be taken into account when reading the properties file.
      * @return A map of {@link GradleModule}s that were assembled from the properties file, with the version as its
-     *         value.
+     * value.
      * @throws IOException In case an error occurs while reading the properties file, this exception is thrown.
      */
     public static Map<String, String> getModulesPropertiesFromPropFile(FilePath gradlePropPath, String[] propKeys)
@@ -104,7 +104,7 @@ public class PropertyUtils {
     }
 
     public static Multimap<String, String> getDeploymentPropertiesMap(String propertiesStr, EnvVars env) {
-        Multimap<String, String> properties = ArrayListMultimap.create();
+        Multimap<String, String> properties = new ListMultimap<>();
         String[] deploymentProperties = StringUtils.split(propertiesStr, ";");
         if (deploymentProperties == null) {
             return properties;

--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -23,6 +23,9 @@ org.jfrog.build.extractor.ci.Vcs
 org.jfrog.build.extractor.dependency.pattern.BuildDependencyPattern
 org.jfrog.build.extractor.dependency.pattern.DependencyPattern
 org.jfrog.build.api.dependency.BuildDependency
+org.jfrog.build.api.multiMap.ListMultimap
+org.jfrog.build.api.multiMap.Multimap
+org.jfrog.build.api.multiMap.SetMultimap
 org.jfrog.build.extractor.dependency.BuildPatternArtifacts
 org.jfrog.build.extractor.dependency.BuildPatternArtifactsRequest
 org.jfrog.build.extractor.dependency.DownloadableArtifact
@@ -43,6 +46,3 @@ org.jfrog.build.extractor.util.NullLog
 org.jfrog.build.extractor.clientConfiguration.IncludeExcludePatterns
 org.jfrog.build.extractor.clientConfiguration.deploy.DeployDetails
 
-com.google.common.collect.ArrayListMultimap
-com.google.common.collect.AbstractListMultimap
-com.google.common.collect.AbstractMapBasedMultimap


### PR DESCRIPTION
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
-----

* Update build-info and Gradle plugins to versions which do not include Guava
* Replace Guava's ArrayListMultimap with [ListMultimap](https://github.com/jfrog/build-info/blob/build-info-extractor-2.41.21/build-info-api/src/main/java/org/jfrog/build/api/multiMap/ListMultimap.java#L10).
* Replace Guava's HashMultimap with [SetMultimap](https://github.com/jfrog/build-info/blob/build-info-extractor-2.41.21/build-info-api/src/main/java/org/jfrog/build/api/multiMap/SetMultimap.java#L10).