### PR TITLE
Exclude Maven build breaking groovy-all dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -355,6 +355,10 @@
                     <groupId>org.codehaus.plexus</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-all</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
By excluding the transitive dependency on `org.codehaus.groovy:groovy-all:jar:3.0.13` we can prevent Maven builds from breaking simply by depending on this plugin. The same has already been done to the dependency on `build-info-extractor-gradle` right below in the `pom.xml` which leads me to suspect that it has been forgotten with the addition of the `build-info-extractor-maven3` dependency. Obviously, Groovy is supplied in the runtime classpath of Jenkins itself and is therefore redundant.

To illustrate the current issue I have created a minimal sample Maven project here:
https://github.com/lpradel/jenkins-artifactory-plugin-groovy-all-dependency-fault-demo
This project only has a single dependency which is this plugin and the build will always fail with the following error message:

`Could not resolve dependencies (...) : Could not find artifact org.codehaus.groovy:groovy-all:jar:3.0.13`

In fact this problem can also be observed by simply trying to import the plugin sources to an IDE of your choice:
![groovy-all-error](https://github.com/user-attachments/assets/5fa609d5-0d01-4e3d-a383-39426f8f4ae3)

I believe the cause of this is that `build-info-extractor-maven3` is built through Gradle and therefore the following issue comes into play:
[1] https://github.com/geb/issues/issues/586
[2] https://stackoverflow.com/questions/61444749/could-not-find-artifact-org-codehaus-groovygroovy-alljar2-5-6-in-pom-in-java/61444990

- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
-----
